### PR TITLE
fix(workspace): resolve personal overlay by config name, not instance name

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -135,6 +135,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// init-time state exists (e.g., create inside a bare .niwa/ dir).
 	// Use configName (the original workspace config name) not instanceName
 	// so the registry lookup succeeds for -2, -3, ... instances too.
+	applier.ConfigName = configName
 	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
 		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
 			applier.GlobalConfigDir = gDir

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -121,21 +121,16 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("instance directory already exists: %s", instanceDir)
 	}
 
-	// Set the instance name on the config so Applier.Create uses it for the directory.
-	cfg.Workspace.Name = instanceName
-
 	token := resolveGitHubToken()
 	gh := github.NewAPIClient(token)
 
 	applier := workspace.NewApplier(gh)
 
-	// Wire up the global config overlay (personal overlay) so vault
-	// resolution and personal-wins merging work during create.
-	// ConfigSourceURL is set as a fallback for overlay discovery when no
-	// init-time state exists (e.g., create inside a bare .niwa/ dir).
-	// Use configName (the original workspace config name) not instanceName
-	// so the registry lookup succeeds for -2, -3, ... instances too.
-	applier.ConfigName = configName
+	// Wire up the global config overlay so vault resolution and personal-wins
+	// merging work during create. ConfigSourceURL is a fallback for overlay
+	// discovery when no init-time state exists (e.g., bare .niwa/ dir).
+	// The registry lookup uses configName (not instanceName) so -2, -3, ...
+	// instances find the same entry as the first instance.
 	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
 		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
 			applier.GlobalConfigDir = gDir
@@ -145,7 +140,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	instancePath, err := applier.Create(cmd.Context(), cfg, configDir, workspaceRoot)
+	instancePath, err := applier.Create(cmd.Context(), cfg, configDir, workspaceRoot, instanceName)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -101,14 +101,23 @@ func runReset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Re-create using the same instance name.
-	cfg.Workspace.Name = state.InstanceName
-
+	// Re-create using the same instance name. cfg.Workspace.Name is the
+	// config name from workspace.toml (never mutated); state.InstanceName
+	// is the directory name being recreated (e.g. "myws-2").
 	token := resolveGitHubToken()
 	gh := github.NewAPIClient(token)
 
 	applier := workspace.NewApplier(gh)
-	instancePath, err := applier.Create(cmd.Context(), cfg, configDir, workspaceRoot)
+	configName := cfg.Workspace.Name
+	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
+		if gDir, gErr := config.GlobalConfigDir(); gErr == nil {
+			applier.GlobalConfigDir = gDir
+		}
+		if entry := globalCfg.LookupWorkspace(configName); entry != nil {
+			applier.ConfigSourceURL = entry.SourceURL
+		}
+	}
+	instancePath, err := applier.Create(cmd.Context(), cfg, configDir, workspaceRoot, state.InstanceName)
 	if err != nil {
 		return fmt.Errorf("recreating instance: %w", err)
 	}

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -51,6 +51,13 @@ type Applier struct {
 	// Empty string disables convention discovery.
 	ConfigSourceURL string
 
+	// ConfigName is the original workspace config name (e.g. "codespar") before
+	// create.go renames cfg.Workspace.Name to the instance name ("codespar-2").
+	// Used for personal overlay scope lookup (ResolveGlobalOverride) and for
+	// recording ConfigName in InstanceState. When empty, cfg.Workspace.Name is
+	// used as the fallback (correct for apply, where no rename has occurred).
+	ConfigName string
+
 	// cloneOrSync is the function used to clone or sync the overlay repo.
 	// Defaults to CloneOrSyncOverlay. Overridable in tests.
 	cloneOrSync func(url, dir string) (bool, error)
@@ -172,7 +179,10 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		return "", fmt.Errorf("determining instance number: %w", err)
 	}
 
-	configName := cfg.Workspace.Name
+	configName := a.ConfigName
+	if configName == "" {
+		configName = cfg.Workspace.Name
+	}
 	state := &InstanceState{
 		SchemaVersion:  SchemaVersion,
 		ConfigName:     &configName,
@@ -669,7 +679,11 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 		if err != nil {
 			return nil, err
 		}
-		flattened := ResolveGlobalOverride(resolvedOverride, cfg.Workspace.Name)
+		overlayScope := a.ConfigName
+		if overlayScope == "" {
+			overlayScope = cfg.Workspace.Name
+		}
+		flattened := ResolveGlobalOverride(resolvedOverride, overlayScope)
 		merged, err := MergeGlobalOverride(resolvedCfg, flattened, a.GlobalConfigDir)
 		if err != nil {
 			return nil, err

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -51,13 +51,6 @@ type Applier struct {
 	// Empty string disables convention discovery.
 	ConfigSourceURL string
 
-	// ConfigName is the original workspace config name (e.g. "codespar") before
-	// create.go renames cfg.Workspace.Name to the instance name ("codespar-2").
-	// Used for personal overlay scope lookup (ResolveGlobalOverride) and for
-	// recording ConfigName in InstanceState. When empty, cfg.Workspace.Name is
-	// used as the fallback (correct for apply, where no rename has occurred).
-	ConfigName string
-
 	// cloneOrSync is the function used to clone or sync the overlay repo.
 	// Defaults to CloneOrSyncOverlay. Overridable in tests.
 	cloneOrSync func(url, dir string) (bool, error)
@@ -125,10 +118,13 @@ type pipelineResult struct {
 // Create creates a new workspace instance under workspaceRoot, runs the full
 // pipeline (discover, classify, clone, install content), assigns an instance
 // number, and writes fresh state. Returns the instance directory path.
-func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, configDir, workspaceRoot string) (string, error) {
+// instanceName is the directory name for the new instance (e.g. "myws-2");
+// cfg.Workspace.Name is the config identity and must not be mutated by the
+// caller — it is used for personal overlay scope lookup and InstanceState.ConfigName.
+func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, configDir, workspaceRoot, instanceName string) (string, error) {
 	now := time.Now()
 
-	instanceRoot := filepath.Join(workspaceRoot, cfg.Workspace.Name)
+	instanceRoot := filepath.Join(workspaceRoot, instanceName)
 	if err := os.MkdirAll(instanceRoot, 0o755); err != nil {
 		return "", fmt.Errorf("creating instance directory: %w", err)
 	}
@@ -179,14 +175,11 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		return "", fmt.Errorf("determining instance number: %w", err)
 	}
 
-	configName := a.ConfigName
-	if configName == "" {
-		configName = cfg.Workspace.Name
-	}
+	configName := cfg.Workspace.Name
 	state := &InstanceState{
 		SchemaVersion:  SchemaVersion,
 		ConfigName:     &configName,
-		InstanceName:   cfg.Workspace.Name,
+		InstanceName:   instanceName,
 		InstanceNumber: instanceNumber,
 		Root:           instanceRoot,
 		Created:        now,
@@ -679,11 +672,7 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 		if err != nil {
 			return nil, err
 		}
-		overlayScope := a.ConfigName
-		if overlayScope == "" {
-			overlayScope = cfg.Workspace.Name
-		}
-		flattened := ResolveGlobalOverride(resolvedOverride, overlayScope)
+		flattened := ResolveGlobalOverride(resolvedOverride, cfg.Workspace.Name)
 		merged, err := MergeGlobalOverride(resolvedCfg, flattened, a.GlobalConfigDir)
 		if err != nil {
 			return nil, err

--- a/internal/workspace/apply_test.go
+++ b/internal/workspace/apply_test.go
@@ -175,7 +175,7 @@ source = "repos/app.md"
 		t.Fatal(err)
 	}
 
-	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -323,7 +323,7 @@ source = "repos/app.md"
 	}
 
 	// First, create to seed state.
-	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -464,7 +464,7 @@ visibility = "public"
 	}
 
 	// Create should succeed even with no content sections.
-	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -729,7 +729,7 @@ source = "repos/app.md"
 		}
 	}
 
-	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -797,7 +797,7 @@ scope = "strategic"
 	}
 
 	// Create should succeed (warnings are printed to stderr, not returned as errors).
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 }
@@ -873,7 +873,7 @@ source = "workspace.md"
 	}
 
 	// Create initial state with workspace content.
-	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -1012,7 +1012,7 @@ source = "workspace.md"
 		t.Fatal(err)
 	}
 
-	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	gotPath, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -1130,7 +1130,7 @@ enabled = false
 		t.Fatal(err)
 	}
 
-	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
@@ -2577,7 +2577,7 @@ PLAIN = "not-a-secret"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 
@@ -2646,7 +2646,7 @@ visibility = "public"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 
@@ -2719,7 +2719,7 @@ visibility = "public"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 
@@ -2787,7 +2787,7 @@ visibility = "public"
 	}
 
 	// Seed state via Create so Apply has something to load.
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 

--- a/internal/workspace/apply_vault_test.go
+++ b/internal/workspace/apply_vault_test.go
@@ -122,7 +122,7 @@ API_TOKEN = "vault://API_TOKEN"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -208,7 +208,7 @@ MISSING = "vault://MISSING"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	if err == nil {
 		t.Fatal("expected error for missing vault key")
 	}
@@ -313,7 +313,7 @@ API_TOKEN = "vault://personal/API_TOKEN"
 	applier.Cloner = &Cloner{}
 	applier.GlobalConfigDir = globalDir
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		os.Stderr = origStderr
 		w.Close()
 		t.Fatalf("Create: %v", err)
@@ -409,7 +409,7 @@ LOG_LEVEL = "trace"
 	applier.Cloner = &Cloner{}
 	applier.GlobalConfigDir = globalDir
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -482,7 +482,7 @@ MISSING = "vault://MISSING"
 	applier.Cloner = &Cloner{}
 	applier.AllowMissingSecrets = true
 
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("expected apply to succeed with AllowMissingSecrets, got %v", err)
 	}
 }
@@ -555,7 +555,7 @@ ANTHROPIC_KEY = "vault://ANTHROPIC_KEY?required=false"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	_, createErr := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot)
+	_, createErr := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name)
 	w.Close()
 	os.Stderr = origStderr
 
@@ -663,7 +663,7 @@ TOKEN = "vault://TOKEN"
 		t.Fatal(err)
 	}
 	os.Stderr = w1
-	_, createErr := applier.Create(context.Background(), result.Config, niwaDir, workspaceRoot)
+	_, createErr := applier.Create(context.Background(), result.Config, niwaDir, workspaceRoot, result.Config.Workspace.Name)
 	w1.Close()
 	os.Stderr = origStderr
 	stderr1, _ := io.ReadAll(r1)
@@ -764,7 +764,7 @@ GITHUB_TOKEN = "GitHub PAT with repo:read scope"
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
 
-	_, err = applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot, parsed.Config.Workspace.Name)
 	if err == nil {
 		t.Fatal("expected apply to fail when a required env secret is missing")
 	}
@@ -839,7 +839,7 @@ GITHUB_TOKEN = "vault://GITHUB_TOKEN"
 	applier.Cloner = &Cloner{}
 	applier.AllowMissingSecrets = true
 
-	_, err = applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot, parsed.Config.Workspace.Name)
 	if err == nil {
 		t.Fatal("expected apply to fail even with --allow-missing-secrets when a required key is missing (R34)")
 	}
@@ -909,7 +909,7 @@ SENTRY_DSN = "Sentry error reporting"
 
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
-	_, createErr := applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot)
+	_, createErr := applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot, parsed.Config.Workspace.Name)
 	w.Close()
 	os.Stderr = origStderr
 
@@ -986,7 +986,7 @@ DEBUG_WEBHOOK_URL = "Personal debug webhook"
 
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
-	_, createErr := applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot)
+	_, createErr := applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot, parsed.Config.Workspace.Name)
 	w.Close()
 	os.Stderr = origStderr
 
@@ -1072,7 +1072,7 @@ LOG_LEVEL = "codespar-debug"
 	applier.Cloner = &Cloner{}
 	applier.GlobalConfigDir = globalDir
 
-	_, err = applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot)
+	_, err = applier.Create(context.Background(), parsed.Config, niwaDir, workspaceRoot, parsed.Config.Workspace.Name)
 	if err == nil {
 		t.Fatal("expected apply to fail on multi-source workspace without vault_scope (R5)")
 	}

--- a/internal/workspace/sources_test.go
+++ b/internal/workspace/sources_test.go
@@ -192,7 +192,7 @@ TOKEN = "vault://TOKEN"
 
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -483,7 +483,7 @@ TOKEN = "vault://TOKEN"
 
 	applier := NewApplier(mockClient)
 	applier.Cloner = &Cloner{}
-	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot); err != nil {
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 

--- a/test/functional/features/critical-path.feature
+++ b/test/functional/features/critical-path.feature
@@ -155,3 +155,35 @@ Feature: Critical path: init, create, and apply
     Then the exit code is 0
     When I run "niwa apply myws"
     Then the exit code is 0
+
+  # --- Regression: personal overlay scope must use config name, not instance name ---
+  # Before the fix, runPipeline used cfg.Workspace.Name (already mutated to the
+  # instance name "myws-2") for the personal overlay scope lookup, so the
+  # [workspaces.myws.*] block was never found, required keys were not merged in,
+  # and create failed with "required env keys not supplied".
+
+  @critical
+  Scenario: create second instance resolves personal overlay by config name not instance name
+    Given a clean niwa environment
+    And a local git server is set up
+    And a config repo "myws" exists with body:
+      """
+      [workspace]
+      name = "myws"
+
+      [env.secrets.required]
+      MY_KEY = "Required key supplied by personal overlay"
+      """
+    And a personal overlay exists with body:
+      """
+      [workspaces.myws.env.secrets]
+      MY_KEY = "plaintext-value"
+      """
+    When I run niwa init from config repo "myws"
+    Then the exit code is 0
+    When I run "niwa create myws"
+    Then the exit code is 0
+    And the instance "myws" exists
+    When I run "niwa create myws"
+    Then the exit code is 0
+    And the instance "myws-2" exists

--- a/test/functional/steps_test.go
+++ b/test/functional/steps_test.go
@@ -783,6 +783,26 @@ func anOverlayRepoExistsWithBody(ctx context.Context, name string, body *godog.D
 	return ctx, nil
 }
 
+// aPersonalOverlayExistsWithBody writes the given TOML content to
+// $XDG_CONFIG_HOME/niwa/global/niwa.toml so niwa treats it as the personal
+// global overlay for the scenario. The file is written inside the sandboxed
+// homeDir, so it is isolated between scenarios.
+func aPersonalOverlayExistsWithBody(ctx context.Context, body *godog.DocString) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	dir := filepath.Join(s.homeDir, ".config", "niwa", "global")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return ctx, fmt.Errorf("creating personal overlay dir: %w", err)
+	}
+	path := filepath.Join(dir, "niwa.toml")
+	if err := os.WriteFile(path, []byte(body.Content), 0o644); err != nil {
+		return ctx, fmt.Errorf("writing personal overlay: %w", err)
+	}
+	return ctx, nil
+}
+
 // aSourceRepoExists creates a bare repo and stores its file:// URL in state.
 func aSourceRepoExists(ctx context.Context, name string) (context.Context, error) {
 	s := getState(ctx)

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -154,6 +154,9 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 	ctx.Step(`^I source the installer env file and run completion for "([^"]*)" with prefix "([^"]*)"$`, iSourceShellInitAndRunCompletion)
 	ctx.Step(`^the "([^"]*)" shell-init output contains "([^"]*)"$`, shellInitContains)
 
+	// Personal overlay
+	ctx.Step(`^a personal overlay exists with body:$`, aPersonalOverlayExistsWithBody)
+
 	// Local git server
 	ctx.Step(`^a local git server is set up$`, aLocalGitServerIsSetUp)
 	ctx.Step(`^a config repo "([^"]*)" exists with body:$`, aConfigRepoExistsWithBody)


### PR DESCRIPTION
fix(workspace): make instanceName explicit in Applier.Create to fix personal overlay scope

create.go and reset.go pre-mutated cfg.Workspace.Name to the instance name
(e.g. \"codespar-2\") before calling Applier.Create. runPipeline used that
mutated name for the personal overlay scope lookup (ResolveGlobalOverride),
so [workspaces.codespar.*] was never found for second and subsequent
instances — required keys were not merged in and checkRequiredKeys fired.

Fix: add instanceName as an explicit parameter to Applier.Create. Callers
pass the instance name directly without mutating the config; cfg.Workspace.Name
always holds the config identity and is used correctly for overlay scope
lookup and InstanceState.ConfigName recording. Removes the Applier.ConfigName
workaround field. Also fixes reset.go, which had the same mutation bug and
was missing GlobalConfigDir/ConfigSourceURL wiring entirely.

## Summary

- `niwa create` was failing with \"required env keys not supplied\" when creating a second instance (e.g. `codespar-2`). The personal overlay's `[workspaces.codespar.*]` block was never applied because `runPipeline` looked up `[workspaces.codespar-2]` instead.
- Root cause: `create.go` and `reset.go` pre-mutated `cfg.Workspace.Name` to the instance name before calling `Applier.Create`, which poisoned the overlay scope lookup and `InstanceState.ConfigName` recording.
- Fix: make `instanceName` an explicit parameter on `Applier.Create`. Callers pass the instance name directly; `cfg.Workspace.Name` is never mutated and always holds the config identity. This removes the `Applier.ConfigName` workaround field, fixes `reset.go` (same bug + missing `GlobalConfigDir`/`ConfigSourceURL` wiring), and restores a clean API contract.

## Test plan

- [ ] `make test-functional-critical` — 27/27 pass, including new scenario "create second instance resolves personal overlay by config name not instance name"
- [ ] `go test ./internal/workspace/... ./internal/cli/...` — all pass
- [ ] Manual: `niwa create tsukumogami` × 2 and `niwa create codespar` × 2 in isolated smoke dirs — all four instances created successfully, `instance.json` records `config_name='tsukumogami'`/`'codespar'` on both instances in each workspace