### PR TITLE
revert: remove install_shell_init from recipe until tsuku bug is fixed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Install tsuku
-        run: curl -fsSL https://tsuku.dev/install.sh | bash
-
       - name: Verify shell-init output
         run: |
           go build -o niwa-test ./cmd/niwa
@@ -66,36 +63,3 @@ jobs:
             echo "OK: shell-init $shell produces valid wrapper output"
           done
           rm niwa-test
-
-      - name: Verify recipe installs via tsuku
-        run: |
-          export PATH="$HOME/.tsuku/bin:$PATH"
-          eval "$(tsuku shellenv)"
-          tsuku install tsukumogami/niwa:niwa --force
-
-          # Verify shell.d init files if install_shell_init ran.
-          # The distributed source fetches the recipe from main. Once the
-          # install_shell_init step is on main, this validates the full
-          # lifecycle. Until then it validates recipe parsing and install.
-          # Full e2e blocked by tsukumogami/tsuku#2218 (--recipe skips
-          # post-install phase).
-          for shell in bash zsh; do
-            init_file="$HOME/.tsuku/share/shell.d/niwa.$shell"
-            if [ -f "$init_file" ]; then
-              if ! grep -q 'niwa()' "$init_file"; then
-                echo "::error::$init_file missing niwa() wrapper function"
-                exit 1
-              fi
-              echo "OK: $init_file exists and contains wrapper function"
-            fi
-          done
-
-          tsuku remove niwa
-          for shell in bash zsh; do
-            init_file="$HOME/.tsuku/share/shell.d/niwa.$shell"
-            if [ -f "$init_file" ]; then
-              echo "::error::$init_file was not cleaned up by tsuku remove"
-              exit 1
-            fi
-          done
-          echo "OK: tsuku install/remove cycle completed successfully"

--- a/.tsuku-recipes/niwa.toml
+++ b/.tsuku-recipes/niwa.toml
@@ -21,12 +21,6 @@ files = ["niwa-{os}-{arch}"]
 action = "install_binaries"
 outputs = [{src = "niwa-{os}-{arch}", dest = "bin/niwa"}]
 
-[[steps]]
-action = "install_shell_init"
-phase = "post-install"
-source_command = "niwa shell-init {shell}"
-target = "niwa"
-shells = ["bash", "zsh"]
 
 [verify]
 command = "niwa version"


### PR DESCRIPTION
Remove the `install_shell_init` step from the niwa recipe. tsuku 0.8.0 has a
bug where post-install phase steps are included in the main plan execution
instead of being deferred, causing `ToolInstallDir` to be unset when the step
runs. This breaks both `tsuku install niwa` and `tsuku update niwa`.

Keep the `shell-init` output CI check since the underlying command works -- it's
only the recipe integration that's broken on tsuku's side.

---

Reverts the recipe change from #43

Tracked upstream: tsukumogami/tsuku#2218

The recipe step can be re-added once tsuku properly defers `phase = "post-install"`
steps and sets `ToolInstallDir` before executing them.