### PR TITLE
fix(create): skip non-instance directories when computing next instance name

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -57,13 +57,24 @@ func computeInstanceName(configName, customName, workspaceRoot string) (string, 
 		return configName, nil
 	}
 
-	// Subsequent instances: find the next available number.
+	// Subsequent instances: find the next available number, skipping any
+	// directories that exist on disk but are not valid niwa instances.
+	// NextInstanceNumber accounts for valid instances only, so the candidate
+	// it produces may collide with a leftover or foreign directory.
 	nextNum, err := workspace.NextInstanceNumber(workspaceRoot)
 	if err != nil {
 		return "", fmt.Errorf("determining next instance number: %w", err)
 	}
 
-	return fmt.Sprintf("%s-%d", configName, nextNum), nil
+	for {
+		candidate := fmt.Sprintf("%s-%d", configName, nextNum)
+		candidateDir := filepath.Join(workspaceRoot, candidate)
+		if _, err := os.Stat(candidateDir); os.IsNotExist(err) {
+			return candidate, nil
+		}
+		fmt.Fprintf(os.Stderr, "warning: skipping %s: directory exists but is not a valid niwa instance\n", candidateDir)
+		nextNum++
+	}
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -100,6 +100,44 @@ func TestComputeInstanceName_DirExistsWithoutState(t *testing.T) {
 	}
 }
 
+func TestComputeInstanceName_SkipsNonInstanceDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create the first instance (valid, InstanceNumber=1).
+	firstDir := filepath.Join(dir, "tsuku")
+	stateDir := filepath.Join(firstDir, ".niwa")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := workspace.InstanceState{
+		SchemaVersion:  1,
+		InstanceName:   "tsuku",
+		InstanceNumber: 1,
+		Root:           firstDir,
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "instance.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// tsuku-2 exists but has no .niwa/instance.json (leftover or foreign dir).
+	if err := os.MkdirAll(filepath.Join(dir, "tsuku-2", "some-content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// computeInstanceName should skip tsuku-2 and return tsuku-3.
+	name, err := computeInstanceName("tsuku", "", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "tsuku-3" {
+		t.Errorf("expected %q, got %q", "tsuku-3", name)
+	}
+}
+
 func TestFindRepoDir_SingleMatch(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "public", "niwa"), 0o755); err != nil {


### PR DESCRIPTION
`computeInstanceName` calls `NextInstanceNumber`, which only counts directories
with `.niwa/instance.json`. If a directory named `<config>-<N>` exists for any
other reason (leftover from a failed create, manually created, or a deleted
instance whose directory survived), `computeInstanceName` still proposes that
name. The pre-create guard then sees the directory and returns a hard error,
permanently blocking `niwa create` until the user manually removes the directory.

The fix adds a loop in the "subsequent instances" branch of `computeInstanceName`:
after computing a candidate name, check if that directory already exists on disk.
If it does, emit a warning to stderr and increment to the next number. The
pre-create guard is kept as a race-condition safety net.

---

## Repro (before fix)

```
~/dev/niwaw/tsuku$ ls
tsukumogami   tsukumogami-2/   # tsukumogami-2 has no .niwa/instance.json
~/dev/niwaw/tsuku$ niwa create
Error: instance directory already exists: .../tsukumogami-2
```

## After fix

```
~/dev/niwaw/tsuku$ niwa create
warning: skipping .../tsukumogami-2: directory exists but is not a valid niwa instance
# creates tsukumogami-3 successfully
```