### PR TITLE
fix: three vault integration bugs (blank import, create overlay, R12 anonymous)

### DIFF
--- a/cmd/niwa/main.go
+++ b/cmd/niwa/main.go
@@ -1,6 +1,13 @@
 package main
 
-import "github.com/tsukumogami/niwa/internal/cli"
+import (
+	"github.com/tsukumogami/niwa/internal/cli"
+
+	// Register vault backends. Each package's init() calls
+	// vault.DefaultRegistry.Register so the resolver can open
+	// providers by kind name at apply time.
+	_ "github.com/tsukumogami/niwa/internal/vault/infisical"
+)
 
 func main() {
 	cli.Execute()

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -126,6 +126,17 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	gh := github.NewAPIClient(token)
 
 	applier := workspace.NewApplier(gh)
+
+	// Wire up the global config overlay (personal overlay) so vault
+	// resolution and personal-wins merging work during create, not
+	// just apply. Without this, [env.secrets.required] keys that the
+	// personal overlay supplies via vault:// would fail as "not supplied".
+	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil && globalCfg.GlobalConfig.Repo != "" {
+		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
+			applier.GlobalConfigDir = gDir
+		}
+	}
+
 	instancePath, err := applier.Create(cmd.Context(), cfg, configDir, workspaceRoot)
 	if err != nil {
 		return err

--- a/internal/vault/resolve/resolve.go
+++ b/internal/vault/resolve/resolve.go
@@ -147,18 +147,26 @@ func CheckProviderNameCollision(team, personal *vault.Bundle) error {
 	if team == nil || personal == nil {
 		return nil
 	}
+	// R12 compares NAMED providers only. Anonymous providers (empty-
+	// string name) are file-scoped by D-9: each config file's
+	// [vault.provider] is independent of the other file's. Two files
+	// can each declare an anonymous provider without conflict because
+	// their vault:// URIs resolve within their own file's context
+	// before the merge runs (D-6 resolve-before-merge ordering).
 	teamNames := map[string]bool{}
 	for _, n := range team.Names() {
+		if n == "" {
+			continue // anonymous — file-scoped, not a shared name
+		}
 		teamNames[n] = true
 	}
 	var colliding []string
 	for _, n := range personal.Names() {
+		if n == "" {
+			continue // anonymous — file-scoped
+		}
 		if teamNames[n] {
-			label := n
-			if label == "" {
-				label = "(anonymous)"
-			}
-			colliding = append(colliding, label)
+			colliding = append(colliding, n)
 		}
 	}
 	if len(colliding) == 0 {

--- a/internal/vault/resolve/resolve_test.go
+++ b/internal/vault/resolve/resolve_test.go
@@ -485,7 +485,9 @@ func TestCheckProviderNameCollisionEmpty(t *testing.T) {
 }
 
 // TestCheckProviderNameCollisionAnonymous: both sides declare the
-// anonymous singular provider; the empty-string name collides.
+// anonymous singular provider. Anonymous providers are file-scoped per
+// D-9: each file's [vault.provider] resolves its own URIs independently
+// before merge. R12 applies only to NAMED providers.
 func TestCheckProviderNameCollisionAnonymous(t *testing.T) {
 	reg := newFakeRegistry(t)
 	team, err := reg.Build(context.Background(), []vault.ProviderSpec{
@@ -504,14 +506,8 @@ func TestCheckProviderNameCollisionAnonymous(t *testing.T) {
 	defer personal.CloseAll()
 
 	err = resolve.CheckProviderNameCollision(team, personal)
-	if err == nil {
-		t.Fatal("expected collision error")
-	}
-	if !errors.Is(err, vault.ErrProviderNameCollision) {
-		t.Errorf("expected ErrProviderNameCollision, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "anonymous") {
-		t.Errorf("expected message to mention anonymous, got %q", err.Error())
+	if err != nil {
+		t.Fatalf("anonymous providers should NOT collide (file-scoped per D-9), got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Add blank import of internal/vault/infisical in cmd/niwa/main.go so the
Infisical factory registers at startup. Wire GlobalConfigDir into the
Applier during niwa create so the personal overlay resolves vault URIs
(was only wired during apply). Fix R12 CheckProviderNameCollision to
skip anonymous providers — they are file-scoped per D-9 and independent
across layers.

Found during end-to-end testing of the vault migration on
tsukumogami/dot-niwa.

---

## What this fixes

1. `niwa apply` with any `[vault.provider] kind = "infisical"` config
   failed with "no factory registered" because the Infisical package
   was never imported by the binary.

2. `niwa create` on a workspace with `[env.secrets.required]` keys
   supplied by the personal overlay failed with "required env keys not
   supplied" because the overlay was never loaded during create.

3. Both team and personal configs declaring `[vault.provider]`
   (anonymous singular) triggered a false R12 collision even though
   anonymous providers are file-scoped and resolve independently.

## Test plan

- [x] TestCheckProviderNameCollisionAnonymous updated to expect no error
- [x] Full test suite green (`go test ./...`)
- [x] End-to-end: `niwa create` on fresh temp workspace with team vault
  (Infisical) + personal overlay (anonymous provider) succeeds and
  materializes all secrets correctly