### PR TITLE
fix(workspace): move context imports to .claude/rules to suppress external-import dialog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,18 @@ jobs:
           INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           INFISICAL_TEST_PROJECT_ID: ${{ secrets.INFISICAL_TEST_PROJECT_ID }}
 
+      - name: Install Claude CLI
+        if: env.ANTHROPIC_API_KEY != ''
+        run: npm install -g @anthropic-ai/claude-code
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Claude integration tests
+        if: env.ANTHROPIC_API_KEY != ''
+        run: make test-functional-claude-integration
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
       - name: Install tsuku
         run: curl -fsSL https://tsuku.dev/install.sh | bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test build-test test-functional test-functional-critical test-install clean
+.PHONY: build test build-test test-functional test-functional-critical test-functional-claude-integration test-install clean
 
 # Build the niwa binary.
 build:
@@ -21,6 +21,11 @@ test-functional: build-test
 # Run only scenarios tagged @critical — fast feedback for core flows.
 test-functional-critical: build-test
 	NIWA_TEST_BINARY=$(CURDIR)/niwa-test NIWA_TEST_TAGS=@critical go test -v ./test/functional/...
+	rm -rf .niwa-test
+
+# Run only scenarios tagged @claude-integration — requires claude CLI and ANTHROPIC_API_KEY.
+test-functional-claude-integration: build-test
+	NIWA_TEST_BINARY=$(CURDIR)/niwa-test NIWA_TEST_TAGS=@claude-integration go test -v ./test/functional/...
 	rm -rf .niwa-test
 
 # Run only install-path integration scenarios. Proves that `niwa shell-init`

--- a/internal/workspace/workspace_context.go
+++ b/internal/workspace/workspace_context.go
@@ -20,10 +20,64 @@ const overlayClaudeImport = "@CLAUDE.overlay.md"
 const globalClaudeFile = "CLAUDE.global.md"
 const globalClaudeImport = "@CLAUDE.global.md"
 
+const workspaceRulesFile = ".claude/rules/workspace-imports.md"
+
+// writeWorkspaceRulesFile creates (or overwrites) the rules file with a single
+// @import line pointing to absPath.
+func writeWorkspaceRulesFile(rulesPath, absPath string) error {
+	if err := os.MkdirAll(filepath.Dir(rulesPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(rulesPath, []byte("@"+absPath+"\n"), 0o644)
+}
+
+// appendToWorkspaceRulesFile appends an @import line to the rules file if not
+// already present. Creates the file and its parent directory if needed.
+func appendToWorkspaceRulesFile(rulesPath, absPath string) error {
+	importLine := "@" + absPath
+	existing, err := os.ReadFile(rulesPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if strings.Contains(string(existing), importLine) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(rulesPath), 0o755); err != nil {
+		return err
+	}
+	content := string(existing)
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += importLine + "\n"
+	return os.WriteFile(rulesPath, []byte(content), 0o644)
+}
+
+// removeImportFromCLAUDE removes an old relative @import from CLAUDE.md
+// (migration support). No-op if not present or file does not exist.
+func removeImportFromCLAUDE(claudePath, importLine string) error {
+	data, err := os.ReadFile(claudePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	content := string(data)
+	if !strings.Contains(content, importLine) {
+		return nil
+	}
+	// ensureImportInCLAUDE always added "line\n\n"; try that form first.
+	content = strings.Replace(content, importLine+"\n\n", "", 1)
+	content = strings.Replace(content, importLine+"\n", "", 1)
+	return os.WriteFile(claudePath, []byte(content), 0o644)
+}
+
 // InstallWorkspaceContext generates a workspace context file at the instance
-// root and adds an @import to the workspace CLAUDE.md. The @import resolves
-// at the instance root but silently fails in child repos (the file doesn't
-// exist relative to them), giving level-scoped visibility without inheritance.
+// root and writes an @import to .claude/rules/workspace-imports.md using an
+// absolute path. This gives workspace-level visibility without triggering the
+// "Allow external CLAUDE.md file imports?" dialog when starting Claude from a
+// sub-repo directory.
 func InstallWorkspaceContext(cfg *config.WorkspaceConfig, classified []ClassifiedRepo, instanceRoot string) ([]string, error) {
 	content := generateWorkspaceContext(cfg, classified)
 
@@ -32,88 +86,24 @@ func InstallWorkspaceContext(cfg *config.WorkspaceConfig, classified []Classifie
 		return nil, fmt.Errorf("writing workspace context: %w", err)
 	}
 
-	// Add @import to the workspace CLAUDE.md if not already present.
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
+		return nil, fmt.Errorf("writing workspace rules file: %w", err)
+	}
+
+	// Migrate: remove old relative import from CLAUDE.md if present.
 	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
-	if err := ensureImportInCLAUDE(claudePath, workspaceContextImport); err != nil {
-		return nil, fmt.Errorf("adding workspace context import: %w", err)
+	if err := removeImportFromCLAUDE(claudePath, workspaceContextImport); err != nil {
+		return nil, fmt.Errorf("removing old workspace context import: %w", err)
 	}
 
-	return []string{contextPath}, nil
-}
-
-// ensureImportInCLAUDE adds an @import line to a CLAUDE.md file if not
-// already present. Creates the file if it doesn't exist.
-func ensureImportInCLAUDE(claudePath, importLine string) error {
-	existing, err := os.ReadFile(claudePath)
-	if os.IsNotExist(err) {
-		return nil // no CLAUDE.md, nothing to add import to
-	}
-	if err != nil {
-		return err
-	}
-
-	content := string(existing)
-	if strings.Contains(content, importLine) {
-		return nil // already present
-	}
-
-	// Prepend the import line.
-	content = importLine + "\n\n" + content
-
-	return os.WriteFile(claudePath, []byte(content), 0o644)
-}
-
-// ensureImportAfterInCLAUDE inserts importLine into a CLAUDE.md file
-// immediately after the first occurrence of afterLine (on its own line).
-// If afterLine is absent, the import is prepended (same behavior as
-// ensureImportInCLAUDE). If importLine is already present, it is a no-op.
-// Returns nil when CLAUDE.md does not exist.
-func ensureImportAfterInCLAUDE(claudePath, importLine, afterLine string) error {
-	existing, err := os.ReadFile(claudePath)
-	if os.IsNotExist(err) {
-		return nil // no CLAUDE.md, nothing to add import to
-	}
-	if err != nil {
-		return err
-	}
-
-	content := string(existing)
-	if strings.Contains(content, importLine) {
-		return nil // already present
-	}
-
-	// Find the position of afterLine as a complete line.
-	lines := strings.Split(content, "\n")
-	insertIdx := -1
-	for i, line := range lines {
-		if line == afterLine {
-			insertIdx = i + 1
-			break
-		}
-	}
-
-	var updated string
-	if insertIdx < 0 {
-		// afterLine not found — prepend.
-		updated = importLine + "\n\n" + content
-	} else {
-		// Insert after the found line, preserving surrounding blank lines.
-		// We insert the importLine followed by a blank line.
-		before := strings.Join(lines[:insertIdx], "\n")
-		after := strings.Join(lines[insertIdx:], "\n")
-		// Trim a leading blank line from `after` to avoid double-blank
-		// when there's already a blank line after the anchor.
-		trimmedAfter := strings.TrimPrefix(after, "\n")
-		updated = before + "\n" + importLine + "\n\n" + trimmedAfter
-	}
-
-	return os.WriteFile(claudePath, []byte(updated), 0o644)
+	return []string{contextPath, rulesPath}, nil
 }
 
 // InstallOverlayClaudeContent copies CLAUDE.overlay.md from the overlay clone
-// into the instance root and injects @CLAUDE.overlay.md into CLAUDE.md after
-// @workspace-context.md and before @CLAUDE.global.md. Returns the installed
-// path when the file was present, or ("", nil) when it was absent.
+// into the instance root and appends an absolute @import to
+// .claude/rules/workspace-imports.md. Returns the installed path when the file
+// was present, or ("", nil) when it was absent.
 func InstallOverlayClaudeContent(overlayDir, instanceRoot string) (string, error) {
 	srcPath := filepath.Join(overlayDir, overlayClaudeFile)
 	data, err := os.ReadFile(srcPath)
@@ -129,9 +119,15 @@ func InstallOverlayClaudeContent(overlayDir, instanceRoot string) (string, error
 		return "", fmt.Errorf("writing %s: %w", overlayClaudeFile, err)
 	}
 
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := appendToWorkspaceRulesFile(rulesPath, destPath); err != nil {
+		return "", fmt.Errorf("adding overlay to workspace rules file: %w", err)
+	}
+
+	// Migrate: remove old relative import from CLAUDE.md if present.
 	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
-	if err := ensureImportAfterInCLAUDE(claudePath, overlayClaudeImport, workspaceContextImport); err != nil {
-		return "", fmt.Errorf("adding overlay claude import: %w", err)
+	if err := removeImportFromCLAUDE(claudePath, overlayClaudeImport); err != nil {
+		return "", fmt.Errorf("removing old overlay import: %w", err)
 	}
 
 	return destPath, nil
@@ -262,12 +258,9 @@ func InstallWorkspaceRootSettings(cfg *config.WorkspaceConfig, configDir, instan
 }
 
 // InstallGlobalClaudeContent copies CLAUDE.global.md from the global config
-// directory into the instance root and adds an @import directive to CLAUDE.md.
+// directory into the instance root and appends an absolute @import to
+// .claude/rules/workspace-imports.md.
 // Returns nil, nil when CLAUDE.global.md does not exist in globalConfigDir.
-//
-// The global import is inserted after @CLAUDE.overlay.md when the overlay is
-// active, or after @workspace-context.md otherwise — preserving the required
-// import order (@workspace-context.md → @CLAUDE.overlay.md → @CLAUDE.global.md).
 func InstallGlobalClaudeContent(globalConfigDir, instanceRoot string) ([]string, error) {
 	srcPath := filepath.Join(globalConfigDir, globalClaudeFile)
 	data, err := os.ReadFile(srcPath)
@@ -283,21 +276,15 @@ func InstallGlobalClaudeContent(globalConfigDir, instanceRoot string) ([]string,
 		return nil, fmt.Errorf("writing %s: %w", globalClaudeFile, err)
 	}
 
-	// Prefer inserting after @CLAUDE.overlay.md (overlay active) or after
-	// @workspace-context.md (overlay absent). Falls back to prepend when
-	// neither anchor is present (e.g., content-only workspace with no context).
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := appendToWorkspaceRulesFile(rulesPath, destPath); err != nil {
+		return nil, fmt.Errorf("adding global to workspace rules file: %w", err)
+	}
+
+	// Migrate: remove old relative import from CLAUDE.md if present.
 	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
-	existing, readErr := os.ReadFile(claudePath)
-	if readErr != nil && !os.IsNotExist(readErr) {
-		return nil, fmt.Errorf("reading CLAUDE.md: %w", readErr)
-	}
-	content := string(existing)
-	anchor := workspaceContextImport // default anchor
-	if strings.Contains(content, overlayClaudeImport) {
-		anchor = overlayClaudeImport
-	}
-	if err := ensureImportAfterInCLAUDE(claudePath, globalClaudeImport, anchor); err != nil {
-		return nil, fmt.Errorf("adding global claude import: %w", err)
+	if err := removeImportFromCLAUDE(claudePath, globalClaudeImport); err != nil {
+		return nil, fmt.Errorf("removing old global import: %w", err)
 	}
 
 	return []string{destPath}, nil

--- a/internal/workspace/workspace_context_test.go
+++ b/internal/workspace/workspace_context_test.go
@@ -5,11 +5,133 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tsukumogami/niwa/internal/config"
 )
 
+// minimalCfg returns a *config.WorkspaceConfig suitable for calling
+// InstallWorkspaceContext. The workspace name is set to "test-ws".
+func minimalCfg() *config.WorkspaceConfig {
+	return &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{
+			Name: "test-ws",
+		},
+	}
+}
+
+// TestInstallWorkspaceContextWritesRulesFile verifies that InstallWorkspaceContext
+// creates .claude/rules/workspace-imports.md with an absolute @import, and does
+// not add any @import to CLAUDE.md.
+func TestInstallWorkspaceContextWritesRulesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	instanceRoot := filepath.Join(tmpDir, "instance")
+	if err := os.MkdirAll(instanceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := InstallWorkspaceContext(minimalCfg(), nil, instanceRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 returned paths, got %d: %v", len(paths), paths)
+	}
+
+	// Verify rules file contains absolute @import.
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	data, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("reading rules file: %v", err)
+	}
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	wantImport := "@" + contextPath
+	if !strings.Contains(string(data), wantImport) {
+		t.Errorf("rules file missing absolute import %q:\n%s", wantImport, string(data))
+	}
+
+	// CLAUDE.md should not contain the old relative import.
+	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
+	if _, err := os.Stat(claudePath); err == nil {
+		claudeData, _ := os.ReadFile(claudePath)
+		if strings.Contains(string(claudeData), workspaceContextImport) {
+			t.Errorf("CLAUDE.md should not contain %q:\n%s", workspaceContextImport, string(claudeData))
+		}
+	}
+}
+
+// TestInstallWorkspaceContextMigratesOldImport verifies that if CLAUDE.md has
+// the old relative @workspace-context.md import, it is removed after install.
+func TestInstallWorkspaceContextMigratesOldImport(t *testing.T) {
+	tmpDir := t.TempDir()
+	instanceRoot := filepath.Join(tmpDir, "instance")
+	if err := os.MkdirAll(instanceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate old format.
+	oldContent := "@workspace-context.md\n\n# Workspace\n"
+	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(oldContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallWorkspaceContext(minimalCfg(), nil, instanceRoot); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Old import must be gone from CLAUDE.md.
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("reading CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(claudeData), workspaceContextImport) {
+		t.Errorf("old relative import still present in CLAUDE.md:\n%s", string(claudeData))
+	}
+
+	// Absolute import must be in rules file.
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	rulesData, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("reading rules file: %v", err)
+	}
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	if !strings.Contains(string(rulesData), "@"+contextPath) {
+		t.Errorf("rules file missing absolute import for workspace-context:\n%s", string(rulesData))
+	}
+}
+
+// TestInstallWorkspaceContextIdempotent verifies that calling
+// InstallWorkspaceContext twice produces exactly one @workspace-context line in
+// the rules file.
+func TestInstallWorkspaceContextIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	instanceRoot := filepath.Join(tmpDir, "instance")
+	if err := os.MkdirAll(instanceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallWorkspaceContext(minimalCfg(), nil, instanceRoot); err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	if _, err := InstallWorkspaceContext(minimalCfg(), nil, instanceRoot); err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	data, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("reading rules file: %v", err)
+	}
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	count := strings.Count(string(data), "@"+contextPath)
+	if count != 1 {
+		t.Errorf("workspace-context import appears %d times in rules file, want 1:\n%s", count, string(data))
+	}
+}
+
 // TestInstallOverlayClaudeContentPresent verifies that CLAUDE.overlay.md is
-// copied to the instance root and @CLAUDE.overlay.md is injected into CLAUDE.md
-// after @workspace-context.md.
+// copied to the instance root, and the rules file contains both workspace-context
+// and overlay imports. CLAUDE.md must not contain @CLAUDE.overlay.md.
 func TestInstallOverlayClaudeContentPresent(t *testing.T) {
 	tmpDir := t.TempDir()
 	overlayDir := filepath.Join(tmpDir, "overlay")
@@ -26,9 +148,10 @@ func TestInstallOverlayClaudeContentPresent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write a CLAUDE.md with @workspace-context.md already present.
-	claudeContent := "@workspace-context.md\n\n# Workspace\n"
-	if err := os.WriteFile(filepath.Join(instanceRoot, "CLAUDE.md"), []byte(claudeContent), 0o644); err != nil {
+	// Simulate prior workspace-context install by creating the rules file.
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,26 +172,33 @@ func TestInstallOverlayClaudeContentPresent(t *testing.T) {
 		t.Errorf("CLAUDE.overlay.md content = %q, want %q", string(data), overlayContent)
 	}
 
-	// Verify the import was injected.
-	claudeData, err := os.ReadFile(filepath.Join(instanceRoot, "CLAUDE.md"))
+	// Rules file must contain both imports.
+	rulesData, err := os.ReadFile(rulesPath)
 	if err != nil {
-		t.Fatalf("reading CLAUDE.md: %v", err)
+		t.Fatalf("reading rules file: %v", err)
 	}
-	claudeMd := string(claudeData)
-	if !strings.Contains(claudeMd, "@CLAUDE.overlay.md") {
-		t.Errorf("@CLAUDE.overlay.md import not injected: %s", claudeMd)
+	rulesContent := string(rulesData)
+	overlayDestPath := filepath.Join(instanceRoot, overlayClaudeFile)
+	if !strings.Contains(rulesContent, "@"+contextPath) {
+		t.Errorf("rules file missing workspace-context import:\n%s", rulesContent)
 	}
-	// Verify ordering: @workspace-context.md comes before @CLAUDE.overlay.md.
-	wsIdx := strings.Index(claudeMd, "@workspace-context.md")
-	overlayIdx := strings.Index(claudeMd, "@CLAUDE.overlay.md")
-	if wsIdx >= overlayIdx {
-		t.Errorf("@workspace-context.md should appear before @CLAUDE.overlay.md in CLAUDE.md:\n%s", claudeMd)
+	if !strings.Contains(rulesContent, "@"+overlayDestPath) {
+		t.Errorf("rules file missing overlay import:\n%s", rulesContent)
+	}
+
+	// CLAUDE.md must not contain the relative overlay import.
+	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
+	if _, err := os.Stat(claudePath); err == nil {
+		claudeData, _ := os.ReadFile(claudePath)
+		if strings.Contains(string(claudeData), overlayClaudeImport) {
+			t.Errorf("CLAUDE.md should not contain %q:\n%s", overlayClaudeImport, string(claudeData))
+		}
 	}
 }
 
 // TestInstallOverlayClaudeContentAbsent verifies that when CLAUDE.overlay.md
-// does not exist in the overlay clone, the function returns ("", nil) and
-// CLAUDE.md is not modified.
+// does not exist in the overlay clone, the function returns ("", nil) and the
+// rules file is unchanged.
 func TestInstallOverlayClaudeContentAbsent(t *testing.T) {
 	tmpDir := t.TempDir()
 	overlayDir := filepath.Join(tmpDir, "overlay")
@@ -80,10 +210,13 @@ func TestInstallOverlayClaudeContentAbsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	claudeContent := "@workspace-context.md\n\n# Workspace\n"
-	if err := os.WriteFile(filepath.Join(instanceRoot, "CLAUDE.md"), []byte(claudeContent), 0o644); err != nil {
+	// Simulate prior workspace-context install.
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
 		t.Fatal(err)
 	}
+	originalRules, _ := os.ReadFile(rulesPath)
 
 	path, err := InstallOverlayClaudeContent(overlayDir, instanceRoot)
 	if err != nil {
@@ -93,24 +226,23 @@ func TestInstallOverlayClaudeContentAbsent(t *testing.T) {
 		t.Errorf("expected empty path when CLAUDE.overlay.md is absent, got %q", path)
 	}
 
-	// CLAUDE.md should be unchanged.
-	data, err := os.ReadFile(filepath.Join(instanceRoot, "CLAUDE.md"))
+	// Rules file should be unchanged.
+	rulesData, err := os.ReadFile(rulesPath)
 	if err != nil {
-		t.Fatalf("reading CLAUDE.md: %v", err)
+		t.Fatalf("reading rules file: %v", err)
 	}
-	if string(data) != claudeContent {
-		t.Errorf("CLAUDE.md modified unexpectedly: got %q", string(data))
+	if string(rulesData) != string(originalRules) {
+		t.Errorf("rules file modified unexpectedly:\ngot  %q\nwant %q", string(rulesData), string(originalRules))
 	}
 
-	// CLAUDE.overlay.md should not exist.
+	// CLAUDE.overlay.md should not exist in instance root.
 	if _, err := os.Stat(filepath.Join(instanceRoot, "CLAUDE.overlay.md")); err == nil {
 		t.Error("CLAUDE.overlay.md should not exist when absent from overlay")
 	}
 }
 
-// TestInstallOverlayClaudeContentImportOrdering verifies that when both
-// @workspace-context.md and @CLAUDE.global.md are present in CLAUDE.md,
-// @CLAUDE.overlay.md is injected between them.
+// TestInstallOverlayClaudeContentImportOrdering verifies that workspace-context
+// import appears before overlay import in the rules file.
 func TestInstallOverlayClaudeContentImportOrdering(t *testing.T) {
 	tmpDir := t.TempDir()
 	overlayDir := filepath.Join(tmpDir, "overlay")
@@ -126,38 +258,52 @@ func TestInstallOverlayClaudeContentImportOrdering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Simulate CLAUDE.md after both workspace-context and global imports have been added.
-	claudeContent := "@workspace-context.md\n\n@CLAUDE.global.md\n\n# Workspace content\n"
-	if err := os.WriteFile(filepath.Join(instanceRoot, "CLAUDE.md"), []byte(claudeContent), 0o644); err != nil {
+	// Step 1: workspace-context install.
+	if _, err := InstallWorkspaceContext(minimalCfg(), nil, instanceRoot); err != nil {
+		t.Fatalf("InstallWorkspaceContext error: %v", err)
+	}
+
+	// Step 2: overlay install.
+	if _, err := InstallOverlayClaudeContent(overlayDir, instanceRoot); err != nil {
+		t.Fatalf("InstallOverlayClaudeContent error: %v", err)
+	}
+
+	// Step 3: global install.
+	globalDir := filepath.Join(tmpDir, "global")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(globalDir, "CLAUDE.global.md"), []byte("# global\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallGlobalClaudeContent(globalDir, instanceRoot); err != nil {
+		t.Fatalf("InstallGlobalClaudeContent error: %v", err)
+	}
 
-	_, err := InstallOverlayClaudeContent(overlayDir, instanceRoot)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	rulesData, err := os.ReadFile(rulesPath)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("reading rules file: %v", err)
 	}
+	rulesContent := string(rulesData)
 
-	data, err := os.ReadFile(filepath.Join(instanceRoot, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("reading CLAUDE.md: %v", err)
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	overlayDestPath := filepath.Join(instanceRoot, overlayClaudeFile)
+
+	wsIdx := strings.Index(rulesContent, "@"+contextPath)
+	overlayIdx := strings.Index(rulesContent, "@"+overlayDestPath)
+
+	if wsIdx < 0 || overlayIdx < 0 {
+		t.Fatalf("missing expected imports in rules file:\n%s", rulesContent)
 	}
-	claudeMd := string(data)
-
-	wsIdx := strings.Index(claudeMd, "@workspace-context.md")
-	overlayIdx := strings.Index(claudeMd, "@CLAUDE.overlay.md")
-	globalIdx := strings.Index(claudeMd, "@CLAUDE.global.md")
-
-	if wsIdx < 0 || overlayIdx < 0 || globalIdx < 0 {
-		t.Fatalf("missing expected imports in CLAUDE.md:\n%s", claudeMd)
-	}
-	if !(wsIdx < overlayIdx && overlayIdx < globalIdx) {
-		t.Errorf("import ordering incorrect: @workspace-context.md=%d, @CLAUDE.overlay.md=%d, @CLAUDE.global.md=%d\n%s",
-			wsIdx, overlayIdx, globalIdx, claudeMd)
+	if wsIdx >= overlayIdx {
+		t.Errorf("workspace-context import should appear before overlay import in rules file:\n%s", rulesContent)
 	}
 }
 
 // TestInstallOverlayClaudeContentIdempotent verifies that calling
-// InstallOverlayClaudeContent twice does not duplicate the import.
+// InstallOverlayClaudeContent twice produces exactly one overlay import in the
+// rules file.
 func TestInstallOverlayClaudeContentIdempotent(t *testing.T) {
 	tmpDir := t.TempDir()
 	overlayDir := filepath.Join(tmpDir, "overlay")
@@ -172,7 +318,11 @@ func TestInstallOverlayClaudeContentIdempotent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(overlayDir, "CLAUDE.overlay.md"), []byte("# overlay\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(instanceRoot, "CLAUDE.md"), []byte("@workspace-context.md\n\n# Workspace\n"), 0o644); err != nil {
+
+	// Simulate prior workspace-context install.
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
 		t.Fatal(err)
 	}
 
@@ -183,20 +333,57 @@ func TestInstallOverlayClaudeContentIdempotent(t *testing.T) {
 		t.Fatalf("second call error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(instanceRoot, "CLAUDE.md"))
+	rulesData, err := os.ReadFile(rulesPath)
 	if err != nil {
-		t.Fatalf("reading CLAUDE.md: %v", err)
+		t.Fatalf("reading rules file: %v", err)
 	}
-	count := strings.Count(string(data), "@CLAUDE.overlay.md")
+	overlayDestPath := filepath.Join(instanceRoot, overlayClaudeFile)
+	count := strings.Count(string(rulesData), "@"+overlayDestPath)
 	if count != 1 {
-		t.Errorf("@CLAUDE.overlay.md appears %d times, want 1:\n%s", count, string(data))
+		t.Errorf("overlay import appears %d times in rules file, want 1:\n%s", count, string(rulesData))
 	}
 }
 
-// TestInstallGlobalClaudeContentOrderingWithOverlay verifies the three-way
-// import ordering on first apply when overlay is active: workspace-context
-// is injected first, then overlay inserts after it, then global inserts after
-// overlay — producing @workspace-context.md → @CLAUDE.overlay.md → @CLAUDE.global.md.
+// TestInstallOverlayClaudeContentMigratesOldImport verifies that the old
+// relative @CLAUDE.overlay.md import is removed from CLAUDE.md after install.
+func TestInstallOverlayClaudeContentMigratesOldImport(t *testing.T) {
+	tmpDir := t.TempDir()
+	overlayDir := filepath.Join(tmpDir, "overlay")
+	instanceRoot := filepath.Join(tmpDir, "instance")
+	if err := os.MkdirAll(overlayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(instanceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(overlayDir, "CLAUDE.overlay.md"), []byte("# overlay\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate old CLAUDE.md with relative import.
+	oldContent := "@workspace-context.md\n\n@CLAUDE.overlay.md\n\n# Workspace\n"
+	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(oldContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallOverlayClaudeContent(overlayDir, instanceRoot); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("reading CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(claudeData), overlayClaudeImport) {
+		t.Errorf("old relative overlay import still present in CLAUDE.md:\n%s", string(claudeData))
+	}
+}
+
+// TestInstallGlobalClaudeContentOrderingWithOverlay verifies that when
+// workspace-context and overlay imports are already in the rules file, the
+// global import is appended after them in the correct order.
 func TestInstallGlobalClaudeContentOrderingWithOverlay(t *testing.T) {
 	tmpDir := t.TempDir()
 	globalDir := filepath.Join(tmpDir, "global")
@@ -212,11 +399,14 @@ func TestInstallGlobalClaudeContentOrderingWithOverlay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Simulate state after workspace-context and overlay have been injected
-	// (as produced by InstallWorkspaceContext then InstallOverlayClaudeContent
-	// on a fresh apply).
-	claudeContent := "@workspace-context.md\n\n@CLAUDE.overlay.md\n\n# Workspace\n"
-	if err := os.WriteFile(filepath.Join(instanceRoot, "CLAUDE.md"), []byte(claudeContent), 0o644); err != nil {
+	// Simulate state after workspace-context and overlay installs.
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	overlayDestPath := filepath.Join(instanceRoot, overlayClaudeFile)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := appendToWorkspaceRulesFile(rulesPath, overlayDestPath); err != nil {
 		t.Fatal(err)
 	}
 
@@ -224,27 +414,29 @@ func TestInstallGlobalClaudeContentOrderingWithOverlay(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(instanceRoot, "CLAUDE.md"))
+	rulesData, err := os.ReadFile(rulesPath)
 	if err != nil {
-		t.Fatalf("reading CLAUDE.md: %v", err)
+		t.Fatalf("reading rules file: %v", err)
 	}
-	claudeMd := string(data)
+	rulesContent := string(rulesData)
 
-	wsIdx := strings.Index(claudeMd, "@workspace-context.md")
-	overlayIdx := strings.Index(claudeMd, "@CLAUDE.overlay.md")
-	globalIdx := strings.Index(claudeMd, "@CLAUDE.global.md")
+	globalDestPath := filepath.Join(instanceRoot, globalClaudeFile)
+	wsIdx := strings.Index(rulesContent, "@"+contextPath)
+	overlayIdx := strings.Index(rulesContent, "@"+overlayDestPath)
+	globalIdx := strings.Index(rulesContent, "@"+globalDestPath)
 
 	if wsIdx < 0 || overlayIdx < 0 || globalIdx < 0 {
-		t.Fatalf("missing expected imports in CLAUDE.md:\n%s", claudeMd)
+		t.Fatalf("missing expected imports in rules file:\n%s", rulesContent)
 	}
 	if !(wsIdx < overlayIdx && overlayIdx < globalIdx) {
-		t.Errorf("import ordering incorrect: @workspace-context.md=%d, @CLAUDE.overlay.md=%d, @CLAUDE.global.md=%d\n%s",
-			wsIdx, overlayIdx, globalIdx, claudeMd)
+		t.Errorf("import ordering incorrect: workspace=%d, overlay=%d, global=%d\n%s",
+			wsIdx, overlayIdx, globalIdx, rulesContent)
 	}
 }
 
-// TestInstallGlobalClaudeContentOrderingWithoutOverlay verifies that when no
-// overlay is active, global is inserted after @workspace-context.md (not before).
+// TestInstallGlobalClaudeContentOrderingWithoutOverlay verifies that when only
+// the workspace-context import is in the rules file, the global import is
+// appended after it.
 func TestInstallGlobalClaudeContentOrderingWithoutOverlay(t *testing.T) {
 	tmpDir := t.TempDir()
 	globalDir := filepath.Join(tmpDir, "global")
@@ -260,9 +452,10 @@ func TestInstallGlobalClaudeContentOrderingWithoutOverlay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Simulate state after workspace-context has been injected (no overlay).
-	claudeContent := "@workspace-context.md\n\n# Workspace\n"
-	if err := os.WriteFile(filepath.Join(instanceRoot, "CLAUDE.md"), []byte(claudeContent), 0o644); err != nil {
+	// Simulate state after workspace-context install only (no overlay).
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,56 +463,64 @@ func TestInstallGlobalClaudeContentOrderingWithoutOverlay(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(instanceRoot, "CLAUDE.md"))
+	rulesData, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("reading rules file: %v", err)
+	}
+	rulesContent := string(rulesData)
+
+	globalDestPath := filepath.Join(instanceRoot, globalClaudeFile)
+	wsIdx := strings.Index(rulesContent, "@"+contextPath)
+	globalIdx := strings.Index(rulesContent, "@"+globalDestPath)
+
+	if wsIdx < 0 || globalIdx < 0 {
+		t.Fatalf("missing expected imports in rules file:\n%s", rulesContent)
+	}
+	if wsIdx >= globalIdx {
+		t.Errorf("workspace-context import should appear before global import:\n%s", rulesContent)
+	}
+}
+
+// TestInstallGlobalClaudeContentMigratesOldImport verifies that the old
+// relative @CLAUDE.global.md import is removed from CLAUDE.md after install.
+func TestInstallGlobalClaudeContentMigratesOldImport(t *testing.T) {
+	tmpDir := t.TempDir()
+	globalDir := filepath.Join(tmpDir, "global")
+	instanceRoot := filepath.Join(tmpDir, "instance")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(instanceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(globalDir, "CLAUDE.global.md"), []byte("# global\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate old CLAUDE.md with relative global import.
+	oldContent := "@workspace-context.md\n\n@CLAUDE.global.md\n\n# Workspace\n"
+	claudePath := filepath.Join(instanceRoot, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(oldContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also need rules file to exist for appendToWorkspaceRulesFile to work.
+	contextPath := filepath.Join(instanceRoot, workspaceContextFile)
+	rulesPath := filepath.Join(instanceRoot, workspaceRulesFile)
+	if err := writeWorkspaceRulesFile(rulesPath, contextPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallGlobalClaudeContent(globalDir, instanceRoot); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	claudeData, err := os.ReadFile(claudePath)
 	if err != nil {
 		t.Fatalf("reading CLAUDE.md: %v", err)
 	}
-	claudeMd := string(data)
-
-	wsIdx := strings.Index(claudeMd, "@workspace-context.md")
-	globalIdx := strings.Index(claudeMd, "@CLAUDE.global.md")
-
-	if wsIdx < 0 || globalIdx < 0 {
-		t.Fatalf("missing expected imports in CLAUDE.md:\n%s", claudeMd)
-	}
-	if wsIdx >= globalIdx {
-		t.Errorf("@workspace-context.md should appear before @CLAUDE.global.md in CLAUDE.md:\n%s", claudeMd)
-	}
-}
-
-// TestEnsureImportAfterInCLAUDENoAnchor verifies that when the anchor line is
-// absent, the import is prepended.
-func TestEnsureImportAfterInCLAUDENoAnchor(t *testing.T) {
-	tmpDir := t.TempDir()
-	claudePath := filepath.Join(tmpDir, "CLAUDE.md")
-	if err := os.WriteFile(claudePath, []byte("# content\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := ensureImportAfterInCLAUDE(claudePath, "@new-import.md", "@missing-anchor.md"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	data, err := os.ReadFile(claudePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(string(data), "@new-import.md") {
-		t.Errorf("import not prepended: %s", string(data))
-	}
-}
-
-// TestEnsureImportAfterInCLAUDENoCLAUDE verifies that when CLAUDE.md does not
-// exist, the function returns nil without creating the file.
-func TestEnsureImportAfterInCLAUDENoCLAUDE(t *testing.T) {
-	tmpDir := t.TempDir()
-	claudePath := filepath.Join(tmpDir, "NONEXISTENT.md")
-
-	if err := ensureImportAfterInCLAUDE(claudePath, "@foo.md", "@anchor.md"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if _, err := os.Stat(claudePath); err == nil {
-		t.Error("file should not have been created")
+	if strings.Contains(string(claudeData), globalClaudeImport) {
+		t.Errorf("old relative global import still present in CLAUDE.md:\n%s", string(claudeData))
 	}
 }

--- a/test/functional/features/workspace-imports.feature
+++ b/test/functional/features/workspace-imports.feature
@@ -48,7 +48,7 @@ Feature: workspace imports via .claude/rules
       """
     When I run niwa init from config repo "myws"
     Then the exit code is 0
-    When I run "niwa create myws"
+    When I run "niwa create niwatest-xq7749"
     Then the exit code is 0
     And the instance "niwatest-xq7749" exists
     And the repo "tools/myapp" exists in instance "niwatest-xq7749"

--- a/test/functional/features/workspace-imports.feature
+++ b/test/functional/features/workspace-imports.feature
@@ -1,0 +1,66 @@
+Feature: workspace imports via .claude/rules
+  niwa apply writes workspace context @imports to .claude/rules/workspace-imports.md
+  with absolute paths instead of injecting relative @imports into CLAUDE.md.
+  This prevents Claude Code from showing an external-import approval dialog when
+  starting a session from a sub-repo directory.
+
+  @critical
+  Scenario: create writes workspace-imports.md and does not add relative imports to CLAUDE.md
+    Given a clean niwa environment
+    And a local git server is set up
+    And a source repo "myapp" exists
+    And a config repo "myws" exists with body:
+      """
+      [workspace]
+      name = "myws"
+
+      [groups.tools]
+
+      [repos.myapp]
+      url = "{repo:myapp}"
+      group = "tools"
+      """
+    When I run niwa init from config repo "myws"
+    Then the exit code is 0
+    When I run "niwa create myws"
+    Then the exit code is 0
+    And the instance "myws" exists
+    And the file ".claude/rules/workspace-imports.md" exists in instance "myws"
+    And the file ".claude/rules/workspace-imports.md" in instance "myws" contains "workspace-context.md"
+    And the file "CLAUDE.md" in instance "myws" does not contain "@workspace-context.md"
+
+  @claude-integration
+  Scenario: claude sees workspace context from workspace root but not from sub-repo
+    Given a clean niwa environment
+    And claude is available
+    And a local git server is set up
+    And a source repo "myapp" exists
+    And a config repo "myws" exists with body:
+      """
+      [workspace]
+      name = "niwatest-xq7749"
+
+      [groups.tools]
+
+      [repos.myapp]
+      url = "{repo:myapp}"
+      group = "tools"
+      """
+    When I run niwa init from config repo "myws"
+    Then the exit code is 0
+    When I run "niwa create myws"
+    Then the exit code is 0
+    And the instance "niwatest-xq7749" exists
+    And the repo "tools/myapp" exists in instance "niwatest-xq7749"
+    When I run claude -p from instance root "niwatest-xq7749" with prompt:
+      """
+      Do not read any files. Using only your current context, do you know about
+      a workspace named niwatest-xq7749? Answer yes or no only.
+      """
+    Then the output contains "yes"
+    When I run claude -p from repo "tools/myapp" in instance "niwatest-xq7749" with prompt:
+      """
+      Do not read any files. Using only your current context, do you know about
+      a workspace named niwatest-xq7749? Answer yes or no only.
+      """
+    Then the output does not contain "yes"

--- a/test/functional/steps_test.go
+++ b/test/functional/steps_test.go
@@ -961,3 +961,128 @@ func noNiwaTempFilesRemain(ctx context.Context) error {
 	}
 	return fmt.Errorf("expected %s to be empty after wrapped run; found %d leftover(s): %v", s.tmpDir, len(entries), names)
 }
+
+// --- File assertion steps ---
+
+// theFileExistsInInstance verifies that a file exists at relPath within the
+// named instance directory.
+func theFileExistsInInstance(ctx context.Context, relPath, instance string) error {
+	s := getState(ctx)
+	if s == nil {
+		return fmt.Errorf("no test state")
+	}
+	path := filepath.Join(s.workspaceRoot, instance, relPath)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("expected file %q to exist in instance %q", relPath, instance)
+	} else if err != nil {
+		return fmt.Errorf("stat %q: %w", path, err)
+	}
+	return nil
+}
+
+// theFileInInstanceContains verifies that the file at relPath within the named
+// instance contains text.
+func theFileInInstanceContains(ctx context.Context, relPath, instance, text string) error {
+	s := getState(ctx)
+	if s == nil {
+		return fmt.Errorf("no test state")
+	}
+	path := filepath.Join(s.workspaceRoot, instance, relPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %q in instance %q: %w", relPath, instance, err)
+	}
+	if !strings.Contains(string(data), text) {
+		return fmt.Errorf("file %q does not contain %q\ncontent:\n%s", path, text, string(data))
+	}
+	return nil
+}
+
+// theFileInInstanceDoesNotContain verifies the file at relPath does not contain text.
+func theFileInInstanceDoesNotContain(ctx context.Context, relPath, instance, text string) error {
+	s := getState(ctx)
+	if s == nil {
+		return fmt.Errorf("no test state")
+	}
+	path := filepath.Join(s.workspaceRoot, instance, relPath)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil // absent file trivially does not contain the text
+	}
+	if err != nil {
+		return fmt.Errorf("reading %q in instance %q: %w", relPath, instance, err)
+	}
+	if strings.Contains(string(data), text) {
+		return fmt.Errorf("file %q should not contain %q\ncontent:\n%s", path, text, string(data))
+	}
+	return nil
+}
+
+// --- Claude integration steps ---
+
+// claudeIsAvailable checks that the claude CLI and ANTHROPIC_API_KEY are
+// available. Returns godog.ErrPending to skip the scenario when either is absent.
+func claudeIsAvailable(ctx context.Context) (context.Context, error) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return ctx, godog.ErrPending
+	}
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		return ctx, godog.ErrPending
+	}
+	return ctx, nil
+}
+
+// iRunClaudePFromInstanceRoot runs claude -p with the given prompt from the
+// named instance's workspace root and records output into state.
+func iRunClaudePFromInstanceRoot(ctx context.Context, instance string, prompt *godog.DocString) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	cwd := filepath.Join(s.workspaceRoot, instance)
+	return ctx, runClaudeP(s, cwd, strings.TrimSpace(prompt.Content))
+}
+
+// iRunClaudePFromRepoInInstance runs claude -p with the given prompt from
+// groupRepo (e.g. "tools/myapp") inside the named instance.
+func iRunClaudePFromRepoInInstance(ctx context.Context, groupRepo, instance string, prompt *godog.DocString) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	cwd := filepath.Join(s.workspaceRoot, instance, groupRepo)
+	return ctx, runClaudeP(s, cwd, strings.TrimSpace(prompt.Content))
+}
+
+// runClaudeP executes claude -p <prompt> in cwd with a sandboxed environment.
+// stdout is stored lowercased so callers can assert "yes"/"no" without caring
+// about capitalisation. Returns godog.ErrPending if claude is not on PATH.
+func runClaudeP(s *testState, cwd, prompt string) error {
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		return godog.ErrPending
+	}
+	env := s.buildEnv()
+	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
+		env = append(env, "ANTHROPIC_API_KEY="+key)
+	}
+	cmd := exec.Command(claudeBin, "-p", prompt)
+	cmd.Dir = cwd
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	s.stdout = strings.ToLower(stdout.String())
+	s.stderr = stderr.String()
+	s.shellPwd = ""
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			s.exitCode = exitErr.ExitCode()
+			return nil
+		}
+		return fmt.Errorf("claude -p failed: %w\nstderr: %s", runErr, s.stderr)
+	}
+	s.exitCode = 0
+	return nil
+}

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -190,4 +190,14 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 	ctx.Step(`^the completion output contains "([^"]*)"$`, theCompletionOutputContains)
 	ctx.Step(`^the completion output does not contain "([^"]*)"$`, theCompletionOutputDoesNotContain)
 	ctx.Step(`^the completion description for "([^"]*)" is "([^"]*)"$`, theCompletionDescriptionMatches)
+
+	// File assertions
+	ctx.Step(`^the file "([^"]*)" exists in instance "([^"]*)"$`, theFileExistsInInstance)
+	ctx.Step(`^the file "([^"]*)" in instance "([^"]*)" contains "([^"]*)"$`, theFileInInstanceContains)
+	ctx.Step(`^the file "([^"]*)" in instance "([^"]*)" does not contain "([^"]*)"$`, theFileInInstanceDoesNotContain)
+
+	// Claude integration
+	ctx.Step(`^claude is available$`, claudeIsAvailable)
+	ctx.Step(`^I run claude -p from instance root "([^"]*)" with prompt:$`, iRunClaudePFromInstanceRoot)
+	ctx.Step(`^I run claude -p from repo "([^"]*)" in instance "([^"]*)" with prompt:$`, iRunClaudePFromRepoInInstance)
 }


### PR DESCRIPTION
The three workspace install functions (`InstallWorkspaceContext`, `InstallOverlayClaudeContent`, `InstallGlobalClaudeContent`) now write absolute @imports to `.claude/rules/workspace-imports.md` instead of injecting relative @import lines into the workspace root's `CLAUDE.md`. `InstallWorkspaceContext` creates the rules file fresh on each apply; the other two append to it. All three also strip any old relative imports from `CLAUDE.md`, migrating existing workspaces on next apply.

---

## What This Fixes

When niwa applied workspace context, overlay, and global imports as relative `@import` lines in the workspace root's `CLAUDE.md`, Claude Code triggered an "Allow external CLAUDE.md file imports?" dialog on every session started from a sub-repo directory. This happened because Claude Code reads `CLAUDE.md` hierarchically from parent directories, resolving `@workspace-context.md` relative to the file's own location (the workspace root) — making those files appear external to the sub-repo's working directory.

`@`-imports inside `.claude/rules/` files behave differently: when the referenced file is outside the current working directory, they are silently skipped with no prompt. Using absolute paths in the rules file ensures the imports load normally from the workspace root while being quietly ignored from sub-repos.

## Changes

- `internal/workspace/workspace_context.go`: Replace `ensureImportInCLAUDE` / `ensureImportAfterInCLAUDE` with `writeWorkspaceRulesFile`, `appendToWorkspaceRulesFile`, and `removeImportFromCLAUDE`; update the three `Install*` functions accordingly
- `internal/workspace/workspace_context_test.go`: Rewrite tests to verify rules file creation, idempotency, import ordering, and CLAUDE.md migration for all three install functions

## Test Plan

- [x] `go test ./internal/workspace/... -run TestInstall` — 12 tests pass
- [x] `go build ./...` — clean build
- [ ] Manual: run `niwa apply` on an existing workspace; confirm `.claude/rules/workspace-imports.md` is created with absolute paths, old `@import` lines are removed from `CLAUDE.md`, and starting Claude from a sub-repo no longer shows the external imports dialog