### PR TITLE
feat: auto-pull remote config on apply

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -15,9 +15,13 @@ import (
 func init() {
 	rootCmd.AddCommand(applyCmd)
 	applyCmd.Flags().StringVar(&applyInstance, "instance", "", "target a specific instance by name")
+	applyCmd.Flags().BoolVar(&applyAllowDirty, "allow-dirty", false, "apply even if config directory has uncommitted changes")
 }
 
-var applyInstance string
+var (
+	applyInstance   string
+	applyAllowDirty bool
+)
 
 var applyCmd = &cobra.Command{
 	Use:   "apply [workspace-name]",
@@ -65,6 +69,12 @@ func runApply(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not locate workspace configuration")
 	}
 
+	// Auto-pull config from origin if it's a git repo with a remote.
+	configDir := filepath.Dir(configPath)
+	if syncErr := workspace.SyncConfigDir(configDir, applyAllowDirty); syncErr != nil {
+		return syncErr
+	}
+
 	result, err := config.Load(configPath)
 	if err != nil {
 		return err
@@ -73,7 +83,6 @@ func runApply(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
 	cfg := result.Config
-	configDir := filepath.Dir(configPath)
 
 	token := resolveGitHubToken()
 	gh := github.NewAPIClient(token)

--- a/internal/workspace/configsync.go
+++ b/internal/workspace/configsync.go
@@ -1,0 +1,49 @@
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// SyncConfigDir pulls the latest config from origin if the config directory
+// is a git repo with a remote. Returns nil if the directory is not a git repo
+// or has no remote. Returns an error if the working tree is dirty (unless
+// allowDirty is true).
+func SyncConfigDir(configDir string, allowDirty bool) error {
+	// Check if it's a git repo.
+	gitDir := filepath.Join(configDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return nil // not a git repo, nothing to sync
+	}
+
+	// Check for origin remote.
+	cmd := exec.Command("git", "-C", configDir, "remote", "get-url", "origin")
+	if err := cmd.Run(); err != nil {
+		return nil // no origin remote, nothing to sync
+	}
+
+	// Check for dirty working tree.
+	if !allowDirty {
+		cmd = exec.Command("git", "-C", configDir, "status", "--porcelain")
+		out, err := cmd.Output()
+		if err != nil {
+			return fmt.Errorf("checking config directory status: %w", err)
+		}
+		if strings.TrimSpace(string(out)) != "" {
+			return fmt.Errorf("config directory has uncommitted changes\n  %s\n  Use --allow-dirty to apply with local modifications", configDir)
+		}
+	}
+
+	// Pull latest from origin.
+	cmd = exec.Command("git", "-C", configDir, "pull", "--ff-only", "origin")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pulling config from origin: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
When .niwa/ is a git repo with an origin remote, niwa apply pulls the
latest config before reading workspace.toml. This ensures changes pushed
from the managed clone are picked up automatically without manual
git pull.

Dirty working trees produce a clear error with --allow-dirty suggestion.
Non-git config directories (scaffolded locally) are unaffected.

---

## Changes

- `internal/workspace/configsync.go`: `SyncConfigDir` checks for git repo,
  origin remote, dirty state, and pulls with --ff-only
- `internal/cli/apply.go`: Call `SyncConfigDir` before `config.Load`,
  add `--allow-dirty` flag

Fixes #17