### PR TITLE
fix(workspace): wire overlay and personal overlay into create path

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -111,10 +111,13 @@ func runApply(cmd *cobra.Command, args []string) error {
 
 	// Wire global config and ConfigSourceURL from the registry if available.
 	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
-		if globalCfg.GlobalConfig.Repo != "" {
-			if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
-				applier.GlobalConfigDir = gDir
-			}
+		// Always set GlobalConfigDir when the path resolves. SyncConfigDir
+		// is a no-op when the directory has no git remote, and the niwa.toml
+		// reader silently skips the file when it doesn't exist — so the guard
+		// on GlobalConfig.Repo is not needed for safety, and omitting it lets
+		// manually-maintained personal overlays (no remote configured) work.
+		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
+			applier.GlobalConfigDir = gDir
 		}
 		// ConfigSourceURL is the original GitHub URL stored at init time.
 		// It enables convention overlay discovery when OverlayURL is not yet

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -132,10 +132,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// ConfigSourceURL is set as a fallback for overlay discovery when no
 	// init-time state exists (e.g., create inside a bare .niwa/ dir).
 	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
-		if globalCfg.GlobalConfig.Repo != "" {
-			if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
-				applier.GlobalConfigDir = gDir
-			}
+		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
+			applier.GlobalConfigDir = gDir
 		}
 		if entry := globalCfg.LookupWorkspace(cfg.Workspace.Name); entry != nil {
 			applier.ConfigSourceURL = entry.SourceURL

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -127,13 +127,17 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	applier := workspace.NewApplier(gh)
 
-	// Wire up the global config overlay (personal overlay) so vault
-	// resolution and personal-wins merging work during create, not
-	// just apply. Without this, [env.secrets.required] keys that the
-	// personal overlay supplies via vault:// would fail as "not supplied".
-	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil && globalCfg.GlobalConfig.Repo != "" {
-		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
-			applier.GlobalConfigDir = gDir
+	// Wire up the global config overlay (personal overlay) and ConfigSourceURL
+	// so that vault resolution, personal-wins merging, and convention overlay
+	// discovery all work during create, not just apply.
+	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
+		if globalCfg.GlobalConfig.Repo != "" {
+			if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
+				applier.GlobalConfigDir = gDir
+			}
+		}
+		if entry := globalCfg.LookupWorkspace(cfg.Workspace.Name); entry != nil {
+			applier.ConfigSourceURL = entry.SourceURL
 		}
 	}
 

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -127,9 +127,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	applier := workspace.NewApplier(gh)
 
-	// Wire up the global config overlay (personal overlay) and ConfigSourceURL
-	// so that vault resolution, personal-wins merging, and convention overlay
-	// discovery all work during create, not just apply.
+	// Wire up the global config overlay (personal overlay) so vault
+	// resolution and personal-wins merging work during create.
+	// ConfigSourceURL is set as a fallback for overlay discovery when no
+	// init-time state exists (e.g., create inside a bare .niwa/ dir).
 	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
 		if globalCfg.GlobalConfig.Repo != "" {
 			if gDir, gErr := config.GlobalConfigDir(); gErr == nil {

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -134,8 +134,27 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		return "", fmt.Errorf("preparing instance .gitignore: %w", err)
 	}
 
+	// Load init-time state from the workspace root. `niwa init` writes
+	// overlay URL, SkipGlobal, and NoOverlay to {workspaceRoot}/.niwa/instance.json
+	// before any instance directory exists. Reading it here lets create honour
+	// everything init discovered (overlay clone, flags) without re-running
+	// discovery and without depending on workspace repos being cloned.
+	initState, _ := LoadState(workspaceRoot)
+
+	var initOverlayURL string
+	var initNoOverlay bool
+	var initSkipGlobal bool
+	if initState != nil {
+		initOverlayURL = initState.OverlayURL
+		initNoOverlay = initState.NoOverlay
+		initSkipGlobal = initState.SkipGlobal
+	}
+
 	result, err := a.runPipeline(ctx, cfg, configDir, instanceRoot, now, &pipelineOpts{
 		existingState:   nil,
+		overlayURL:      initOverlayURL,
+		noOverlay:       initNoOverlay,
+		skipGlobal:      initSkipGlobal,
 		configSourceURL: a.ConfigSourceURL,
 	})
 	if err != nil {

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -134,11 +134,9 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		return "", fmt.Errorf("preparing instance .gitignore: %w", err)
 	}
 
-	// configSourceURL is intentionally not set here: overlay discovery is an
-	// apply-time concern. Create initializes the workspace; the overlay URL (if
-	// any) is discovered on the first apply and stored in state from that point.
 	result, err := a.runPipeline(ctx, cfg, configDir, instanceRoot, now, &pipelineOpts{
-		existingState: nil,
+		existingState:   nil,
+		configSourceURL: a.ConfigSourceURL,
 	})
 	if err != nil {
 		return "", err
@@ -153,8 +151,6 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		return "", fmt.Errorf("determining instance number: %w", err)
 	}
 
-	// Overlay fields are not set for a fresh create: overlay discovery happens
-	// at init time (when configSourceURL is known) or on subsequent applies.
 	configName := cfg.Workspace.Name
 	state := &InstanceState{
 		SchemaVersion:  SchemaVersion,
@@ -167,6 +163,8 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		ManagedFiles:   result.managedFiles,
 		Repos:          result.repoStates,
 		Shadows:        result.shadows,
+		OverlayURL:     result.overlayURL,
+		OverlayCommit:  result.overlayCommit,
 	}
 
 	if err := SaveState(instanceRoot, state); err != nil {

--- a/internal/workspace/override.go
+++ b/internal/workspace/override.go
@@ -690,14 +690,38 @@ func MergeWorkspaceOverlay(ws *config.WorkspaceConfig, overlay *config.Workspace
 		}
 	}
 
-	// Repos: add overlay repos; base wins on collision.
+	// Repos: add overlay repos; base wins on collision for structural fields
+	// (URL, Group, Branch, Scope, Claude, Files, SetupDir). For env values,
+	// overlay supplies vault-resolved secrets/vars for keys not present in the
+	// base — same base-wins-per-key semantics as the top-level Env merge.
 	for k, v := range overlay.Repos {
-		if _, exists := merged.Repos[k]; !exists {
+		base, exists := merged.Repos[k]
+		if !exists {
 			if merged.Repos == nil {
 				merged.Repos = make(map[string]config.RepoOverride)
 			}
 			merged.Repos[k] = v
+			continue
 		}
+		// Repo exists in both: merge env values from overlay into base.
+		mergedRepo := base
+		for envKey, envVal := range v.Env.Vars.Values {
+			if _, exists := mergedRepo.Env.Vars.Values[envKey]; !exists {
+				if mergedRepo.Env.Vars.Values == nil {
+					mergedRepo.Env.Vars.Values = map[string]config.MaybeSecret{}
+				}
+				mergedRepo.Env.Vars.Values[envKey] = envVal
+			}
+		}
+		for envKey, envVal := range v.Env.Secrets.Values {
+			if _, exists := mergedRepo.Env.Secrets.Values[envKey]; !exists {
+				if mergedRepo.Env.Secrets.Values == nil {
+					mergedRepo.Env.Secrets.Values = map[string]config.MaybeSecret{}
+				}
+				mergedRepo.Env.Secrets.Values[envKey] = envVal
+			}
+		}
+		merged.Repos[k] = mergedRepo
 	}
 
 	// Claude.Hooks: append overlay hooks; resolve scripts to absolute paths within overlayDir.


### PR DESCRIPTION
`Create()` in `internal/workspace/apply.go` now reads `{workspaceRoot}/.niwa/instance.json` (written by `niwa init`) and passes the overlay URL, `noOverlay`, and `skipGlobal` flags into `runPipeline`. Previously those values were silently dropped and the workspace overlay was never fetched or merged during create.

`cli/apply.go` and `cli/create.go` no longer gate `applier.GlobalConfigDir` on `GlobalConfig.Repo` being non-empty. The personal overlay at `~/.config/niwa/global/niwa.toml` is now loaded whenever the path resolves — `SyncConfigDir` already handles the no-remote case as a no-op, so the guard was unnecessary.

`MergeWorkspaceOverlay` in `internal/workspace/override.go` now merges per-repo `env.vars` and `env.secrets` values key-by-key for repos that appear in both base and overlay configs. Previously, "base wins" applied at the whole-entry level: any overlay repo that collided with a base repo was discarded entirely, including its vault-resolved secrets.

---

## What This Fixes

`niwa init --from <repo> && niwa create` failed with "required env keys not supplied" even when the workspace overlay and personal overlay supplied all secrets. Three independent bugs caused the failure:

1. **`Create()` ignored init-time state.** `niwa init` writes the discovered overlay URL to `{workspaceRoot}/.niwa/instance.json`. `Create()` never read that file, so the overlay was absent and vault resolution for overlay-backed secrets produced empty values.

2. **Personal overlay silently skipped.** `GlobalConfig.Repo` being unset (e.g. manually-maintained personal overlay without a registered remote) prevented `GlobalConfigDir` from being set on the applier, so `niwa.toml` was never loaded.

3. **Per-repo env values dropped on overlay collision.** `[repos.niwa.env.secrets]` in the overlay was ignored because `niwa` already existed in the base config. The whole-entry collision check discarded the overlay's vault-resolved values before they could satisfy the required-key check.

## Example

Before:
```
$ niwa init --from tsukumogami/dot-niwa && niwa create
Error: required env keys not supplied:
  [env.secrets] GH_TOKEN: ...
  [repos.niwa.env.secrets] INFISICAL_CLIENT_ID: ...
```

After:
```
$ niwa init --from tsukumogami/dot-niwa && niwa create
Created instance: /home/user/dev/tsukumogami
```