### PR TITLE
fix(recipe): add checksum verification and version source

### DIFF
--- a/.tsuku-recipes/niwa.toml
+++ b/.tsuku-recipes/niwa.toml
@@ -4,11 +4,22 @@ description = "Declarative workspace manager for AI-assisted development"
 homepage = "https://github.com/tsukumogami/niwa"
 version_format = "semver"
 
+[version]
+github_repo = "tsukumogami/niwa"
+tag_prefix = "v"
+
 [[steps]]
-action = "github_file"
-repo = "tsukumogami/niwa"
-asset_pattern = "niwa-{os}-{arch}"
-binary = "niwa"
+action = "download"
+url = "https://github.com/tsukumogami/niwa/releases/download/v{version}/niwa-{os}-{arch}"
+checksum_url = "https://github.com/tsukumogami/niwa/releases/download/v{version}/checksums.txt"
+
+[[steps]]
+action = "chmod"
+files = ["niwa-{os}-{arch}"]
+
+[[steps]]
+action = "install_binaries"
+outputs = [{src = "niwa-{os}-{arch}", dest = "bin/niwa"}]
 
 [verify]
 command = "niwa version"


### PR DESCRIPTION
The tsuku recipe used `github_file`, which doesn't support checksum
verification. Replace it with the `download` action pointing at the
GoReleaser-produced `checksums.txt`, and add explicit `chmod` and
`install_binaries` steps with a src/dest mapping to rename the
platform-specific binary to `niwa`. Also add a `[version]` section so
tsuku can resolve the latest release from GitHub without manual version
pinning.

---

Discovered during the v0.0.1 release validation: `tsuku install` warned
about missing checksum verification. Verified the fix installs cleanly
with checksum validation on linux-amd64.

Fixes #1
