### PR TITLE
fix: fill gaps in instance numbering when instances are deleted

### DIFF
--- a/internal/workspace/state.go
+++ b/internal/workspace/state.go
@@ -147,26 +147,31 @@ func EnumerateInstances(workspaceRoot string) ([]string, error) {
 	return instances, nil
 }
 
-// NextInstanceNumber returns max(existing instance numbers) + 1 by scanning
-// subdirectories of workspaceRoot. Returns 1 if no instances exist.
+// NextInstanceNumber finds the lowest unused instance number by scanning
+// subdirectories of workspaceRoot. It fills gaps left by deleted instances
+// (e.g., if instances 2, 4, 5 exist, it returns 3). Returns 1 if no
+// instances exist.
 func NextInstanceNumber(workspaceRoot string) (int, error) {
 	instances, err := EnumerateInstances(workspaceRoot)
 	if err != nil {
 		return 0, err
 	}
 
-	maxNum := 0
+	used := make(map[int]bool)
 	for _, dir := range instances {
 		state, err := LoadState(dir)
 		if err != nil {
 			continue
 		}
-		if state.InstanceNumber > maxNum {
-			maxNum = state.InstanceNumber
-		}
+		used[state.InstanceNumber] = true
 	}
 
-	return maxNum + 1, nil
+	// Find the first unused number starting from 1.
+	for n := 1; ; n++ {
+		if !used[n] {
+			return n, nil
+		}
+	}
 }
 
 // HashFile computes the SHA-256 hash of a file and returns it with a "sha256:"

--- a/internal/workspace/state_test.go
+++ b/internal/workspace/state_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -326,16 +327,15 @@ func TestNextInstanceNumber(t *testing.T) {
 		t.Errorf("NextInstanceNumber = %d, want 1", num)
 	}
 
-	// Create instances with numbers 1 and 3.
+	// Create instances with numbers 1 and 3 (gap at 2).
 	for _, n := range []int{1, 3} {
-		name := "ws"
-		dir := filepath.Join(root, name+"-"+string(rune('0'+n)))
+		dir := filepath.Join(root, fmt.Sprintf("ws-%d", n))
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		state := &InstanceState{
 			SchemaVersion:  SchemaVersion,
-			InstanceName:   name,
+			InstanceName:   "ws",
 			InstanceNumber: n,
 			Root:           dir,
 			Created:        time.Now(),
@@ -347,12 +347,75 @@ func TestNextInstanceNumber(t *testing.T) {
 		}
 	}
 
+	// Should fill the gap at 2, not jump to 4.
 	num, err = NextInstanceNumber(root)
 	if err != nil {
 		t.Fatalf("NextInstanceNumber: %v", err)
 	}
-	if num != 4 {
-		t.Errorf("NextInstanceNumber = %d, want 4", num)
+	if num != 2 {
+		t.Errorf("NextInstanceNumber = %d, want 2 (should fill gap)", num)
+	}
+}
+
+func TestNextInstanceNumber_FillsDeletedGap(t *testing.T) {
+	root := t.TempDir()
+
+	// Simulate instances 1, 2, 4, 5 existing (3 was deleted).
+	for _, n := range []int{1, 2, 4, 5} {
+		dir := filepath.Join(root, fmt.Sprintf("ws-%d", n))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := SaveState(dir, &InstanceState{
+			SchemaVersion:  SchemaVersion,
+			InstanceName:   "ws",
+			InstanceNumber: n,
+			Root:           dir,
+			Created:        time.Now(),
+			LastApplied:    time.Now(),
+			Repos:          map[string]RepoState{},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	num, err := NextInstanceNumber(root)
+	if err != nil {
+		t.Fatalf("NextInstanceNumber: %v", err)
+	}
+	if num != 3 {
+		t.Errorf("NextInstanceNumber = %d, want 3 (should fill gap left by deleted instance)", num)
+	}
+}
+
+func TestNextInstanceNumber_Contiguous(t *testing.T) {
+	root := t.TempDir()
+
+	// Instances 1, 2, 3, 4 with no gaps.
+	for _, n := range []int{1, 2, 3, 4} {
+		dir := filepath.Join(root, fmt.Sprintf("ws-%d", n))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := SaveState(dir, &InstanceState{
+			SchemaVersion:  SchemaVersion,
+			InstanceName:   "ws",
+			InstanceNumber: n,
+			Root:           dir,
+			Created:        time.Now(),
+			LastApplied:    time.Now(),
+			Repos:          map[string]RepoState{},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	num, err := NextInstanceNumber(root)
+	if err != nil {
+		t.Fatalf("NextInstanceNumber: %v", err)
+	}
+	if num != 5 {
+		t.Errorf("NextInstanceNumber = %d, want 5", num)
 	}
 }
 


### PR DESCRIPTION
NextInstanceNumber previously returned max(existing) + 1, so deleting
instance 3 out of [1,2,3,4,5] then running niwa create would produce
instance 6 instead of reusing 3. Change to scan for the lowest unused
number, filling gaps left by deleted instances.

---

## What This Fixes

After manually deleting a workspace instance directory (e.g., tsukumogami-3),
`niwa create` skipped the gap and picked the next number after all existing
instances. Now it finds the first hole in the sequence.

## Test Plan

- [x] `TestNextInstanceNumber` — gap at 2 with instances 1,3 returns 2
- [x] `TestNextInstanceNumber_FillsDeletedGap` — gap at 3 with instances 1,2,4,5 returns 3
- [x] `TestNextInstanceNumber_Contiguous` — no gaps with instances 1,2,3,4 returns 5
- [x] `go vet ./...` clean
- [x] All existing tests pass