### PR TITLE
fix: skip plugin installation when claude is disabled

### DIFF
--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -356,10 +356,13 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 			return nil, fmt.Errorf("marketplace registration: %w", fatalErr)
 		}
 
-		// Phase B: Install plugins per repo.
+		// Phase B: Install plugins per repo (skip repos with claude = false).
 		_, claudeFound := FindClaude()
 		if claudeFound {
 			for _, cr := range classified {
+				if !ClaudeEnabled(cfg, cr.Repo.Name) {
+					continue
+				}
 				effective := MergeOverrides(cfg, cr.Repo.Name)
 				if len(effective.Plugins) == 0 {
 					continue


### PR DESCRIPTION
Gate plugin installation on ClaudeEnabled. Repos with
claude.enabled = false now skip all Claude-namespaced operations
(hooks, settings, plugins) but still get env (.local.env) and files
distribution since those are tool-agnostic.