### PR TITLE
fix: support niwa init --from without explicit name argument

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -54,6 +54,10 @@ const (
 // It returns the mode, workspace name, and source URL (empty for scaffold/named).
 func resolveInitMode(args []string, from string, globalCfg *config.GlobalConfig) (initMode, string, string) {
 	if len(args) == 0 {
+		if from != "" {
+			// Clone without explicit name -- name will be derived from config after cloning.
+			return modeClone, "", from
+		}
 		return modeScaffold, "", ""
 	}
 


### PR DESCRIPTION
When --from is set but no workspace name argument is given, clone the
config repo first then derive the name from workspace.toml. Previously
this fell through to scaffold mode and silently ignored --from.

---

## What This Fixes

```bash
niwa init --from my-org/my-config
# Before: creates blank scaffold, ignores --from
# After: clones config repo, reads name from workspace.toml
```

Root cause: `resolveInitMode` checked `len(args) == 0` before checking the
`--from` flag.

Fixes #24