### PR TITLE
fix: default clone protocol to SSH instead of HTTPS

### DIFF
--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -25,12 +25,14 @@ type RegistryEntry struct {
 	Root   string `toml:"root"`
 }
 
-// CloneProtocol returns the configured clone protocol, defaulting to "https".
+// CloneProtocol returns the configured clone protocol, defaulting to "ssh".
+// SSH is the default because it handles both public and private repos without
+// requiring a credential helper.
 func (g *GlobalConfig) CloneProtocol() string {
 	if g.Global.CloneProtocol != "" {
 		return g.Global.CloneProtocol
 	}
-	return "https"
+	return "ssh"
 }
 
 // LookupWorkspace returns the registry entry for the given workspace name.

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -58,8 +58,8 @@ func TestParseGlobalConfigEmpty(t *testing.T) {
 
 func TestCloneProtocolDefault(t *testing.T) {
 	cfg := &GlobalConfig{}
-	if got := cfg.CloneProtocol(); got != "https" {
-		t.Errorf("CloneProtocol() = %q, want %q", got, "https")
+	if got := cfg.CloneProtocol(); got != "ssh" {
+		t.Errorf("CloneProtocol() = %q, want %q", got, "ssh")
 	}
 }
 


### PR DESCRIPTION
SSH handles both public and private repos without requiring a credential
helper. HTTPS clones of private repos prompt for a password unless a
helper like `gh auth setup-git` is configured.

Users who prefer HTTPS can set `clone_protocol = "https"` in their
global niwa config (`~/.config/niwa/config.toml`).