### PR TITLE
fix: use absolute hook paths at instance root

### DIFF
--- a/internal/workspace/materialize.go
+++ b/internal/workspace/materialize.go
@@ -153,6 +153,7 @@ type BuildSettingsConfig struct {
 	RepoIndex              map[string]string
 	BaseDir                string // for computing relative hook paths
 	IncludeGitInstructions *bool
+	UseAbsolutePaths      bool // use absolute paths for hooks (instance root)
 }
 
 // buildSettingsDoc produces the map[string]any JSON document for Claude Code
@@ -194,13 +195,19 @@ func buildSettingsDoc(cfg BuildSettingsConfig) (map[string]any, error) {
 			for _, ie := range installedEntries {
 				hookCommands := make([]map[string]string, 0, len(ie.Paths))
 				for _, absPath := range ie.Paths {
-					rel, err := filepath.Rel(cfg.BaseDir, absPath)
-					if err != nil {
-						return nil, fmt.Errorf("computing relative path for hook %s: %w", absPath, err)
+					var cmdPath string
+					if cfg.UseAbsolutePaths {
+						cmdPath = filepath.ToSlash(absPath)
+					} else {
+						rel, err := filepath.Rel(cfg.BaseDir, absPath)
+						if err != nil {
+							return nil, fmt.Errorf("computing relative path for hook %s: %w", absPath, err)
+						}
+						cmdPath = filepath.ToSlash(rel)
 					}
 					hookCommands = append(hookCommands, map[string]string{
 						"type":    "command",
-						"command": filepath.ToSlash(rel),
+						"command": cmdPath,
 					})
 				}
 				entry := map[string]any{

--- a/internal/workspace/workspace_context.go
+++ b/internal/workspace/workspace_context.go
@@ -143,6 +143,7 @@ func InstallWorkspaceRootSettings(cfg *config.WorkspaceConfig, configDir, instan
 		RepoIndex:              repoIndex,
 		BaseDir:                instanceRoot,
 		IncludeGitInstructions: &includeGit,
+		UseAbsolutePaths:       true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("building workspace root settings: %w", err)


### PR DESCRIPTION
The instance root is a non-git directory where cwd can change during a
session. Relative hook paths break when this happens. Use absolute paths
for instance root hooks so they resolve regardless of cwd.

Repo hooks remain relative (cwd stays within the repo).

Fixes #37