### PR TITLE
fix: auto-detect GitHub token from gh CLI

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -75,7 +75,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	cfg := result.Config
 	configDir := filepath.Dir(configPath)
 
-	token := os.Getenv("GITHUB_TOKEN")
+	token := resolveGitHubToken()
 	gh := github.NewAPIClient(token)
 	applier := workspace.NewApplier(gh)
 

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -92,7 +92,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// Set the instance name on the config so Applier.Create uses it for the directory.
 	cfg.Workspace.Name = instanceName
 
-	token := os.Getenv("GITHUB_TOKEN")
+	token := resolveGitHubToken()
 	gh := github.NewAPIClient(token)
 
 	applier := workspace.NewApplier(gh)

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -103,7 +103,7 @@ func runReset(cmd *cobra.Command, args []string) error {
 	// Re-create using the same instance name.
 	cfg.Workspace.Name = state.InstanceName
 
-	token := os.Getenv("GITHUB_TOKEN")
+	token := resolveGitHubToken()
 	gh := github.NewAPIClient(token)
 
 	applier := workspace.NewApplier(gh)

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// resolveGitHubToken returns a GitHub API token from the environment or by
+// calling `gh auth token`. It checks GITHUB_TOKEN and GH_TOKEN env vars first,
+// then falls back to the gh CLI. Returns empty string if no token is available.
+func resolveGitHubToken() string {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token
+	}
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		return token
+	}
+
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}


### PR DESCRIPTION
Check GITHUB_TOKEN, GH_TOKEN env vars, then fall back to
`gh auth token` for API access. Users with `gh` authenticated no
longer need to manually export a token to discover private repos.