### PR TITLE
fix(cli): apply <name> no longer silently no-ops on single-instance workspaces

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -162,6 +162,17 @@ func resolveRegistryScope(name string) (*workspace.ApplyScope, error) {
 		return nil, fmt.Errorf("enumerating instances: %w", err)
 	}
 
+	// Single-instance layout: the workspace root is itself the instance
+	// (instance.json lives at workspaceRoot/.niwa/instance.json rather than
+	// in a child subdirectory). EnumerateInstances only scans children, so
+	// it returns empty for this layout. Fall back to treating workspaceRoot
+	// as the sole instance.
+	if len(instances) == 0 {
+		if _, statErr := os.Stat(filepath.Join(workspaceRoot, workspace.StateDir, workspace.StateFile)); statErr == nil {
+			instances = []string{workspaceRoot}
+		}
+	}
+
 	return &workspace.ApplyScope{
 		Mode:      workspace.ApplyAll,
 		Instances: instances,


### PR DESCRIPTION
## Summary

- `resolveRegistryScope` derived `workspaceRoot` from `configDir`'s parent, then called `EnumerateInstances` which only scans children for `.niwa/instance.json`. For single-instance workspaces where the workspace root **is** the instance root, `instance.json` lives at `workspaceRoot/.niwa/instance.json` — not in any child directory — so `EnumerateInstances` returned empty and the apply loop never ran.
- After `EnumerateInstances` returns empty, now falls back to checking whether `workspaceRoot` itself has `.niwa/instance.json` and treats it as the sole instance.

Closes #56.

## Test plan

- [ ] `go test ./internal/cli/... ./internal/workspace/...` passes
- [ ] `niwa apply <name>` on a single-instance workspace applies correctly instead of silently returning
- [ ] `niwa apply <name>` on a multi-instance workspace is unaffected (fallback only triggers when `EnumerateInstances` returns empty)