### PR TITLE
fix: generate correct Claude Code hooks JSON format

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,8 +78,17 @@ type GroupConfig struct {
 }
 
 // HooksConfig maps hook event names (e.g., "pre_tool_use", "stop") to lists
-// of script paths that should be executed for that event.
-type HooksConfig map[string][]string
+// of hook entries. Each entry has an optional matcher (tool name filter) and
+// a list of script paths.
+type HooksConfig map[string][]HookEntry
+
+// HookEntry defines a hook with an optional matcher and script paths.
+// The matcher filters which tools trigger the hook (e.g., "Bash", "Edit|Write").
+// Empty matcher means match all tools.
+type HookEntry struct {
+	Matcher string   `toml:"matcher,omitempty"`
+	Scripts []string `toml:"scripts"`
+}
 
 // SettingsConfig maps setting keys to their values. The primary key today is
 // "permissions" (values: "bypass", "ask").

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,9 +68,11 @@ source = "repos/tsuku.md"
 marketplaces = ["tsukumogami/shirabe", "repo:tools/.claude-plugin/marketplace.json"]
 plugins = ["shirabe@shirabe", "tsukumogami@tsukumogami"]
 
-[claude.hooks]
-pre_tool_use = ["hooks/gate-online.sh"]
-stop = ["hooks/workflow-continue.sh"]
+[[claude.hooks.pre_tool_use]]
+scripts = ["hooks/gate-online.sh"]
+
+[[claude.hooks.stop]]
+scripts = ["hooks/workflow-continue.sh"]
 
 [claude.settings]
 permissions = "bypass"
@@ -267,11 +269,11 @@ func TestParseFullConfig(t *testing.T) {
 	if cfg.Claude.Hooks == nil {
 		t.Error("claude.hooks should not be nil")
 	}
-	if len(cfg.Claude.Hooks["pre_tool_use"]) != 1 || cfg.Claude.Hooks["pre_tool_use"][0] != "hooks/gate-online.sh" {
-		t.Errorf("claude.hooks.pre_tool_use = %v, want [hooks/gate-online.sh]", cfg.Claude.Hooks["pre_tool_use"])
+	if len(cfg.Claude.Hooks["pre_tool_use"]) != 1 || cfg.Claude.Hooks["pre_tool_use"][0].Scripts[0] != "hooks/gate-online.sh" {
+		t.Errorf("claude.hooks.pre_tool_use = %v, want [{scripts: [hooks/gate-online.sh]}]", cfg.Claude.Hooks["pre_tool_use"])
 	}
-	if len(cfg.Claude.Hooks["stop"]) != 1 || cfg.Claude.Hooks["stop"][0] != "hooks/workflow-continue.sh" {
-		t.Errorf("claude.hooks.stop = %v, want [hooks/workflow-continue.sh]", cfg.Claude.Hooks["stop"])
+	if len(cfg.Claude.Hooks["stop"]) != 1 || cfg.Claude.Hooks["stop"][0].Scripts[0] != "hooks/workflow-continue.sh" {
+		t.Errorf("claude.hooks.stop = %v, want [{scripts: [hooks/workflow-continue.sh]}]", cfg.Claude.Hooks["stop"])
 	}
 	if cfg.Claude.Settings == nil {
 		t.Error("claude.settings should not be nil")
@@ -312,8 +314,8 @@ scope = "tactical"
 [repos.myapp.claude]
 enabled = true
 
-[repos.myapp.claude.hooks]
-pre_tool_use = ["repo-gate.sh"]
+[[repos.myapp.claude.hooks.pre_tool_use]]
+scripts = ["repo-gate.sh"]
 
 [repos.myapp.claude.settings]
 permissions = "ask"
@@ -346,8 +348,8 @@ files = ["repo.env"]
 	if repo.Claude.Hooks == nil {
 		t.Fatal("claude.hooks should not be nil")
 	}
-	if len(repo.Claude.Hooks["pre_tool_use"]) != 1 || repo.Claude.Hooks["pre_tool_use"][0] != "repo-gate.sh" {
-		t.Errorf("claude.hooks.pre_tool_use = %v, want [repo-gate.sh]", repo.Claude.Hooks["pre_tool_use"])
+	if len(repo.Claude.Hooks["pre_tool_use"]) != 1 || repo.Claude.Hooks["pre_tool_use"][0].Scripts[0] != "repo-gate.sh" {
+		t.Errorf("claude.hooks.pre_tool_use = %v, want [{scripts: [repo-gate.sh]}]", repo.Claude.Hooks["pre_tool_use"])
 	}
 	if repo.Claude.Settings == nil {
 		t.Fatal("claude.settings should not be nil")

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -278,20 +278,27 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 		if len(discoveredHooks) > 0 {
 			merged := make(config.HooksConfig, len(discoveredHooks)+len(effective.Claude.Hooks))
 			// Start with discovered hooks (converted to relative paths).
-			for event, scripts := range discoveredHooks {
-				relScripts := make([]string, 0, len(scripts))
-				for _, absPath := range scripts {
-					rel, err := filepath.Rel(configDir, absPath)
-					if err != nil {
-						return nil, fmt.Errorf("materializer hooks: computing relative path for %s: %w", absPath, err)
+			for event, entries := range discoveredHooks {
+				var relEntries []config.HookEntry
+				for _, entry := range entries {
+					relScripts := make([]string, 0, len(entry.Scripts))
+					for _, absPath := range entry.Scripts {
+						rel, err := filepath.Rel(configDir, absPath)
+						if err != nil {
+							return nil, fmt.Errorf("materializer hooks: computing relative path for %s: %w", absPath, err)
+						}
+						relScripts = append(relScripts, rel)
 					}
-					relScripts = append(relScripts, rel)
+					relEntries = append(relEntries, config.HookEntry{
+						Matcher: entry.Matcher,
+						Scripts: relScripts,
+					})
 				}
-				merged[event] = relScripts
+				merged[event] = relEntries
 			}
 			// Explicit config overrides per event.
-			for event, scripts := range effective.Claude.Hooks {
-				merged[event] = scripts
+			for event, entries := range effective.Claude.Hooks {
+				merged[event] = entries
 			}
 			effective.Claude.Hooks = merged
 		}

--- a/internal/workspace/discover.go
+++ b/internal/workspace/discover.go
@@ -53,7 +53,7 @@ func DiscoverHooks(configDir string) (config.HooksConfig, error) {
 				if err := validateWithinDir(configDir, scriptPath); err != nil {
 					return nil, err
 				}
-				hooks[event] = append(hooks[event], scriptPath)
+				hooks[event] = append(hooks[event], config.HookEntry{Scripts: []string{scriptPath}})
 			}
 		} else if strings.HasSuffix(entry.Name(), ".sh") {
 			// Top-level .sh file: event name is filename without extension.
@@ -61,7 +61,7 @@ func DiscoverHooks(configDir string) (config.HooksConfig, error) {
 			if err := validateWithinDir(configDir, entryPath); err != nil {
 				return nil, err
 			}
-			hooks[event] = append(hooks[event], entryPath)
+			hooks[event] = append(hooks[event], config.HookEntry{Scripts: []string{entryPath}})
 		}
 	}
 

--- a/internal/workspace/discover_test.go
+++ b/internal/workspace/discover_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/tsukumogami/niwa/internal/config"
 )
 
 // --- DiscoverHooks tests ---
@@ -33,8 +35,8 @@ func TestDiscoverHooks_TopLevelScripts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assertHookPaths(t, hooks, "pre_tool_use", []string{filepath.Join(hooksDir, "pre_tool_use.sh")})
-	assertHookPaths(t, hooks, "stop", []string{filepath.Join(hooksDir, "stop.sh")})
+	assertHookScripts(t, hooks, "pre_tool_use", []string{filepath.Join(hooksDir, "pre_tool_use.sh")})
+	assertHookScripts(t, hooks, "stop", []string{filepath.Join(hooksDir, "stop.sh")})
 }
 
 func TestDiscoverHooks_SubdirectoryScripts(t *testing.T) {
@@ -50,9 +52,9 @@ func TestDiscoverHooks_SubdirectoryScripts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	paths := hooks["pre_tool_use"]
-	if len(paths) != 2 {
-		t.Fatalf("expected 2 scripts, got %d: %v", len(paths), paths)
+	entries := hooks["pre_tool_use"]
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(entries), entries)
 	}
 }
 
@@ -91,9 +93,9 @@ func TestDiscoverHooks_IgnoresNonShInSubdir(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	paths := hooks["stop"]
-	if len(paths) != 1 {
-		t.Fatalf("expected 1 script, got %d: %v", len(paths), paths)
+	entries := hooks["stop"]
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(entries), entries)
 	}
 }
 
@@ -120,10 +122,10 @@ func TestDiscoverHooks_MixedLayout(t *testing.T) {
 		t.Fatalf("expected 2 events, got %d", len(hooks))
 	}
 	if len(hooks["stop"]) != 1 {
-		t.Fatalf("expected 1 stop script, got %d", len(hooks["stop"]))
+		t.Fatalf("expected 1 stop entry, got %d", len(hooks["stop"]))
 	}
 	if len(hooks["pre_tool_use"]) != 2 {
-		t.Fatalf("expected 2 pre_tool_use scripts, got %d", len(hooks["pre_tool_use"]))
+		t.Fatalf("expected 2 pre_tool_use entries, got %d", len(hooks["pre_tool_use"]))
 	}
 }
 
@@ -316,20 +318,25 @@ func mustWriteFile(t *testing.T, path, content string) {
 	}
 }
 
-func assertHookPaths(t *testing.T, hooks map[string][]string, event string, expected []string) {
+func assertHookScripts(t *testing.T, hooks config.HooksConfig, event string, expected []string) {
 	t.Helper()
-	got, ok := hooks[event]
+	entries, ok := hooks[event]
 	if !ok {
 		t.Fatalf("event %q not found in hooks", event)
+	}
+	// Collect all scripts from all entries for comparison.
+	var got []string
+	for _, e := range entries {
+		got = append(got, e.Scripts...)
 	}
 	sort.Strings(got)
 	sort.Strings(expected)
 	if len(got) != len(expected) {
-		t.Fatalf("event %q: expected %d paths, got %d: %v", event, len(expected), len(got), got)
+		t.Fatalf("event %q: expected %d scripts, got %d: %v", event, len(expected), len(got), got)
 	}
 	for i := range got {
 		if got[i] != expected[i] {
-			t.Fatalf("event %q path[%d]: expected %q, got %q", event, i, expected[i], got[i])
+			t.Fatalf("event %q script[%d]: expected %q, got %q", event, i, expected[i], got[i])
 		}
 	}
 }

--- a/internal/workspace/materialize.go
+++ b/internal/workspace/materialize.go
@@ -27,8 +27,15 @@ type MaterializeContext struct {
 	RepoName       string
 	RepoDir        string
 	ConfigDir      string
-	InstalledHooks map[string][]string // event -> installed script paths, populated by hooks materializer
+	InstalledHooks map[string][]InstalledHookEntry // event -> installed hook entries, populated by hooks materializer
 	DiscoveredEnv  *DiscoveredEnv      // auto-discovered env files, may be nil
+}
+
+// InstalledHookEntry holds the installed paths for a single hook entry,
+// preserving the optional matcher from the source HookEntry.
+type InstalledHookEntry struct {
+	Matcher string
+	Paths   []string
 }
 
 // Materializer is the interface for components that install workspace
@@ -58,39 +65,46 @@ func (h *HooksMaterializer) Materialize(ctx *MaterializeContext) ([]string, erro
 		return nil, nil
 	}
 
-	installed := make(map[string][]string, len(hooks))
+	installed := make(map[string][]InstalledHookEntry, len(hooks))
 	var written []string
 
-	for event, scripts := range hooks {
-		for _, scriptPath := range scripts {
-			src := filepath.Join(ctx.ConfigDir, scriptPath)
+	for event, entries := range hooks {
+		for _, entry := range entries {
+			var installedPaths []string
+			for _, scriptPath := range entry.Scripts {
+				src := filepath.Join(ctx.ConfigDir, scriptPath)
 
-			if err := checkContainment(src, ctx.ConfigDir); err != nil {
-				return nil, fmt.Errorf("hook script %q: %w", scriptPath, err)
+				if err := checkContainment(src, ctx.ConfigDir); err != nil {
+					return nil, fmt.Errorf("hook script %q: %w", scriptPath, err)
+				}
+
+				targetDir := filepath.Join(ctx.RepoDir, ".claude", "hooks", event)
+				target := filepath.Join(targetDir, filepath.Base(scriptPath))
+
+				if err := os.MkdirAll(targetDir, 0o755); err != nil {
+					return nil, fmt.Errorf("creating hooks directory %s: %w", targetDir, err)
+				}
+
+				data, err := os.ReadFile(src)
+				if err != nil {
+					return nil, fmt.Errorf("reading hook script %s: %w", src, err)
+				}
+
+				if err := os.WriteFile(target, data, 0o644); err != nil {
+					return nil, fmt.Errorf("writing hook script %s: %w", target, err)
+				}
+
+				if err := os.Chmod(target, 0o755); err != nil {
+					return nil, fmt.Errorf("setting executable permission on %s: %w", target, err)
+				}
+
+				installedPaths = append(installedPaths, target)
+				written = append(written, target)
 			}
-
-			targetDir := filepath.Join(ctx.RepoDir, ".claude", "hooks", event)
-			target := filepath.Join(targetDir, filepath.Base(scriptPath))
-
-			if err := os.MkdirAll(targetDir, 0o755); err != nil {
-				return nil, fmt.Errorf("creating hooks directory %s: %w", targetDir, err)
-			}
-
-			data, err := os.ReadFile(src)
-			if err != nil {
-				return nil, fmt.Errorf("reading hook script %s: %w", src, err)
-			}
-
-			if err := os.WriteFile(target, data, 0o644); err != nil {
-				return nil, fmt.Errorf("writing hook script %s: %w", target, err)
-			}
-
-			if err := os.Chmod(target, 0o755); err != nil {
-				return nil, fmt.Errorf("setting executable permission on %s: %w", target, err)
-			}
-
-			installed[event] = append(installed[event], target)
-			written = append(written, target)
+			installed[event] = append(installed[event], InstalledHookEntry{
+				Matcher: entry.Matcher,
+				Paths:   installedPaths,
+			})
 		}
 	}
 
@@ -174,24 +188,34 @@ func (s *SettingsMaterializer) Materialize(ctx *MaterializeContext) ([]string, e
 		sort.Strings(events)
 
 		for _, event := range events {
-			paths := hooks[event]
+			installedEntries := hooks[event]
 			pascalEvent, ok := hookEventMapping[event]
 			if !ok {
 				pascalEvent = snakeToPascal(event)
 			}
 
-			entries := make([]map[string]string, 0, len(paths))
-			for _, absPath := range paths {
-				rel, err := filepath.Rel(ctx.RepoDir, absPath)
-				if err != nil {
-					return nil, fmt.Errorf("computing relative path for hook %s: %w", absPath, err)
+			var eventEntries []map[string]any
+			for _, ie := range installedEntries {
+				hookCommands := make([]map[string]string, 0, len(ie.Paths))
+				for _, absPath := range ie.Paths {
+					rel, err := filepath.Rel(ctx.RepoDir, absPath)
+					if err != nil {
+						return nil, fmt.Errorf("computing relative path for hook %s: %w", absPath, err)
+					}
+					hookCommands = append(hookCommands, map[string]string{
+						"type":    "command",
+						"command": filepath.ToSlash(rel),
+					})
 				}
-				entries = append(entries, map[string]string{
-					"type":    "command",
-					"command": filepath.ToSlash(rel),
-				})
+				entry := map[string]any{
+					"hooks": hookCommands,
+				}
+				if ie.Matcher != "" {
+					entry["matcher"] = ie.Matcher
+				}
+				eventEntries = append(eventEntries, entry)
 			}
-			hooksDoc[pascalEvent] = entries
+			hooksDoc[pascalEvent] = eventEntries
 		}
 		doc["hooks"] = hooksDoc
 	}

--- a/internal/workspace/materialize_test.go
+++ b/internal/workspace/materialize_test.go
@@ -63,7 +63,7 @@ func TestHooksMaterializerSingleEvent(t *testing.T) {
 		Effective: EffectiveConfig{
 			Claude: config.ClaudeConfig{
 				Hooks: config.HooksConfig{
-					"pre_tool_use": {"hooks/pre_tool_use/check.sh"},
+					"pre_tool_use": {{Scripts: []string{"hooks/pre_tool_use/check.sh"}}},
 				},
 			},
 		},
@@ -108,12 +108,12 @@ func TestHooksMaterializerSingleEvent(t *testing.T) {
 	if ctx.InstalledHooks == nil {
 		t.Fatal("InstalledHooks should be set")
 	}
-	paths, ok := ctx.InstalledHooks["pre_tool_use"]
+	installedEntries, ok := ctx.InstalledHooks["pre_tool_use"]
 	if !ok {
 		t.Fatal("InstalledHooks should have pre_tool_use key")
 	}
-	if len(paths) != 1 || paths[0] != expectedTarget {
-		t.Errorf("InstalledHooks[pre_tool_use] = %v, want [%s]", paths, expectedTarget)
+	if len(installedEntries) != 1 || len(installedEntries[0].Paths) != 1 || installedEntries[0].Paths[0] != expectedTarget {
+		t.Errorf("InstalledHooks[pre_tool_use] = %v, want [{Paths: [%s]}]", installedEntries, expectedTarget)
 	}
 }
 
@@ -145,8 +145,8 @@ func TestHooksMaterializerMultipleEvents(t *testing.T) {
 		Effective: EffectiveConfig{
 			Claude: config.ClaudeConfig{
 				Hooks: config.HooksConfig{
-					"pre_tool_use": {"hooks/pre_tool_use/run.sh"},
-					"stop":         {"hooks/stop/run.sh"},
+					"pre_tool_use": {{Scripts: []string{"hooks/pre_tool_use/run.sh"}}},
+					"stop":         {{Scripts: []string{"hooks/stop/run.sh"}}},
 				},
 			},
 		},
@@ -201,10 +201,10 @@ func TestHooksMaterializerMultipleScriptsPerEvent(t *testing.T) {
 		Effective: EffectiveConfig{
 			Claude: config.ClaudeConfig{
 				Hooks: config.HooksConfig{
-					"pre_tool_use": {
+					"pre_tool_use": {{Scripts: []string{
 						"hooks/pre_tool_use/check.sh",
 						"hooks/pre_tool_use/validate.sh",
-					},
+					}}},
 				},
 			},
 		},
@@ -222,9 +222,9 @@ func TestHooksMaterializerMultipleScriptsPerEvent(t *testing.T) {
 		t.Fatalf("expected 2 files written, got %d", len(written))
 	}
 
-	paths := ctx.InstalledHooks["pre_tool_use"]
-	if len(paths) != 2 {
-		t.Errorf("expected 2 scripts for pre_tool_use, got %d", len(paths))
+	hookEntries := ctx.InstalledHooks["pre_tool_use"]
+	if len(hookEntries) != 1 || len(hookEntries[0].Paths) != 2 {
+		t.Errorf("expected 1 entry with 2 scripts for pre_tool_use, got %v", hookEntries)
 	}
 }
 
@@ -256,7 +256,7 @@ func TestHooksMaterializerContainmentReject(t *testing.T) {
 		Effective: EffectiveConfig{
 			Claude: config.ClaudeConfig{
 				Hooks: config.HooksConfig{
-					"pre_tool_use": {"../outside/evil.sh"},
+					"pre_tool_use": {{Scripts: []string{"../outside/evil.sh"}}},
 				},
 			},
 		},
@@ -291,7 +291,7 @@ func TestHooksMaterializerMissingSource(t *testing.T) {
 		Effective: EffectiveConfig{
 			Claude: config.ClaudeConfig{
 				Hooks: config.HooksConfig{
-					"pre_tool_use": {"hooks/nonexistent.sh"},
+					"pre_tool_use": {{Scripts: []string{"hooks/nonexistent.sh"}}},
 				},
 			},
 		},
@@ -469,8 +469,8 @@ func TestSettingsMaterializerHooksOnly(t *testing.T) {
 			Claude: config.ClaudeConfig{},
 		},
 		RepoDir: repoDir,
-		InstalledHooks: map[string][]string{
-			"pre_tool_use": {filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.sh")},
+		InstalledHooks: map[string][]InstalledHookEntry{
+			"pre_tool_use": {{Paths: []string{filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.sh")}}},
 		},
 	}
 
@@ -511,11 +511,16 @@ func TestSettingsMaterializerHooksOnly(t *testing.T) {
 	}
 
 	entry := entries[0].(map[string]any)
-	if entry["type"] != "command" {
-		t.Errorf("type = %v, want %q", entry["type"], "command")
+	hooksList := entry["hooks"].([]any)
+	if len(hooksList) != 1 {
+		t.Fatalf("expected 1 hook command, got %d", len(hooksList))
 	}
-	if entry["command"] != ".claude/hooks/pre_tool_use/gate.sh" {
-		t.Errorf("command = %v, want %q", entry["command"], ".claude/hooks/pre_tool_use/gate.sh")
+	hookCmd := hooksList[0].(map[string]any)
+	if hookCmd["type"] != "command" {
+		t.Errorf("type = %v, want %q", hookCmd["type"], "command")
+	}
+	if hookCmd["command"] != ".claude/hooks/pre_tool_use/gate.sh" {
+		t.Errorf("command = %v, want %q", hookCmd["command"], ".claude/hooks/pre_tool_use/gate.sh")
 	}
 }
 
@@ -533,9 +538,9 @@ func TestSettingsMaterializerSettingsAndHooks(t *testing.T) {
 			},
 		},
 		RepoDir: repoDir,
-		InstalledHooks: map[string][]string{
-			"pre_tool_use": {filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.sh")},
-			"stop":         {filepath.Join(repoDir, ".claude", "hooks", "stop", "stop.sh")},
+		InstalledHooks: map[string][]InstalledHookEntry{
+			"pre_tool_use": {{Paths: []string{filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.sh")}}},
+			"stop":         {{Paths: []string{filepath.Join(repoDir, ".claude", "hooks", "stop", "stop.sh")}}},
 		},
 	}
 
@@ -583,8 +588,14 @@ func TestSettingsMaterializerSettingsAndHooks(t *testing.T) {
 			continue
 		}
 		entry := entries[0].(map[string]any)
-		if entry["command"] != tc.command {
-			t.Errorf("%s command = %v, want %q", tc.event, entry["command"], tc.command)
+		hooksList := entry["hooks"].([]any)
+		if len(hooksList) != 1 {
+			t.Errorf("%s: expected 1 hook command, got %d", tc.event, len(hooksList))
+			continue
+		}
+		hookCmd := hooksList[0].(map[string]any)
+		if hookCmd["command"] != tc.command {
+			t.Errorf("%s command = %v, want %q", tc.event, hookCmd["command"], tc.command)
 		}
 	}
 }
@@ -601,11 +612,11 @@ func TestSettingsMaterializerMultipleHooksPerEvent(t *testing.T) {
 			Claude: config.ClaudeConfig{},
 		},
 		RepoDir: repoDir,
-		InstalledHooks: map[string][]string{
-			"pre_tool_use": {
+		InstalledHooks: map[string][]InstalledHookEntry{
+			"pre_tool_use": {{Paths: []string{
 				filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.sh"),
 				filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "validate.sh"),
-			},
+			}}},
 		},
 	}
 
@@ -630,8 +641,13 @@ func TestSettingsMaterializerMultipleHooksPerEvent(t *testing.T) {
 
 	hooksDoc := doc["hooks"].(map[string]any)
 	entries := hooksDoc["PreToolUse"].([]any)
-	if len(entries) != 2 {
-		t.Fatalf("expected 2 entries for PreToolUse, got %d", len(entries))
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry for PreToolUse, got %d", len(entries))
+	}
+	entry := entries[0].(map[string]any)
+	hooksList := entry["hooks"].([]any)
+	if len(hooksList) != 2 {
+		t.Fatalf("expected 2 hook commands for PreToolUse, got %d", len(hooksList))
 	}
 }
 
@@ -874,8 +890,8 @@ func TestSettingsMaterializerAllBlocks(t *testing.T) {
 			},
 		},
 		RepoDir: repoDir,
-		InstalledHooks: map[string][]string{
-			"stop": {filepath.Join(repoDir, ".claude", "hooks", "stop", "continue.sh")},
+		InstalledHooks: map[string][]InstalledHookEntry{
+			"stop": {{Paths: []string{filepath.Join(repoDir, ".claude", "hooks", "stop", "continue.sh")}}},
 		},
 	}
 

--- a/internal/workspace/override.go
+++ b/internal/workspace/override.go
@@ -177,7 +177,7 @@ func WarnUnknownRepos(ws *config.WorkspaceConfig, known map[string]bool) []strin
 	return warnings
 }
 
-// copyHooks returns a deep copy of a HooksConfig. Each hook event's script
+// copyHooks returns a deep copy of a HooksConfig. Each hook event's entry
 // list is independently copied so mutations don't affect the original.
 func copyHooks(h config.HooksConfig) config.HooksConfig {
 	if h == nil {
@@ -185,7 +185,14 @@ func copyHooks(h config.HooksConfig) config.HooksConfig {
 	}
 	out := make(config.HooksConfig, len(h))
 	for k, v := range h {
-		out[k] = slices.Clone(v)
+		entries := make([]config.HookEntry, len(v))
+		for i, e := range v {
+			entries[i] = config.HookEntry{
+				Matcher: e.Matcher,
+				Scripts: slices.Clone(e.Scripts),
+			}
+		}
+		out[k] = entries
 	}
 	return out
 }

--- a/internal/workspace/override_test.go
+++ b/internal/workspace/override_test.go
@@ -98,7 +98,7 @@ func TestRepoCloneBranchOverride(t *testing.T) {
 func TestMergeOverridesNoOverride(t *testing.T) {
 	ws := &config.WorkspaceConfig{
 		Claude: config.ClaudeConfig{
-			Hooks:    config.HooksConfig{"pre_tool_use": {"a.sh"}},
+			Hooks:    config.HooksConfig{"pre_tool_use": {{Scripts: []string{"a.sh"}}}},
 			Settings: config.SettingsConfig{"permissions": "bypass"},
 		},
 		Env: config.EnvConfig{Files: []string{"ws.env"}},
@@ -197,14 +197,14 @@ func TestMergeOverridesEnvVarsMerge(t *testing.T) {
 func TestMergeOverridesHooksExtend(t *testing.T) {
 	ws := &config.WorkspaceConfig{
 		Claude: config.ClaudeConfig{
-			Hooks: config.HooksConfig{"pre_tool_use": {"ws-gate.sh"}},
+			Hooks: config.HooksConfig{"pre_tool_use": {{Scripts: []string{"ws-gate.sh"}}}},
 		},
 		Repos: map[string]config.RepoOverride{
 			"myrepo": {
 				Claude: &config.ClaudeConfig{
 					Hooks: config.HooksConfig{
-						"pre_tool_use": {"repo-gate.sh"},
-						"stop":         {"repo-stop.sh"},
+						"pre_tool_use": {{Scripts: []string{"repo-gate.sh"}}},
+						"stop":         {{Scripts: []string{"repo-stop.sh"}}},
 					},
 				},
 			},
@@ -215,16 +215,16 @@ func TestMergeOverridesHooksExtend(t *testing.T) {
 	// pre_tool_use should be extended (concatenated).
 	preToolUse := eff.Claude.Hooks["pre_tool_use"]
 	if len(preToolUse) != 2 {
-		t.Fatalf("expected 2 hooks, got %d: %v", len(preToolUse), preToolUse)
+		t.Fatalf("expected 2 hook entries, got %d: %v", len(preToolUse), preToolUse)
 	}
-	if preToolUse[0] != "ws-gate.sh" || preToolUse[1] != "repo-gate.sh" {
+	if preToolUse[0].Scripts[0] != "ws-gate.sh" || preToolUse[1].Scripts[0] != "repo-gate.sh" {
 		t.Errorf("expected [ws-gate.sh repo-gate.sh], got %v", preToolUse)
 	}
 
 	// stop should be a new hook key from repo.
 	stop := eff.Claude.Hooks["stop"]
-	if len(stop) != 1 || stop[0] != "repo-stop.sh" {
-		t.Errorf("expected [repo-stop.sh], got %v", stop)
+	if len(stop) != 1 || stop[0].Scripts[0] != "repo-stop.sh" {
+		t.Errorf("expected [{scripts: [repo-stop.sh]}], got %v", stop)
 	}
 }
 
@@ -235,7 +235,7 @@ func TestMergeOverridesNilWorkspaceFields(t *testing.T) {
 			"myrepo": {
 				Claude: &config.ClaudeConfig{
 					Settings: config.SettingsConfig{"permissions": "ask"},
-					Hooks:    config.HooksConfig{"stop": {"stop.sh"}},
+					Hooks:    config.HooksConfig{"stop": {{Scripts: []string{"stop.sh"}}}},
 				},
 				Env: config.EnvConfig{Files: []string{"repo.env"}},
 			},
@@ -247,8 +247,8 @@ func TestMergeOverridesNilWorkspaceFields(t *testing.T) {
 		t.Errorf("expected permissions=ask, got %v", eff.Claude.Settings["permissions"])
 	}
 	stop := eff.Claude.Hooks["stop"]
-	if len(stop) != 1 || stop[0] != "stop.sh" {
-		t.Errorf("expected [stop.sh], got %v", stop)
+	if len(stop) != 1 || stop[0].Scripts[0] != "stop.sh" {
+		t.Errorf("expected [{scripts: [stop.sh]}], got %v", stop)
 	}
 	if len(eff.Env.Files) != 1 || eff.Env.Files[0] != "repo.env" {
 		t.Errorf("expected [repo.env], got %v", eff.Env.Files)
@@ -390,7 +390,7 @@ func TestKnownRepoNames(t *testing.T) {
 
 func TestMergeOverridesMutationSafety(t *testing.T) {
 	// Verify that merging doesn't mutate the workspace-level maps.
-	wsHooks := config.HooksConfig{"pre_tool_use": {"ws.sh"}}
+	wsHooks := config.HooksConfig{"pre_tool_use": {{Scripts: []string{"ws.sh"}}}}
 	ws := &config.WorkspaceConfig{
 		Claude: config.ClaudeConfig{
 			Hooks: wsHooks,
@@ -398,7 +398,7 @@ func TestMergeOverridesMutationSafety(t *testing.T) {
 		Repos: map[string]config.RepoOverride{
 			"myrepo": {
 				Claude: &config.ClaudeConfig{
-					Hooks: config.HooksConfig{"pre_tool_use": {"repo.sh"}},
+					Hooks: config.HooksConfig{"pre_tool_use": {{Scripts: []string{"repo.sh"}}}},
 				},
 			},
 		},
@@ -407,7 +407,7 @@ func TestMergeOverridesMutationSafety(t *testing.T) {
 
 	// The workspace hooks should not be modified.
 	original := ws.Claude.Hooks["pre_tool_use"]
-	if len(original) != 1 || original[0] != "ws.sh" {
+	if len(original) != 1 || original[0].Scripts[0] != "ws.sh" {
 		t.Errorf("workspace hooks were mutated: %v", ws.Claude.Hooks["pre_tool_use"])
 	}
 }

--- a/internal/workspace/scaffold.go
+++ b/internal/workspace/scaffold.go
@@ -40,7 +40,9 @@ content_dir = "claude"
 # [claude]
 # marketplaces = ["my-org/my-plugins"]
 # plugins = ["my-tool@my-plugins"]
-# [claude.hooks]
+# [[claude.hooks.pre_tool_use]]
+# matcher = "Bash"
+# scripts = ["hooks/pre_tool_use/gate.sh"]
 # [claude.settings]
 # [claude.env]
 # promote = ["GH_TOKEN"]

--- a/internal/workspace/scaffold_test.go
+++ b/internal/workspace/scaffold_test.go
@@ -57,7 +57,7 @@ func TestScaffold_WithName(t *testing.T) {
 	}
 
 	// Verify commented sections are present.
-	for _, section := range []string{"[[sources]]", "[groups.public]", "[repos.my-repo]", "[content.workspace]", "[claude.hooks]", "[claude.settings]", "[env]", "[channels]"} {
+	for _, section := range []string{"[[sources]]", "[groups.public]", "[repos.my-repo]", "[content.workspace]", "[[claude.hooks.pre_tool_use]]", "[claude.settings]", "[env]", "[channels]"} {
 		if !strings.Contains(content, "# "+section) {
 			t.Errorf("expected commented section %q in template", section)
 		}


### PR DESCRIPTION
Change HooksConfig from `map[string][]string` to `map[string][]HookEntry`
to support the matcher field that Claude Code requires. The settings
materializer now generates the correct nested format with optional
matcher and hooks array per event entry.

TOML hooks syntax changes from bare string lists to array-of-tables:
```toml
[[claude.hooks.pre_tool_use]]
matcher = "Bash"
scripts = ["hooks/pre_tool_use/gate-online.sh"]
```

---

## What This Fixes

Claude Code expects hooks in settings.local.json as:
```json
{"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "..."}]}]}
```

niwa was generating a flat format without the `matcher`/`hooks` wrapper:
```json
{"PreToolUse": [{"type": "command", "command": "..."}]}
```

This caused Claude Code to reject the settings file on startup with a
validation error about `hooks: Expected array, but received undefined`.

## Changes

- `internal/config/config.go`: `HookEntry` struct with `Matcher` and `Scripts`
- `internal/workspace/materialize.go`: `InstalledHookEntry` carries matcher through
  pipeline; settings JSON output uses nested `{matcher, hooks}` format
- `internal/workspace/discover.go`: wrap discovered hooks in `HookEntry`
- `internal/workspace/apply.go`: hook merging works with `[]HookEntry`
- `internal/workspace/override.go`: deep copy handles `HookEntry` structs