### PR TITLE
fix(workspace): inject machine-identity tokens into overlay vault provider

### DIFF
--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -312,6 +312,22 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 	// attribute" — drift for those files is pure content-hash drift.
 	sourceTuples := map[string][]SourceEntry{}
 
+	// Multi-org auth: read the local credential file once for the whole
+	// pipeline. authEntries is consumed by every layer that builds a vault
+	// bundle — the overlay (Step 0.6), the team config (Step 6), and the
+	// personal global overlay (Step 6). The file lives at
+	// ~/.config/niwa/provider-auth.toml (same directory that holds the
+	// global config clone). When the file is absent, authEntries is nil
+	// and every injection call is a no-op (single-org path unchanged).
+	var authEntries []ProviderAuthEntry
+	if niwaConfigDir, err := NiwaConfigDir(); err == nil {
+		entries, err := LoadProviderAuth(niwaConfigDir)
+		if err != nil {
+			return nil, err
+		}
+		authEntries = entries
+	}
+
 	// Step 0.5: overlay sync and merge — determine and sync the workspace overlay.
 	// This must run BEFORE discoverAllRepos so that the merged config (base +
 	// overlay) feeds into discovery — overlay sources can then contribute repos.
@@ -396,6 +412,14 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 				return nil, fmt.Errorf("workspace overlay is missing workspace-overlay.toml")
 			}
 			return nil, fmt.Errorf("parsing workspace overlay: %w", parseErr)
+		}
+
+		// Inject machine-identity tokens into the overlay's [vault.provider]
+		// before building its bundle. Without this, multi-org users whose
+		// secrets live in the workspace overlay fall through to the CLI
+		// session for that provider.
+		if err := injectProviderTokens(ctx, authEntries, overlay.Vault); err != nil {
+			return nil, err
 		}
 
 		// Build the overlay's own vault bundle. A nil Vault field produces an
@@ -528,24 +552,16 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 		return nil, err
 	}
 
-	// Multi-org auth: read local credential file, obtain per-provider
-	// tokens. The credential file lives at ~/.config/niwa/provider-auth.toml
-	// (same directory that holds the global config clone). When the file
-	// is absent, this is a no-op (single-org path unchanged).
-	niwaConfigDir, niwaConfigErr := NiwaConfigDir()
-	if niwaConfigErr == nil {
-		authEntries, authErr := LoadProviderAuth(niwaConfigDir)
-		if authErr != nil {
-			return nil, authErr
+	// Multi-org auth: inject machine-identity tokens into the team config
+	// and personal global overlay vault registries. authEntries was loaded
+	// at the top of runPipeline so the overlay layer (Step 0.6) could see it.
+	if len(authEntries) > 0 {
+		if err := injectProviderTokens(ctx, authEntries, cfg.Vault); err != nil {
+			return nil, err
 		}
-		if len(authEntries) > 0 {
-			if err := injectProviderTokens(ctx, authEntries, cfg.Vault); err != nil {
+		if globalOverride != nil {
+			if err := injectProviderTokens(ctx, authEntries, globalOverride.Global.Vault); err != nil {
 				return nil, err
-			}
-			if globalOverride != nil {
-				if err := injectProviderTokens(ctx, authEntries, globalOverride.Global.Vault); err != nil {
-					return nil, err
-				}
 			}
 		}
 	}

--- a/internal/workspace/apply_vault_test.go
+++ b/internal/workspace/apply_vault_test.go
@@ -2,7 +2,10 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1079,5 +1082,116 @@ LOG_LEVEL = "codespar-debug"
 	}
 	if !strings.Contains(msg, "tsukumogami") || !strings.Contains(msg, "codespar") {
 		t.Errorf("error must list both source orgs so the user can pick, got: %v", err)
+	}
+}
+
+// TestApplyOverlayInjectsMachineIdentityToken locks in the multi-org auth
+// wiring for the workspace overlay layer. Without this regression, the
+// overlay's [vault.provider] is built before token injection runs, so a
+// matching provider-auth.toml entry is silently ignored and the infisical
+// subprocess falls through to the CLI session.
+//
+// The test asserts that the universal-auth endpoint is hit exactly once
+// during apply, proving injectProviderTokens runs against the overlay
+// vault registry. The overlay declares a provider but no vault:// refs,
+// so Open is exercised but Resolve (which would shell out to the
+// infisical CLI) is not — keeping the test self-contained.
+func TestApplyOverlayInjectsMachineIdentityToken(t *testing.T) {
+	var authHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		authHits++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "test-jwt"})
+	}))
+	defer srv.Close()
+
+	xdgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgHome)
+	niwaConfigDir := filepath.Join(xdgHome, "niwa")
+	if err := os.MkdirAll(niwaConfigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	authTOML := `
+[[providers]]
+kind          = "infisical"
+project       = "test-project-uuid"
+client_id     = "test-client-id"
+client_secret = "test-client-secret"
+api_url       = "` + srv.URL + `"
+`
+	if err := os.WriteFile(filepath.Join(niwaConfigDir, "provider-auth.toml"), []byte(authTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	overlayTOML := `
+[vault.provider]
+kind    = "infisical"
+project = "test-project-uuid"
+`
+	overlayDir := setupOverlayDir(t, overlayTOML)
+
+	configTOML := `
+[workspace]
+name = "test-ws"
+
+[[sources]]
+org = "testorg"
+
+[groups.all]
+visibility = "public"
+`
+	niwaDir, instanceRoot := setupTestWorkspace(t, configTOML, nil, []struct{ group, name string }{
+		{"all", "repo1"},
+	})
+
+	result, err := config.Load(filepath.Join(niwaDir, "workspace.toml"))
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	cfg := result.Config
+
+	mockClient := &mockGitHubClient{
+		repos: map[string][]github.Repo{
+			"testorg": {
+				{Name: "repo1", Visibility: "public", SSHURL: "git@github.com:testorg/repo1.git"},
+			},
+		},
+	}
+
+	initialState := &InstanceState{
+		SchemaVersion:  SchemaVersion,
+		InstanceName:   "test-ws",
+		InstanceNumber: 1,
+		Root:           instanceRoot,
+		OverlayURL:     "testorg/test-ws-overlay",
+		OverlayCommit:  "abc123",
+	}
+	if err := SaveState(instanceRoot, initialState); err != nil {
+		t.Fatal(err)
+	}
+
+	cloneFn := func(_, dir string) (bool, error) {
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			return false, err
+		}
+		data, err := os.ReadFile(filepath.Join(overlayDir, "workspace-overlay.toml"))
+		if err != nil {
+			return false, err
+		}
+		return false, os.WriteFile(filepath.Join(dir, "workspace-overlay.toml"), data, 0o644)
+	}
+	headFn := func(_ string) (string, error) { return "abc123", nil }
+
+	applier := NewApplier(mockClient)
+	applier.Cloner = &Cloner{}
+	applier.cloneOrSync = cloneFn
+	applier.headSHA = headFn
+
+	if err := applier.Apply(context.Background(), cfg, niwaDir, instanceRoot); err != nil {
+		t.Fatalf("apply with overlay+provider-auth failed: %v", err)
+	}
+
+	if authHits != 1 {
+		t.Errorf("expected exactly 1 hit on universal-auth endpoint (proving overlay vault token injection ran), got %d", authHits)
 	}
 }


### PR DESCRIPTION
The workspace overlay layer builds its own vault bundle in step 0.6 of runPipeline, but the multi-org auth wiring only injected machine-identity tokens into the team config and personal global overlay registries — both processed in step 6, after the overlay bundle had already been built. Multi-org users whose secrets live in the workspace overlay silently fell through to the CLI session for that provider, defeating provider-auth.toml for that layer.

Hoist LoadProviderAuth to the top of runPipeline so authEntries is available to every layer that builds a vault bundle. Call injectProviderTokens on overlay.Vault before its bundle is built. Replace the redundant load near the end of the pipeline with a use of the hoisted variable. Add a regression test that asserts the universal-auth endpoint is hit exactly once when an overlay declares a provider matching a credential entry.

---

## What This Fixes

PR #58 added the multi-org auth path (`provider-auth.toml`); PR #54 added the workspace overlay layer. Each shipped its own vault wiring, but the overlay's `BuildBundle` runs before the existing `injectProviderTokens` calls, so any `[vault.provider]` declared in `workspace-overlay.toml` silently used the CLI session instead of the configured machine identity. The failure mode was a 403 (or "No valid login session found") when the CLI session was logged into a different org than the overlay project.

## Changes

- `internal/workspace/apply.go`: hoist auth-load, inject on overlay vault, simplify the existing inject block
- `internal/workspace/apply_vault_test.go`: regression test using an httptest auth server, asserts the endpoint is hit when an overlay matches a credential entry

## Test Plan

- [x] `go test ./internal/workspace/...` passes
- [x] `go vet ./...` clean
- [x] Regression test fails on `main` (auth hits = 0), passes after the fix (= 1)
- [x] End-to-end on a real workspace whose Tsukumogami `[vault.provider]` lives in the overlay layer: `niwa apply` succeeds with no Infisical CLI session present
- [x] End-to-end on four fresh test workspaces (test-tsuku and test-codespar, each with and without their overlay): `--no-overlay` resolves personal-org secrets via the global overlay (CLI session); with overlay, both personal-org and team-org secrets resolve, with the team-org path going through machine-identity injection on the workspace overlay layer