### PR TITLE
fix(channels): write .mcp.json at instance root with coordinator role

### DIFF
--- a/docs/designs/current/DESIGN-cross-session-communication.md
+++ b/docs/designs/current/DESIGN-cross-session-communication.md
@@ -349,7 +349,7 @@ Key assumptions: Claude Code inherits env from the parent `claude -p` process in
 
 #### Chosen: Per-session stdio MCP server + filesystem coordination + env-var task identity + state.json authorization
 
-The MCP server remains a stdio subprocess spawned per Claude session by Claude Code from `.claude/.mcp.json`. Same for coordinators, peer sessions, and ephemeral workers. No per-instance daemon-hosted MCP server; no Unix-socket relay.
+The MCP server remains a stdio subprocess spawned per Claude session by Claude Code from `.mcp.json`. Same for coordinators, peer sessions, and ephemeral workers. No per-instance daemon-hosted MCP server; no Unix-socket relay.
 
 Coordination between MCP server instances and the daemon is filesystem-only. The daemon writes per-task state (Decision 1); MCP tool calls read it under shared flock. The existing fsnotify `notifyNewFile` pathway is extended to route `task.completed`, `task.abandoned`, `task.cancelled` messages to a new `awaitWaiters map[string]chan taskEvent` (keyed by `task_id`) for `niwa_await_task` and synchronous `niwa_delegate`.
 
@@ -384,7 +384,7 @@ The MCP server reads these once on startup into `Server.{instanceRoot, role, tas
 
 The daemon spawns `claude -p` for each queued task. The contract must pass the task ID to the worker (for inbox retrieval by the LLM and for auth by the MCP subprocess), fix argv so tests can assert on it, and accommodate the `NIWA_WORKER_SPAWN_COMMAND` override (R51) for scripted-fake testing.
 
-Key assumptions: MCP server runs per-worker as a stdio subprocess launched by Claude Code from `.claude/.mcp.json` (Decision 3 confirmed); `claude -p` tolerates R33's flags alongside `-p <prompt>`; Go's `exec.Cmd.Env` last-wins semantics for duplicate keys.
+Key assumptions: MCP server runs per-worker as a stdio subprocess launched by Claude Code from `.mcp.json` (Decision 3 confirmed); `claude -p` tolerates R33's flags alongside `-p <prompt>`; Go's `exec.Cmd.Env` last-wins semantics for duplicate keys.
 
 #### Chosen: Literal-path override + dual task-ID propagation (argv + env) + pass-through env with niwa-owned last-wins overrides
 
@@ -395,7 +395,7 @@ Key assumptions: MCP server runs per-worker as a stdio subprocess launched by Cl
 ```
 claude -p "You are a worker for niwa task <task-id>. Call niwa_check_messages to retrieve your task envelope."
         --permission-mode=acceptEdits
-        --mcp-config=<instanceRoot>/.claude/.mcp.json
+        --mcp-config=<instanceRoot>/.mcp.json
         --strict-mcp-config
 ```
 
@@ -549,7 +549,7 @@ A ~40-60 LOC migration helper runs at the top of the rewritten `InstallChannelIn
 1. **Detect old layout.** If `.niwa/sessions/` contains any `<uuid>/` subdirectory (old layout signature) and `.niwa/roles/` is absent (new layout signature): treat as pre-1.0 upgrade.
 2. **One-shot warning.** Log to stderr: `"niwa: upgrading mesh layout. Discarding N queued envelopes from the previous mesh version; any in-flight conversations are abandoned. Run 'niwa destroy && niwa create --channels' for a fresh start. See docs/guides/cross-session-communication.md for details."`
 3. **Cleanup.** Recursively remove `.niwa/sessions/<uuid>/` directories. Leave `.niwa/sessions/sessions.json` in place (coordinator registry survives; registered coordinators re-register on next SessionStart hook).
-4. **Provision the new layout.** Create `.niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/` for every enumerated role; create `.niwa/tasks/`; write `.claude/.mcp.json` at instance and per-repo; install the `niwa-mesh` skill (Decision 5); write the minimal `## Channels` section; inject `SessionStart` + `UserPromptSubmit` hooks via the existing `HooksMaterializer` pipeline.
+4. **Provision the new layout.** Create `.niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/` for every enumerated role; create `.niwa/tasks/`; write `.mcp.json` at instance and per-repo; install the `niwa-mesh` skill (Decision 5); write the minimal `## Channels` section; inject `SessionStart` + `UserPromptSubmit` hooks via the existing `HooksMaterializer` pipeline.
 5. **ManagedFiles discipline.** Every installer-written file goes into `InstanceState.ManagedFiles` so `niwa destroy` cleans up uniformly. Runtime artifacts (`.niwa/tasks/<id>/*`, `.niwa/roles/*/inbox/<id>.json`) are NOT tracked — they are created by the daemon and the MCP tool handlers.
 
 **Idempotency (AC-P10).** A second `niwa apply` on the new layout: installer computes ContentHash on skill files → matches → skip write; checks `.mcp.json` presence and content → matches → skip; role inboxes present → skip; `sessions.json` preserved; in-progress envelopes byte-identical; per-task state files untouched.
@@ -598,7 +598,9 @@ niwa apply
        - migration helper (detect + remove old .niwa/sessions/<uuid>/)
        - create .niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/
        - create .niwa/tasks/
-       - write <instanceRoot>/.claude/.mcp.json and <repoDir>/.claude/.mcp.json
+       - write <instanceRoot>/.mcp.json (no per-repo mirror; the
+         instance-root file is discovered from sub-repos via Claude
+         Code's directory-tree walk-up)
        - install niwa-mesh skill to <instanceRoot>/.claude/skills/niwa-mesh/
          and each <repoDir>/.claude/skills/niwa-mesh/ (sha256 idempotent)
        - write minimal ## Channels section to workspace-context.md
@@ -962,7 +964,7 @@ Deliverables:
   - Migration helper: detect + remove `.niwa/sessions/<uuid>/` directories; emit one-shot stderr warning; preserve `sessions.json`.
   - Create `.niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/` for every role.
   - Create `.niwa/tasks/`, `.niwa/daemon.pid` placeholder (empty).
-  - Write `<instanceRoot>/.claude/.mcp.json`; mirror into each `<repoDir>/.claude/.mcp.json`.
+  - Write `<instanceRoot>/.mcp.json` at the directory root (not under `.claude/`) so Claude Code's MCP discovery resolves it from the instance root and from any sub-repo via upward walk; no per-repo mirror is needed or written.
   - Write `niwa-mesh/SKILL.md` to instance-root and per-repo; sha256 hash check vs `InstanceState.ManagedFiles.ContentHash` for idempotency; drift warning on mismatch; overwrite.
   - Write minimal `## Channels` section to `workspace-context.md`.
   - Inject SessionStart + UserPromptSubmit hook entries into `cfg.Claude.Hooks` for the coordinator role only (workers do not use these hooks).

--- a/docs/designs/current/DESIGN-cross-session-communication.md
+++ b/docs/designs/current/DESIGN-cross-session-communication.md
@@ -598,12 +598,13 @@ niwa apply
        - migration helper (detect + remove old .niwa/sessions/<uuid>/)
        - create .niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/
        - create .niwa/tasks/
-       - write `.mcp.json` at every directory a coordinator might
-         launch Claude in: <instanceRoot>/.mcp.json and
-         <repoDir>/.mcp.json for every cloned repo (Claude Code reads
-         <cwd>/.mcp.json and does not walk parents); append .mcp.json
-         to each repo's .git/info/exclude so the per-repo copy stays
-         out of upstream history
+       - write <instanceRoot>/.mcp.json (Claude Code reads <cwd>/.mcp.json
+         and does not walk parents; the instance root covers the PRD's
+         headline "open Claude at the instance root" scenario; sub-repo
+         cwd launches are out-of-spec and reachable with explicit
+         --mcp-config; per-repo .mcp.json files are intentionally not
+         written to avoid colliding with projects that ship their own
+         MCP config — see issue #78)
        - install niwa-mesh skill to <instanceRoot>/.claude/skills/niwa-mesh/
          and each <repoDir>/.claude/skills/niwa-mesh/ (sha256 idempotent)
        - write minimal ## Channels section to workspace-context.md
@@ -967,7 +968,7 @@ Deliverables:
   - Migration helper: detect + remove `.niwa/sessions/<uuid>/` directories; emit one-shot stderr warning; preserve `sessions.json`.
   - Create `.niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/` for every role.
   - Create `.niwa/tasks/`, `.niwa/daemon.pid` placeholder (empty).
-  - Write `.mcp.json` at the directory root (not under `.claude/`) of every directory a coordinator might launch Claude in: `<instanceRoot>/.mcp.json` and `<repoDir>/.mcp.json` for every cloned repo. Claude Code's MCP discovery loads the project-scoped config from `<cwd>/.mcp.json` and does not walk parent directories. Append `.mcp.json` to each repo's `.git/info/exclude` so the per-repo copy (which carries absolute paths) does not get committed upstream.
+  - Write `<instanceRoot>/.mcp.json` at the directory root (not under `.claude/`). Claude Code's MCP discovery loads `<cwd>/.mcp.json` and does not walk parent directories. The PRD's headline scenario "open one Claude at the instance root and ask it to delegate" is covered. Per-repo `.mcp.json` files are intentionally not written: a file at `<repoDir>/.mcp.json` would either collide destructively with any project shipping its own MCP config or require merging absolute machine-specific paths into a tracked file. Sub-repo launches are an out-of-spec entry point reachable with explicit `--mcp-config`. See issue #78.
   - Write `niwa-mesh/SKILL.md` to instance-root and per-repo; sha256 hash check vs `InstanceState.ManagedFiles.ContentHash` for idempotency; drift warning on mismatch; overwrite.
   - Write minimal `## Channels` section to `workspace-context.md`.
   - Inject SessionStart + UserPromptSubmit hook entries into `cfg.Claude.Hooks` for the coordinator role only (workers do not use these hooks).

--- a/docs/designs/current/DESIGN-cross-session-communication.md
+++ b/docs/designs/current/DESIGN-cross-session-communication.md
@@ -598,9 +598,12 @@ niwa apply
        - migration helper (detect + remove old .niwa/sessions/<uuid>/)
        - create .niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/
        - create .niwa/tasks/
-       - write <instanceRoot>/.mcp.json (no per-repo mirror; the
-         instance-root file is discovered from sub-repos via Claude
-         Code's directory-tree walk-up)
+       - write `.mcp.json` at every directory a coordinator might
+         launch Claude in: <instanceRoot>/.mcp.json and
+         <repoDir>/.mcp.json for every cloned repo (Claude Code reads
+         <cwd>/.mcp.json and does not walk parents); append .mcp.json
+         to each repo's .git/info/exclude so the per-repo copy stays
+         out of upstream history
        - install niwa-mesh skill to <instanceRoot>/.claude/skills/niwa-mesh/
          and each <repoDir>/.claude/skills/niwa-mesh/ (sha256 idempotent)
        - write minimal ## Channels section to workspace-context.md
@@ -964,7 +967,7 @@ Deliverables:
   - Migration helper: detect + remove `.niwa/sessions/<uuid>/` directories; emit one-shot stderr warning; preserve `sessions.json`.
   - Create `.niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/` for every role.
   - Create `.niwa/tasks/`, `.niwa/daemon.pid` placeholder (empty).
-  - Write `<instanceRoot>/.mcp.json` at the directory root (not under `.claude/`) so Claude Code's MCP discovery resolves it from the instance root and from any sub-repo via upward walk; no per-repo mirror is needed or written.
+  - Write `.mcp.json` at the directory root (not under `.claude/`) of every directory a coordinator might launch Claude in: `<instanceRoot>/.mcp.json` and `<repoDir>/.mcp.json` for every cloned repo. Claude Code's MCP discovery loads the project-scoped config from `<cwd>/.mcp.json` and does not walk parent directories. Append `.mcp.json` to each repo's `.git/info/exclude` so the per-repo copy (which carries absolute paths) does not get committed upstream.
   - Write `niwa-mesh/SKILL.md` to instance-root and per-repo; sha256 hash check vs `InstanceState.ManagedFiles.ContentHash` for idempotency; drift warning on mismatch; overwrite.
   - Write minimal `## Channels` section to `workspace-context.md`.
   - Inject SessionStart + UserPromptSubmit hook entries into `cfg.Claude.Hooks` for the coordinator role only (workers do not use these hooks).

--- a/docs/guides/cross-session-communication.md
+++ b/docs/guides/cross-session-communication.md
@@ -277,7 +277,7 @@ persistent session registry.
   INFO. The daemon reuses that absolute path for every spawn — `PATH` changes
   after startup have no effect.
 - **Argv.** Fixed shape: `-p "<bootstrap prompt with <task-id>>"
-  --permission-mode=acceptEdits --mcp-config=<instanceRoot>/.claude/.mcp.json
+  --permission-mode=acceptEdits --mcp-config=<instanceRoot>/.mcp.json
   --strict-mcp-config`. The bootstrap prompt references the task ID; the task
   body never appears in argv — the worker retrieves it via
   `niwa_check_messages` on its first tool call.

--- a/docs/guides/cross-session-communication.md
+++ b/docs/guides/cross-session-communication.md
@@ -20,7 +20,11 @@ Enable the mesh for an instance and delegate a task:
 niwa create my-workspace --channels
 cd my-workspace
 
-# Open a coordinator session.
+# Open a coordinator session. Launch Claude from the instance root
+# (the workspace directory above); that is where niwa writes `.mcp.json`,
+# and Claude Code's MCP discovery loads `<cwd>/.mcp.json` only — it does
+# not walk parent directories. Sub-repo cwds work too if you pass the
+# config path explicitly: `claude --mcp-config=<instance>/.mcp.json`.
 claude
 ```
 

--- a/docs/guides/cross-session-communication.md
+++ b/docs/guides/cross-session-communication.md
@@ -398,9 +398,11 @@ Pre-1.0 queued envelopes are not carried forward — the wire format changed.
 
 Killing workers first minimizes the window during which an
 `acceptEdits`-enabled worker could still write to the filesystem while the
-instance is being torn down. If you use `rm -rf` on an instance directory, the
-daemon detects the missing watch path via fsnotify and exits on its own — but
-unclean, and workers may outlive the daemon by seconds.
+instance is being torn down. **Always use `niwa destroy` to tear down a
+channeled instance.** `rm -rf` of the instance directory does not signal
+the daemon — it keeps running, holding fsnotify watches against a now-
+missing path, and you'll need `pgrep -af "niwa.*mesh watch"` plus a manual
+`kill` to clean it up. Tracking proper teardown semantics is in issue #75.
 
 ### Coordinator restart
 

--- a/docs/prds/PRD-cross-session-communication.md
+++ b/docs/prds/PRD-cross-session-communication.md
@@ -175,15 +175,20 @@ drift detection and `niwa destroy` work uniformly.
 after repository clones are complete and before per-repo materializers. It
 shall be invoked imperatively from `Applier.runPipeline`.
 
-**R4** — The channel installer shall write `<instanceRoot>/.mcp.json`
-declaring a `niwa` MCP server entry that invokes `niwa mcp-serve` with
-`NIWA_INSTANCE_ROOT` baked in. The file lives at the directory root (not
-under `.claude/`) so Claude Code's MCP discovery, which reads
-`<cwd>/.mcp.json` and walks the directory tree upward, finds it both when
-a session is launched at the instance root and when it is launched from
-any sub-repo. No per-repo mirror is written: the upward walk makes one
-copy sufficient, and a per-repo `.mcp.json` would commit the local binary
-path and instance root into upstream history.
+**R4** — The channel installer shall write a project-scoped `.mcp.json`
+at the directory root of every directory a coordinator might launch
+Claude in: `<instanceRoot>/.mcp.json` and `<repoDir>/.mcp.json` for every
+cloned repo. Each file declares a `niwa` MCP server entry that invokes
+`niwa mcp-serve` with `NIWA_INSTANCE_ROOT` baked in. The file lives at
+the directory root (not under `.claude/`) because Claude Code's MCP
+discovery loads the project-scoped config from `<cwd>/.mcp.json` only —
+it does not walk parent directories to find one (per
+https://code.claude.com/docs/en/mcp). A user who launches Claude at the
+instance root reads `<instanceRoot>/.mcp.json`; a user who launches
+inside a cloned repo reads `<repoDir>/.mcp.json`. The per-repo file
+carries machine-specific absolute paths (the niwa binary path and
+`NIWA_INSTANCE_ROOT`); the installer shall add `.mcp.json` to each
+repo's `.git/info/exclude` so the file does not get committed upstream.
 
 **R5** — The channel installer shall enumerate the full set of roles from
 `workspace.toml` (explicit `[channels.mesh.roles]` entries) and the cloned
@@ -665,10 +670,11 @@ live `claude -p` is not required to verify correctness.
 - [ ] **AC-P5** After apply on a channeled workspace, `.niwa/tasks/` exists,
   `.niwa/sessions/sessions.json` exists and is empty, and
   `.niwa/daemon.pid` contains the PID of a live process.
-- [ ] **AC-P6** `<instanceRoot>/.mcp.json` exists and contains a `niwa`
-  entry pointing to `niwa mcp-serve`. No per-repo mirror is written —
-  Claude Code's directory-tree walk-up makes the instance-root file
-  visible from sub-repo cwds.
+- [ ] **AC-P6** `<instanceRoot>/.mcp.json` and `<repoDir>/.mcp.json`
+  both exist for every cloned repo, each containing a `niwa` entry
+  pointing to `niwa mcp-serve`, each at the directory root (not under
+  `.claude/`). Each cloned repo's `.git/info/exclude` lists `.mcp.json`
+  so the per-repo copy is hidden from `git status`.
 - [ ] **AC-P7** `<instanceRoot>/.claude/skills/niwa-mesh/SKILL.md` exists
   after apply, and the same file exists at
   `<repoDir>/.claude/skills/niwa-mesh/SKILL.md` for every cloned repo.

--- a/docs/prds/PRD-cross-session-communication.md
+++ b/docs/prds/PRD-cross-session-communication.md
@@ -175,20 +175,21 @@ drift detection and `niwa destroy` work uniformly.
 after repository clones are complete and before per-repo materializers. It
 shall be invoked imperatively from `Applier.runPipeline`.
 
-**R4** — The channel installer shall write a project-scoped `.mcp.json`
-at the directory root of every directory a coordinator might launch
-Claude in: `<instanceRoot>/.mcp.json` and `<repoDir>/.mcp.json` for every
-cloned repo. Each file declares a `niwa` MCP server entry that invokes
-`niwa mcp-serve` with `NIWA_INSTANCE_ROOT` baked in. The file lives at
-the directory root (not under `.claude/`) because Claude Code's MCP
-discovery loads the project-scoped config from `<cwd>/.mcp.json` only —
-it does not walk parent directories to find one (per
-https://code.claude.com/docs/en/mcp). A user who launches Claude at the
-instance root reads `<instanceRoot>/.mcp.json`; a user who launches
-inside a cloned repo reads `<repoDir>/.mcp.json`. The per-repo file
-carries machine-specific absolute paths (the niwa binary path and
-`NIWA_INSTANCE_ROOT`); the installer shall add `.mcp.json` to each
-repo's `.git/info/exclude` so the file does not get committed upstream.
+**R4** — The channel installer shall write a project-scoped
+`<instanceRoot>/.mcp.json` declaring a `niwa` MCP server entry that
+invokes `niwa mcp-serve` with `NIWA_INSTANCE_ROOT` baked in. The file
+lives at the directory root (not under `.claude/`) because Claude
+Code's MCP discovery loads the project-scoped config from
+`<cwd>/.mcp.json` only — it does not walk parent directories (per
+https://code.claude.com/docs/en/mcp). The headline scenario "open one
+Claude at the instance root and ask it to delegate" is therefore
+covered. The installer shall NOT write per-repo `.mcp.json` files: a
+file at `<repoDir>/.mcp.json` would either collide destructively with
+any project that ships its own MCP config or require merging absolute
+machine-specific paths into a tracked file. Users who want to launch
+Claude in a sub-repo cwd (an out-of-spec entry point) can pass
+`--mcp-config=<instanceRoot>/.mcp.json` explicitly. See issue #78 for
+the longer-term strategy review.
 
 **R5** — The channel installer shall enumerate the full set of roles from
 `workspace.toml` (explicit `[channels.mesh.roles]` entries) and the cloned
@@ -670,11 +671,11 @@ live `claude -p` is not required to verify correctness.
 - [ ] **AC-P5** After apply on a channeled workspace, `.niwa/tasks/` exists,
   `.niwa/sessions/sessions.json` exists and is empty, and
   `.niwa/daemon.pid` contains the PID of a live process.
-- [ ] **AC-P6** `<instanceRoot>/.mcp.json` and `<repoDir>/.mcp.json`
-  both exist for every cloned repo, each containing a `niwa` entry
-  pointing to `niwa mcp-serve`, each at the directory root (not under
-  `.claude/`). Each cloned repo's `.git/info/exclude` lists `.mcp.json`
-  so the per-repo copy is hidden from `git status`.
+- [ ] **AC-P6** `<instanceRoot>/.mcp.json` exists at the instance root
+  (not under `.claude/`) and contains a `niwa` entry pointing to
+  `niwa mcp-serve`. No per-repo `.mcp.json` is written, at either
+  `<repoDir>/.mcp.json` or `<repoDir>/.claude/.mcp.json`, so niwa
+  cannot collide with a project that ships its own MCP config.
 - [ ] **AC-P7** `<instanceRoot>/.claude/skills/niwa-mesh/SKILL.md` exists
   after apply, and the same file exists at
   `<repoDir>/.claude/skills/niwa-mesh/SKILL.md` for every cloned repo.

--- a/docs/prds/PRD-cross-session-communication.md
+++ b/docs/prds/PRD-cross-session-communication.md
@@ -175,11 +175,15 @@ drift detection and `niwa destroy` work uniformly.
 after repository clones are complete and before per-repo materializers. It
 shall be invoked imperatively from `Applier.runPipeline`.
 
-**R4** — The channel installer shall write `<instanceRoot>/.claude/.mcp.json`
+**R4** — The channel installer shall write `<instanceRoot>/.mcp.json`
 declaring a `niwa` MCP server entry that invokes `niwa mcp-serve` with
-`NIWA_INSTANCE_ROOT` baked in. The installer shall mirror the `.mcp.json`
-into each repository's `.claude/` directory so that Claude sessions opened
-inside a repo pick up the same MCP server.
+`NIWA_INSTANCE_ROOT` baked in. The file lives at the directory root (not
+under `.claude/`) so Claude Code's MCP discovery, which reads
+`<cwd>/.mcp.json` and walks the directory tree upward, finds it both when
+a session is launched at the instance root and when it is launched from
+any sub-repo. No per-repo mirror is written: the upward walk makes one
+copy sufficient, and a per-repo `.mcp.json` would commit the local binary
+path and instance root into upstream history.
 
 **R5** — The channel installer shall enumerate the full set of roles from
 `workspace.toml` (explicit `[channels.mesh.roles]` entries) and the cloned
@@ -481,7 +485,7 @@ bootstrap prompt shall not contain the task body.
   the instance root for the coordinator role);
 - `--permission-mode=acceptEdits` (so background workers do not block on
   permission prompts);
-- `--mcp-config=<instanceRoot>/.claude/.mcp.json --strict-mcp-config` (so
+- `--mcp-config=<instanceRoot>/.mcp.json --strict-mcp-config` (so
   the worker has deterministic MCP access regardless of user-level
   config).
 
@@ -661,9 +665,10 @@ live `claude -p` is not required to verify correctness.
 - [ ] **AC-P5** After apply on a channeled workspace, `.niwa/tasks/` exists,
   `.niwa/sessions/sessions.json` exists and is empty, and
   `.niwa/daemon.pid` contains the PID of a live process.
-- [ ] **AC-P6** `<instanceRoot>/.claude/.mcp.json` and
-  `<repoDir>/.claude/.mcp.json` both exist for every cloned repo, each
-  containing a `niwa` entry pointing to `niwa mcp-serve`.
+- [ ] **AC-P6** `<instanceRoot>/.mcp.json` exists and contains a `niwa`
+  entry pointing to `niwa mcp-serve`. No per-repo mirror is written —
+  Claude Code's directory-tree walk-up makes the instance-root file
+  visible from sub-repo cwds.
 - [ ] **AC-P7** `<instanceRoot>/.claude/skills/niwa-mesh/SKILL.md` exists
   after apply, and the same file exists at
   `<repoDir>/.claude/skills/niwa-mesh/SKILL.md` for every cloned repo.
@@ -737,7 +742,7 @@ live `claude -p` is not required to verify correctness.
   hook, not by wall-clock bound).
 - [ ] **AC-D4** The daemon spawns `claude -p` with working directory
   set to the role's repo directory, `--permission-mode=acceptEdits`,
-  `--mcp-config=<instanceRoot>/.claude/.mcp.json`, and
+  `--mcp-config=<instanceRoot>/.mcp.json`, and
   `--strict-mcp-config` (verified via the test spawn hook's captured
   argv and env).
 - [ ] **AC-D5** The spawn prompt argv does not contain any field from
@@ -1197,7 +1202,7 @@ ever existed; the daemon spawns one to consume it.
 
 A background worker cannot answer permission prompts, so `claude -p` is
 spawned with `--permission-mode=acceptEdits`. Workers use
-`--mcp-config=<instanceRoot>/.claude/.mcp.json --strict-mcp-config` to
+`--mcp-config=<instanceRoot>/.mcp.json --strict-mcp-config` to
 guarantee the niwa MCP server is present and no user-level MCP servers
 leak into the worker. Without these flags, workers hang on first write
 or see an indeterminate MCP tool set.

--- a/internal/cli/mesh_watch.go
+++ b/internal/cli/mesh_watch.go
@@ -831,7 +831,7 @@ func handleInboxEvent(evt inboxEvent, s spawnContext) {
 // pipeline intentionally does not cover this case.
 func spawnWorker(evt inboxEvent, taskDir string, s spawnContext) {
 	prompt := fmt.Sprintf(bootstrapPromptTemplate, evt.taskID)
-	mcpConfigPath := filepath.Join(s.instanceRoot, ".claude", ".mcp.json")
+	mcpConfigPath := filepath.Join(s.instanceRoot, ".mcp.json")
 
 	// --permission-mode=acceptEdits auto-approves file edits but does NOT
 	// auto-approve MCP tool calls; a worker running in headless `-p` mode

--- a/internal/cli/mesh_watch.go
+++ b/internal/cli/mesh_watch.go
@@ -47,6 +47,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"github.com/tsukumogami/niwa/internal/mcp"
+	"github.com/tsukumogami/niwa/internal/workspace"
 )
 
 var meshWatchInstanceRoot string
@@ -831,7 +832,7 @@ func handleInboxEvent(evt inboxEvent, s spawnContext) {
 // pipeline intentionally does not cover this case.
 func spawnWorker(evt inboxEvent, taskDir string, s spawnContext) {
 	prompt := fmt.Sprintf(bootstrapPromptTemplate, evt.taskID)
-	mcpConfigPath := filepath.Join(s.instanceRoot, ".mcp.json")
+	mcpConfigPath := workspace.InstanceMCPConfigPath(s.instanceRoot)
 
 	// --permission-mode=acceptEdits auto-approves file edits but does NOT
 	// auto-approve MCP tool calls; a worker running in headless `-p` mode
@@ -841,6 +842,14 @@ func spawnWorker(evt inboxEvent, taskDir string, s spawnContext) {
 	// without prompting. The list must stay in sync with the MCP server's
 	// tools/list response (internal/mcp/server.go) and the niwa-mesh skill
 	// allowed-tools block (internal/workspace/channels.go).
+	//
+	// --strict-mcp-config disables Claude Code's MCP discovery so the
+	// worker only sees the niwa server we point it at via --mcp-config —
+	// never a server the user has registered globally in ~/.claude.json.
+	// This isolation is intentional for workers; do NOT copy this flag
+	// onto a coordinator launcher (human-launched at the instance root)
+	// because coordinators rely on Claude Code discovering
+	// <instance>/.mcp.json automatically.
 	cmd := exec.Command(
 		s.spawnBin,
 		"-p", prompt,

--- a/internal/cli/mesh_watch_test.go
+++ b/internal/cli/mesh_watch_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/tsukumogami/niwa/internal/mcp"
+	"github.com/tsukumogami/niwa/internal/workspace"
 )
 
 // ---------------------------------------------------------------------
@@ -334,7 +335,7 @@ func TestParseDurationList(t *testing.T) {
 // the production argument-shape logic.
 func buildSpawnCommand(instanceRoot, role, taskID, spawnBin string) *exec.Cmd {
 	prompt := "You are a worker for niwa task " + taskID + ". Call niwa_check_messages to retrieve your task envelope."
-	mcpConfigPath := filepath.Join(instanceRoot, ".mcp.json")
+	mcpConfigPath := workspace.InstanceMCPConfigPath(instanceRoot)
 	cmd := exec.Command(
 		spawnBin,
 		"-p", prompt,
@@ -376,7 +377,7 @@ func TestSpawnArgvShape_FixedShape(t *testing.T) {
 	if args[3] != "--permission-mode=acceptEdits" {
 		t.Errorf("argv[3] = %q, want --permission-mode=acceptEdits", args[3])
 	}
-	wantMCP := "--mcp-config=" + filepath.Join(root, ".mcp.json")
+	wantMCP := "--mcp-config=" + workspace.InstanceMCPConfigPath(root)
 	if args[4] != wantMCP {
 		t.Errorf("argv[4] = %q, want %q", args[4], wantMCP)
 	}

--- a/internal/cli/mesh_watch_test.go
+++ b/internal/cli/mesh_watch_test.go
@@ -334,7 +334,7 @@ func TestParseDurationList(t *testing.T) {
 // the production argument-shape logic.
 func buildSpawnCommand(instanceRoot, role, taskID, spawnBin string) *exec.Cmd {
 	prompt := "You are a worker for niwa task " + taskID + ". Call niwa_check_messages to retrieve your task envelope."
-	mcpConfigPath := filepath.Join(instanceRoot, ".claude", ".mcp.json")
+	mcpConfigPath := filepath.Join(instanceRoot, ".mcp.json")
 	cmd := exec.Command(
 		spawnBin,
 		"-p", prompt,
@@ -376,7 +376,7 @@ func TestSpawnArgvShape_FixedShape(t *testing.T) {
 	if args[3] != "--permission-mode=acceptEdits" {
 		t.Errorf("argv[3] = %q, want --permission-mode=acceptEdits", args[3])
 	}
-	wantMCP := "--mcp-config=" + filepath.Join(root, ".claude", ".mcp.json")
+	wantMCP := "--mcp-config=" + filepath.Join(root, ".mcp.json")
 	if args[4] != wantMCP {
 		t.Errorf("argv[4] = %q, want %q", args[4], wantMCP)
 	}

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -58,7 +58,8 @@ const channelsMCPTemplate = `{
       "command": %s,
       "args": ["mcp-serve"],
       "env": {
-        "NIWA_INSTANCE_ROOT": %s
+        "NIWA_INSTANCE_ROOT": %s,
+        "NIWA_SESSION_ROLE": "coordinator"
       }
     }
   }

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -21,13 +21,13 @@ var roleNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
 // coordinatorRole is the reserved role name for the instance root session.
 const coordinatorRole = "coordinator"
 
-// channelsMCPTemplate is the template for .claude/.mcp.json. It registers
-// the niwa mcp-serve command with NIWA_INSTANCE_ROOT baked in so Claude Code
-// can start the MCP server without any user configuration. The command
-// field is the absolute path to the provisioning niwa binary (resolved via
-// os.Executable at apply time) so the MCP server always matches the version
-// that provisioned the instance; this avoids PATH ambiguity when multiple
-// niwa installs coexist on one machine.
+// channelsMCPTemplate is the template for the instance-root `.mcp.json`.
+// It registers the niwa mcp-serve command with NIWA_INSTANCE_ROOT baked in
+// so Claude Code can start the MCP server without any user configuration.
+// The command field is the absolute path to the provisioning niwa binary
+// (resolved via os.Executable at apply time) so the MCP server always
+// matches the version that provisioned the instance; this avoids PATH
+// ambiguity when multiple niwa installs coexist on one machine.
 const channelsMCPTemplate = `{
   "mcpServers": {
     "niwa": {
@@ -92,8 +92,10 @@ const skillFrontmatterCharLimit = 1536
 //     collision, reserved-name, and format constraints.
 //  3. Creates .niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/
 //     for every role, plus .niwa/tasks/, .niwa/daemon.pid, .niwa/daemon.log.
-//  4. Writes <instanceRoot>/.claude/.mcp.json and mirrors it into every
-//     cloned repo's .claude/.mcp.json with NIWA_INSTANCE_ROOT baked in.
+//  4. Writes <instanceRoot>/.mcp.json (the project-scoped MCP config that
+//     Claude Code's discovery reads at the directory root and walks up the
+//     tree to find from sub-repos). NIWA_INSTANCE_ROOT is baked into the
+//     env block so the MCP server resolves the right workspace.
 //  5. Installs the niwa-mesh SKILL.md at instance-root and per-repo
 //     .claude/skills/niwa-mesh/ with byte-compare idempotency — writes only
 //     when the on-disk bytes differ from the installer's output, emits a
@@ -176,30 +178,31 @@ func InstallChannelInfrastructure(cfg *config.WorkspaceConfig, instanceRoot stri
 	}
 	*writtenFiles = append(*writtenFiles, logPath)
 
-	// Step 4: .mcp.json at instance root. Mirror into each role's repo
-	// dir (not coordinator — that lives at the instance root).
+	// Step 4: .mcp.json at the instance root. Claude Code's MCP discovery
+	// reads `<cwd>/.mcp.json` (a project-scoped file at the directory root,
+	// not under `.claude/`) and walks the directory tree upward collecting
+	// configs (see Claude Code's src/services/mcp/config.ts). Writing the
+	// file at the instance root makes it visible to:
+	//
+	//   1. Human-launched coordinator sessions started at the instance root
+	//      — discovered directly.
+	//   2. Human-launched sessions started inside a sub-repo — discovered
+	//      via the upward walk to the instance root.
+	//
+	// Daemon-spawned workers receive the path explicitly via `--mcp-config`
+	// + `--strict-mcp-config` (see internal/cli/mesh_watch.go::spawnWorker),
+	// so discovery doesn't matter for them — but they read the same file.
+	//
+	// Per-repo mirrors are intentionally not written: Claude's directory
+	// walk-up makes them redundant, and putting `.mcp.json` inside a tracked
+	// git repo would commit the local binary path and instance root into
+	// upstream history.
 	mcpContent := buildMCPContent(instanceRoot)
-	instanceMCPPath := filepath.Join(instanceRoot, ".claude", ".mcp.json")
+	instanceMCPPath := filepath.Join(instanceRoot, ".mcp.json")
 	if err := writeIdempotent(instanceMCPPath, mcpContent, 0o600, os.Stderr); err != nil {
 		return fmt.Errorf("writing instance .mcp.json: %w", err)
 	}
 	*writtenFiles = append(*writtenFiles, instanceMCPPath)
-
-	for _, r := range roles {
-		if r.name == coordinatorRole {
-			continue
-		}
-		if r.repoPath == "" {
-			// Explicit [channels.mesh.roles] entry without a resolved
-			// path (e.g., a virtual peer); skip the per-repo mirror.
-			continue
-		}
-		repoMCP := filepath.Join(r.repoPath, ".claude", ".mcp.json")
-		if err := writeIdempotent(repoMCP, mcpContent, 0o600, os.Stderr); err != nil {
-			return fmt.Errorf("writing %s: %w", repoMCP, err)
-		}
-		*writtenFiles = append(*writtenFiles, repoMCP)
-	}
 
 	// Step 5: niwa-mesh SKILL.md at instance-root and per-repo. Content
 	// is identical across paths (flat uniform skill, Decision 5).
@@ -490,7 +493,7 @@ func migratePre1Layout(niwaDir string) error {
 	return nil
 }
 
-// buildMCPContent returns the instance-root-aware .mcp.json bytes. The
+// buildMCPContent returns the bytes for `<instance>/.mcp.json`. The
 // command field resolves to the absolute path of the provisioning niwa
 // binary (os.Executable) so Claude Code's MCP subprocess launcher does
 // not depend on PATH. The NIWA_INSTANCE_ROOT env entry is JSON-marshaled

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -92,10 +92,14 @@ const skillFrontmatterCharLimit = 1536
 //     collision, reserved-name, and format constraints.
 //  3. Creates .niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/
 //     for every role, plus .niwa/tasks/, .niwa/daemon.pid, .niwa/daemon.log.
-//  4. Writes <instanceRoot>/.mcp.json (the project-scoped MCP config that
-//     Claude Code's discovery reads at the directory root and walks up the
-//     tree to find from sub-repos). NIWA_INSTANCE_ROOT is baked into the
-//     env block so the MCP server resolves the right workspace.
+//  4. Writes the project-scoped MCP config (`.mcp.json`) at every
+//     directory a coordinator might launch Claude from: the instance
+//     root and every cloned repo's root. Claude Code reads `.mcp.json`
+//     at the cwd's directory root and does not walk parents, so all
+//     candidate cwds need a copy. The per-repo file is added to that
+//     repo's `.git/info/exclude` so its absolute paths don't get
+//     committed upstream. NIWA_INSTANCE_ROOT is baked into the env
+//     block so the MCP server resolves the right workspace.
 //  5. Installs the niwa-mesh SKILL.md at instance-root and per-repo
 //     .claude/skills/niwa-mesh/ with byte-compare idempotency — writes only
 //     when the on-disk bytes differ from the installer's output, emits a
@@ -178,31 +182,59 @@ func InstallChannelInfrastructure(cfg *config.WorkspaceConfig, instanceRoot stri
 	}
 	*writtenFiles = append(*writtenFiles, logPath)
 
-	// Step 4: .mcp.json at the instance root. Claude Code's MCP discovery
-	// reads `<cwd>/.mcp.json` (a project-scoped file at the directory root,
-	// not under `.claude/`) and walks the directory tree upward collecting
-	// configs (see Claude Code's src/services/mcp/config.ts). Writing the
-	// file at the instance root makes it visible to:
+	// Step 4: .mcp.json at every directory a coordinator might be launched
+	// from. Claude Code's MCP discovery is per-cwd: it loads the
+	// project-scoped `.mcp.json` at the directory root of the cwd it was
+	// started in, and does NOT walk parent directories
+	// (https://code.claude.com/docs/en/mcp). For users who open Claude at
+	// the instance root the file at <instance>/.mcp.json is what loads;
+	// for users who open Claude inside a cloned repo the file at
+	// <repoDir>/.mcp.json is what loads. Both must exist.
 	//
-	//   1. Human-launched coordinator sessions started at the instance root
-	//      — discovered directly.
-	//   2. Human-launched sessions started inside a sub-repo — discovered
-	//      via the upward walk to the instance root.
+	// The file is NOT placed under `.claude/` — Claude Code looks for
+	// `.mcp.json` directly at the directory root.
+	//
+	// `<repoDir>/.mcp.json` carries machine-specific content (absolute
+	// niwa binary path and absolute NIWA_INSTANCE_ROOT) and must not be
+	// committed upstream. Niwa appends `.mcp.json` to each repo's
+	// `.git/info/exclude` (a per-clone, never-tracked exclude file
+	// supported by git for exactly this purpose) so the entry is hidden
+	// from `git status` without modifying the tracked `.gitignore`.
 	//
 	// Daemon-spawned workers receive the path explicitly via `--mcp-config`
-	// + `--strict-mcp-config` (see internal/cli/mesh_watch.go::spawnWorker),
-	// so discovery doesn't matter for them — but they read the same file.
-	//
-	// Per-repo mirrors are intentionally not written: Claude's directory
-	// walk-up makes them redundant, and putting `.mcp.json` inside a tracked
-	// git repo would commit the local binary path and instance root into
-	// upstream history.
+	// + `--strict-mcp-config` (see internal/cli/mesh_watch.go::spawnWorker)
+	// and intentionally do NOT use discovery — that isolates them from
+	// any user-scoped MCP servers in `~/.claude.json`. The file we write
+	// here is the same one workers point at, so there is one source of
+	// truth on disk.
 	mcpContent := buildMCPContent(instanceRoot)
 	instanceMCPPath := filepath.Join(instanceRoot, ".mcp.json")
 	if err := writeIdempotent(instanceMCPPath, mcpContent, 0o600, os.Stderr); err != nil {
 		return fmt.Errorf("writing instance .mcp.json: %w", err)
 	}
 	*writtenFiles = append(*writtenFiles, instanceMCPPath)
+
+	for _, r := range roles {
+		if r.name == coordinatorRole {
+			continue
+		}
+		if r.repoPath == "" {
+			// Explicit [channels.mesh.roles] entry without a resolved
+			// path (e.g., a virtual peer); skip the per-repo mirror.
+			continue
+		}
+		repoMCP := filepath.Join(r.repoPath, ".mcp.json")
+		if err := writeIdempotent(repoMCP, mcpContent, 0o600, os.Stderr); err != nil {
+			return fmt.Errorf("writing %s: %w", repoMCP, err)
+		}
+		*writtenFiles = append(*writtenFiles, repoMCP)
+
+		if err := ensureGitInfoExclude(r.repoPath, ".mcp.json"); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not exclude .mcp.json from git in %s: %v\n",
+				r.repoPath, err)
+		}
+	}
 
 	// Step 5: niwa-mesh SKILL.md at instance-root and per-repo. Content
 	// is identical across paths (flat uniform skill, Decision 5).
@@ -762,6 +794,43 @@ func ensureEmptyFile(path string, mode os.FileMode) error {
 	}
 	_ = f.Close()
 	return os.Chmod(path, mode)
+}
+
+// ensureGitInfoExclude appends pattern as its own line to
+// <repoDir>/.git/info/exclude when the file exists and the pattern isn't
+// already present. The exclude file is per-clone and never tracked,
+// which is exactly what we want for machine-specific files (like the
+// per-repo `.mcp.json` carrying absolute paths).
+//
+// When `.git/info/` doesn't exist the function is a no-op and returns
+// nil — a niwa repo path that isn't a git clone (e.g., a manually
+// created directory) can't have its config hidden from git, but the
+// caller's main work (writing the .mcp.json) has already succeeded and
+// shouldn't fail because of this auxiliary step.
+func ensureGitInfoExclude(repoDir, pattern string) error {
+	excludePath := filepath.Join(repoDir, ".git", "info", "exclude")
+	infoDir := filepath.Dir(excludePath)
+	if _, err := os.Stat(infoDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	existing, err := os.ReadFile(excludePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	for _, line := range strings.Split(string(existing), "\n") {
+		if strings.TrimSpace(line) == pattern {
+			return nil
+		}
+	}
+	out := string(existing)
+	if len(out) > 0 && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	out += pattern + "\n"
+	return os.WriteFile(excludePath, []byte(out), 0o600)
 }
 
 // isHiddenOrSkip reports whether a directory basename should be skipped

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -92,14 +92,12 @@ const skillFrontmatterCharLimit = 1536
 //     collision, reserved-name, and format constraints.
 //  3. Creates .niwa/roles/<role>/inbox/{in-progress,cancelled,expired,read}/
 //     for every role, plus .niwa/tasks/, .niwa/daemon.pid, .niwa/daemon.log.
-//  4. Writes the project-scoped MCP config (`.mcp.json`) at every
-//     directory a coordinator might launch Claude from: the instance
-//     root and every cloned repo's root. Claude Code reads `.mcp.json`
-//     at the cwd's directory root and does not walk parents, so all
-//     candidate cwds need a copy. The per-repo file is added to that
-//     repo's `.git/info/exclude` so its absolute paths don't get
-//     committed upstream. NIWA_INSTANCE_ROOT is baked into the env
-//     block so the MCP server resolves the right workspace.
+//  4. Writes `<instanceRoot>/.mcp.json` (the project-scoped MCP config
+//     Claude Code reads when launched at the instance root, per the
+//     PRD's headline scenario). NIWA_INSTANCE_ROOT is baked into the
+//     env block so the MCP server resolves the right workspace. No
+//     per-repo mirror is written — see the rationale at the call site
+//     and issue #78 for the trade-off matrix.
 //  5. Installs the niwa-mesh SKILL.md at instance-root and per-repo
 //     .claude/skills/niwa-mesh/ with byte-compare idempotency — writes only
 //     when the on-disk bytes differ from the installer's output, emits a
@@ -182,59 +180,39 @@ func InstallChannelInfrastructure(cfg *config.WorkspaceConfig, instanceRoot stri
 	}
 	*writtenFiles = append(*writtenFiles, logPath)
 
-	// Step 4: .mcp.json at every directory a coordinator might be launched
-	// from. Claude Code's MCP discovery is per-cwd: it loads the
-	// project-scoped `.mcp.json` at the directory root of the cwd it was
-	// started in, and does NOT walk parent directories
-	// (https://code.claude.com/docs/en/mcp). For users who open Claude at
-	// the instance root the file at <instance>/.mcp.json is what loads;
-	// for users who open Claude inside a cloned repo the file at
-	// <repoDir>/.mcp.json is what loads. Both must exist.
+	// Step 4: .mcp.json at the instance root. Claude Code's MCP discovery
+	// is per-cwd: it loads the project-scoped `.mcp.json` at the directory
+	// root of the cwd it was started in, and does NOT walk parent
+	// directories (https://code.claude.com/docs/en/mcp). The PRD's
+	// headline scenario is "open one Claude at the instance root and ask
+	// it to delegate," so the instance root is the only cwd niwa needs to
+	// cover for human-launched coordinator sessions. Sub-repo cwds are an
+	// out-of-spec entry point; users who want one can launch with
+	// `--mcp-config=<instance>/.mcp.json` explicitly.
+	//
+	// Avoiding per-repo files is a deliberate scope choice: a per-repo
+	// `.mcp.json` would either collide destructively with any project
+	// that ships its own (drift-warning + overwrite, then the change is
+	// hidden by `.git/info/exclude` so the user can't see what happened)
+	// or require merging niwa's entry into upstream's mcpServers — which
+	// puts machine-specific absolute paths into a tracked file. Neither
+	// is acceptable; see issue #78 for the trade-off matrix.
 	//
 	// The file is NOT placed under `.claude/` — Claude Code looks for
 	// `.mcp.json` directly at the directory root.
 	//
-	// `<repoDir>/.mcp.json` carries machine-specific content (absolute
-	// niwa binary path and absolute NIWA_INSTANCE_ROOT) and must not be
-	// committed upstream. Niwa appends `.mcp.json` to each repo's
-	// `.git/info/exclude` (a per-clone, never-tracked exclude file
-	// supported by git for exactly this purpose) so the entry is hidden
-	// from `git status` without modifying the tracked `.gitignore`.
-	//
-	// Daemon-spawned workers receive the path explicitly via `--mcp-config`
-	// + `--strict-mcp-config` (see internal/cli/mesh_watch.go::spawnWorker)
-	// and intentionally do NOT use discovery — that isolates them from
-	// any user-scoped MCP servers in `~/.claude.json`. The file we write
-	// here is the same one workers point at, so there is one source of
-	// truth on disk.
+	// Daemon-spawned workers receive the same path explicitly via
+	// `--mcp-config` + `--strict-mcp-config` (see
+	// internal/cli/mesh_watch.go::spawnWorker) and intentionally do NOT
+	// use discovery, which isolates them from any user-scoped MCP servers
+	// in `~/.claude.json`. The file we write here is the same one workers
+	// point at, so there is one source of truth on disk.
 	mcpContent := buildMCPContent(instanceRoot)
 	instanceMCPPath := filepath.Join(instanceRoot, ".mcp.json")
 	if err := writeIdempotent(instanceMCPPath, mcpContent, 0o600, os.Stderr); err != nil {
 		return fmt.Errorf("writing instance .mcp.json: %w", err)
 	}
 	*writtenFiles = append(*writtenFiles, instanceMCPPath)
-
-	for _, r := range roles {
-		if r.name == coordinatorRole {
-			continue
-		}
-		if r.repoPath == "" {
-			// Explicit [channels.mesh.roles] entry without a resolved
-			// path (e.g., a virtual peer); skip the per-repo mirror.
-			continue
-		}
-		repoMCP := filepath.Join(r.repoPath, ".mcp.json")
-		if err := writeIdempotent(repoMCP, mcpContent, 0o600, os.Stderr); err != nil {
-			return fmt.Errorf("writing %s: %w", repoMCP, err)
-		}
-		*writtenFiles = append(*writtenFiles, repoMCP)
-
-		if err := ensureGitInfoExclude(r.repoPath, ".mcp.json"); err != nil {
-			fmt.Fprintf(os.Stderr,
-				"warning: could not exclude .mcp.json from git in %s: %v\n",
-				r.repoPath, err)
-		}
-	}
 
 	// Step 5: niwa-mesh SKILL.md at instance-root and per-repo. Content
 	// is identical across paths (flat uniform skill, Decision 5).
@@ -794,43 +772,6 @@ func ensureEmptyFile(path string, mode os.FileMode) error {
 	}
 	_ = f.Close()
 	return os.Chmod(path, mode)
-}
-
-// ensureGitInfoExclude appends pattern as its own line to
-// <repoDir>/.git/info/exclude when the file exists and the pattern isn't
-// already present. The exclude file is per-clone and never tracked,
-// which is exactly what we want for machine-specific files (like the
-// per-repo `.mcp.json` carrying absolute paths).
-//
-// When `.git/info/` doesn't exist the function is a no-op and returns
-// nil — a niwa repo path that isn't a git clone (e.g., a manually
-// created directory) can't have its config hidden from git, but the
-// caller's main work (writing the .mcp.json) has already succeeded and
-// shouldn't fail because of this auxiliary step.
-func ensureGitInfoExclude(repoDir, pattern string) error {
-	excludePath := filepath.Join(repoDir, ".git", "info", "exclude")
-	infoDir := filepath.Dir(excludePath)
-	if _, err := os.Stat(infoDir); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	existing, err := os.ReadFile(excludePath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	for _, line := range strings.Split(string(existing), "\n") {
-		if strings.TrimSpace(line) == pattern {
-			return nil
-		}
-	}
-	out := string(existing)
-	if len(out) > 0 && !strings.HasSuffix(out, "\n") {
-		out += "\n"
-	}
-	out += pattern + "\n"
-	return os.WriteFile(excludePath, []byte(out), 0o600)
 }
 
 // isHiddenOrSkip reports whether a directory basename should be skipped

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -171,6 +171,28 @@ func InstallChannelInfrastructure(cfg *config.WorkspaceConfig, instanceRoot stri
 		return fmt.Errorf("creating .niwa/roles: %w", err)
 	}
 
+	// .niwa/sessions/sessions.json is the coordinator session registry
+	// (per PRD R39, R40 and AC-P5). Workers are not registered, only
+	// coordinators. Provision the directory and an empty registry file
+	// here so `niwa session list` finds a well-formed file from apply
+	// time, not a lazy-create on first `niwa session register`. Create
+	// only if absent — re-apply must NOT overwrite a populated registry
+	// (that would wipe live session entries).
+	sessionsDir := filepath.Join(niwaDir, "sessions")
+	if err := mkdirAllMode(sessionsDir, 0o700); err != nil {
+		return fmt.Errorf("creating .niwa/sessions: %w", err)
+	}
+	sessionsPath := filepath.Join(sessionsDir, "sessions.json")
+	if _, err := os.Stat(sessionsPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("checking sessions.json: %w", err)
+		}
+		if err := os.WriteFile(sessionsPath, []byte("{\"sessions\":[]}\n"), 0o600); err != nil {
+			return fmt.Errorf("writing sessions.json: %w", err)
+		}
+	}
+	*writtenFiles = append(*writtenFiles, sessionsPath)
+
 	// Create per-role inbox trees. Role enumeration is stable-sorted by
 	// enumerateRoles; walking the sorted slice keeps directory creation
 	// order deterministic for easier test assertions.

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/tsukumogami/niwa/internal/config"
 )
@@ -20,6 +21,28 @@ var roleNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,31}$`)
 
 // coordinatorRole is the reserved role name for the instance root session.
 const coordinatorRole = "coordinator"
+
+// instanceMCPConfigName is the basename of the project-scoped MCP config
+// file Claude Code's discovery loads at the cwd directory root. It lives
+// at the directory root, not under .claude/.
+const instanceMCPConfigName = ".mcp.json"
+
+// InstanceMCPConfigPath returns the absolute path to the niwa-managed
+// MCP config file at instanceRoot. Three callers must agree on this
+// path:
+//
+//   - the channels installer that writes the file (this package)
+//   - the daemon's worker spawn that hands the path to claude via
+//     --mcp-config (internal/cli/mesh_watch.go::spawnWorker)
+//   - the functional-test coordinator launcher that does the same
+//     (test/functional/mesh_steps_test.go)
+//
+// All three reference this helper so a future move (e.g., to
+// .niwa/.mcp.json, or per-repo files keyed differently) is a one-line
+// change. See issue #78 for the longer-term strategy review.
+func InstanceMCPConfigPath(instanceRoot string) string {
+	return filepath.Join(instanceRoot, instanceMCPConfigName)
+}
 
 // channelsMCPTemplate is the template for the instance-root `.mcp.json`.
 // It registers the niwa mcp-serve command with NIWA_INSTANCE_ROOT baked in
@@ -180,35 +203,20 @@ func InstallChannelInfrastructure(cfg *config.WorkspaceConfig, instanceRoot stri
 	}
 	*writtenFiles = append(*writtenFiles, logPath)
 
-	// Step 4: .mcp.json at the instance root. Claude Code's MCP discovery
-	// is per-cwd: it loads the project-scoped `.mcp.json` at the directory
-	// root of the cwd it was started in, and does NOT walk parent
-	// directories (https://code.claude.com/docs/en/mcp). The PRD's
-	// headline scenario is "open one Claude at the instance root and ask
-	// it to delegate," so the instance root is the only cwd niwa needs to
-	// cover for human-launched coordinator sessions. Sub-repo cwds are an
-	// out-of-spec entry point; users who want one can launch with
-	// `--mcp-config=<instance>/.mcp.json` explicitly.
-	//
-	// Avoiding per-repo files is a deliberate scope choice: a per-repo
-	// `.mcp.json` would either collide destructively with any project
-	// that ships its own (drift-warning + overwrite, then the change is
-	// hidden by `.git/info/exclude` so the user can't see what happened)
-	// or require merging niwa's entry into upstream's mcpServers — which
-	// puts machine-specific absolute paths into a tracked file. Neither
-	// is acceptable; see issue #78 for the trade-off matrix.
-	//
-	// The file is NOT placed under `.claude/` — Claude Code looks for
-	// `.mcp.json` directly at the directory root.
-	//
-	// Daemon-spawned workers receive the same path explicitly via
-	// `--mcp-config` + `--strict-mcp-config` (see
-	// internal/cli/mesh_watch.go::spawnWorker) and intentionally do NOT
-	// use discovery, which isolates them from any user-scoped MCP servers
-	// in `~/.claude.json`. The file we write here is the same one workers
-	// point at, so there is one source of truth on disk.
-	mcpContent := buildMCPContent(instanceRoot)
-	instanceMCPPath := filepath.Join(instanceRoot, ".mcp.json")
+	// Step 4: project-scoped MCP config at the instance root. Claude
+	// Code's discovery loads `<cwd>/.mcp.json` only, no parent walk-up,
+	// so the instance root is the cwd where the headline scenario "open
+	// Claude here and delegate" finds niwa tools. The file lives at the
+	// directory root, not under `.claude/`. Per-repo writes are
+	// deliberately omitted to avoid colliding with projects that ship
+	// their own `.mcp.json`; see issue #78. Workers don't depend on
+	// discovery — `mesh_watch.go::spawnWorker` passes `--mcp-config` to
+	// this same file with `--strict-mcp-config`.
+	mcpContent, err := buildMCPContent(instanceRoot)
+	if err != nil {
+		return fmt.Errorf("building .mcp.json content: %w", err)
+	}
+	instanceMCPPath := InstanceMCPConfigPath(instanceRoot)
 	if err := writeIdempotent(instanceMCPPath, mcpContent, 0o600, os.Stderr); err != nil {
 		return fmt.Errorf("writing instance .mcp.json: %w", err)
 	}
@@ -343,11 +351,11 @@ func enumerateRoles(cfg *config.WorkspaceConfig, instanceRoot string) ([]roleEnt
 
 	// Enumerate topology-derived roles in a single walk of the instance
 	// root. We need two things at once: the absolute on-disk path for
-	// each repo basename (for per-repo .mcp.json and SKILL.md mirroring)
-	// and the occurrence count (for collision detection per AC-R2). A
-	// missing instance root is possible on a create path before clones
-	// have finished; treat it as zero repos so coordinator-only
-	// workspaces install cleanly.
+	// each repo basename (for per-repo SKILL.md mirroring) and the
+	// occurrence count (for collision detection per AC-R2). A missing
+	// instance root is possible on a create path before clones have
+	// finished; treat it as zero repos so coordinator-only workspaces
+	// install cleanly.
 	topologyPaths := map[string]string{}
 	repoOccurrences := map[string]int{}
 	entries, err := os.ReadDir(instanceRoot)
@@ -369,8 +377,11 @@ func enumerateRoles(cfg *config.WorkspaceConfig, instanceRoot string) ([]roleEnt
 			if !repo.IsDir() || isHiddenOrSkip(repoName) {
 				continue
 			}
-			// Last writer wins when the same basename appears in two
-			// groups; the collision is detected via repoOccurrences below.
+			// When the same basename appears in two groups, the second
+			// iteration's path wins for topologyPaths. That ordering only
+			// matters in the explicit-override case below; without an
+			// override, the duplicate is detected via repoOccurrences and
+			// rejected as a hard error (AC-R2).
 			topologyPaths[repoName] = filepath.Join(groupDir, repoName)
 			repoOccurrences[repoName]++
 		}
@@ -503,23 +514,38 @@ func migratePre1Layout(niwaDir string) error {
 	return nil
 }
 
-// buildMCPContent returns the bytes for `<instance>/.mcp.json`. The
-// command field resolves to the absolute path of the provisioning niwa
-// binary (os.Executable) so Claude Code's MCP subprocess launcher does
-// not depend on PATH. The NIWA_INSTANCE_ROOT env entry is JSON-marshaled
-// so instance paths with spaces, quotes, or other special characters are
-// preserved correctly.
-func buildMCPContent(instanceRoot string) []byte {
+// buildMCPContent returns the bytes for `<instance>/.mcp.json`. It
+// errors when the niwa binary path or the instance root contain
+// invalid UTF-8 — extremely rare on Linux but reachable on
+// filesystems with mojibake-encoded paths. json.Marshal of a string
+// silently coerces invalid bytes to U+FFFD, so without this guard
+// the file would land on disk with a path Claude Code would later
+// fail to launch with a confusing "no such file" — checking up front
+// produces a clear apply-time error instead.
+//
+// The command field resolves to the absolute path of the provisioning
+// niwa binary (os.Executable) so Claude Code's MCP subprocess launcher
+// does not depend on PATH. The NIWA_INSTANCE_ROOT env entry is
+// JSON-marshaled so instance paths with spaces, quotes, or other
+// special characters are preserved correctly.
+func buildMCPContent(instanceRoot string) ([]byte, error) {
 	cmdPath, err := os.Executable()
 	if err != nil || cmdPath == "" {
-		// Fallback to PATH resolution if the process path is unavailable.
-		// This is the legacy behavior; it only fires when os.Executable
-		// fails outright (very rare on POSIX systems).
+		// Defensive default: fall back to PATH resolution when
+		// os.Executable() returns empty (very rare on POSIX). Workers
+		// spawned via this fallback rely on `niwa` being on PATH at
+		// claude-launch time. Prefer the absolute path when available.
 		cmdPath = "niwa"
+	}
+	if !utf8.ValidString(cmdPath) {
+		return nil, fmt.Errorf("niwa binary path is not valid UTF-8: %q", cmdPath)
+	}
+	if !utf8.ValidString(instanceRoot) {
+		return nil, fmt.Errorf("instance root is not valid UTF-8: %q", instanceRoot)
 	}
 	cmdJSON, _ := json.Marshal(cmdPath)
 	rootJSON, _ := json.Marshal(instanceRoot)
-	return []byte(fmt.Sprintf(channelsMCPTemplate, string(cmdJSON), string(rootJSON)))
+	return []byte(fmt.Sprintf(channelsMCPTemplate, string(cmdJSON), string(rootJSON))), nil
 }
 
 // buildSkillContent returns the canonical niwa-mesh SKILL.md content. The

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -776,6 +776,20 @@ func TestInjectChannelHooks_PrependToExisting(t *testing.T) {
 	}
 }
 
+// TestInstanceMCPConfigPath documents the path contract three call
+// sites depend on: the channels installer that writes the file, the
+// daemon's worker spawn that hands the path to claude via
+// --mcp-config, and the functional-test coordinator launcher. If this
+// constant changes (say to .niwa/.mcp.json), this is the test that
+// will fail first.
+func TestInstanceMCPConfigPath(t *testing.T) {
+	got := InstanceMCPConfigPath("/some/instance")
+	want := "/some/instance/.mcp.json"
+	if got != want {
+		t.Errorf("InstanceMCPConfigPath(%q) = %q, want %q", "/some/instance", got, want)
+	}
+}
+
 func TestBuildMCPContent_InstanceRootEscaping(t *testing.T) {
 	instanceRoot := "/some/path/with spaces"
 	data, err := buildMCPContent(instanceRoot)

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -31,10 +31,7 @@ func channeledConfig() *config.WorkspaceConfig {
 func seedRepo(t *testing.T, instanceRoot, group, name string) string {
 	t.Helper()
 	repoDir := filepath.Join(instanceRoot, group, name)
-	// Real `git init` creates .git/info/ alongside .git/objects/, .git/refs/,
-	// etc. The channel installer's git-info-exclude write needs the info/
-	// dir to exist; mirror that here so the seed matches real git layout.
-	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
 		t.Fatalf("seeding repo %s/%s: %v", group, name, err)
 	}
 	return repoDir
@@ -119,11 +116,12 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("daemon.log missing: %v", err)
 	}
 
-	// `.mcp.json` lives at every directory root a coordinator might
-	// launch Claude from. Claude Code's MCP discovery is per-cwd (no
-	// parent walk-up), so the instance root and every cloned repo root
-	// each need their own copy. The file is NOT under `.claude/` —
-	// Claude Code reads `.mcp.json` directly at the directory root.
+	// `.mcp.json` lives at the instance root only. Claude Code's MCP
+	// discovery is per-cwd (no parent walk-up); the PRD's headline
+	// scenario is "open one Claude at the instance root and ask it to
+	// delegate," so the instance root is the only cwd niwa needs to
+	// cover. The file is NOT under `.claude/` — Claude Code reads
+	// `.mcp.json` directly at the directory root.
 	instanceMCP := filepath.Join(dir, ".mcp.json")
 	data, err := os.ReadFile(instanceMCP)
 	if err != nil {
@@ -140,44 +138,21 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("instance .mcp.json is not valid JSON: %v", err)
 	}
 
-	// `.mcp.json` mirrored to every cloned repo at the repo root (NOT
-	// under `.claude/`). The legacy `.claude/.mcp.json` path must not
-	// be written.
+	// No per-repo `.mcp.json` is written, at either the legacy
+	// `.claude/.mcp.json` path (which Claude Code's discovery never
+	// reads) or the repo-root `.mcp.json` path (which would collide
+	// destructively with any project that ships its own MCP config).
+	// Sub-repo cwd launches are an out-of-spec entry point users can
+	// reach with `--mcp-config=<instance>/.mcp.json` explicitly. See
+	// issue #78 for the trade-off rationale.
 	for _, role := range []string{"web", "api"} {
 		legacyOld := filepath.Join(dir, "apps", role, ".claude", ".mcp.json")
 		if _, err := os.Stat(legacyOld); err == nil {
 			t.Errorf("legacy per-repo .claude/.mcp.json should not be written for %q", role)
 		}
 		repoRoot := filepath.Join(dir, "apps", role, ".mcp.json")
-		repoData, err := os.ReadFile(repoRoot)
-		if err != nil {
-			t.Fatalf("repo %q .mcp.json not written at repo root: %v", role, err)
-		}
-		if !bytes.Equal(repoData, data) {
-			t.Errorf("repo %q .mcp.json content differs from instance copy", role)
-		}
-	}
-
-	// The per-repo `.mcp.json` carries absolute paths that must not be
-	// committed upstream. Niwa appends the entry to each repo's
-	// `.git/info/exclude` so it stays out of `git status`.
-	for _, role := range []string{"web", "api"} {
-		excludePath := filepath.Join(dir, "apps", role, ".git", "info", "exclude")
-		excludeBytes, err := os.ReadFile(excludePath)
-		if err != nil {
-			t.Errorf("repo %q .git/info/exclude unreadable: %v", role, err)
-			continue
-		}
-		found := false
-		for _, line := range strings.Split(string(excludeBytes), "\n") {
-			if strings.TrimSpace(line) == ".mcp.json" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("repo %q .git/info/exclude does not list .mcp.json:\n%s",
-				role, excludeBytes)
+		if _, err := os.Stat(repoRoot); err == nil {
+			t.Errorf("per-repo .mcp.json should not be written at repo root for %q", role)
 		}
 	}
 
@@ -472,11 +447,10 @@ func TestInstallChannelInfrastructure_DirAndFileModes(t *testing.T) {
 		t.Fatalf("walking .niwa/: %v", err)
 	}
 
-	// .mcp.json (instance root + per-repo) and SKILL.md must all be 0600.
+	// .mcp.json (instance root) and SKILL.md must all be 0600.
 	for _, p := range []string{
 		filepath.Join(dir, ".mcp.json"),
 		filepath.Join(dir, ".claude", "skills", "niwa-mesh", "SKILL.md"),
-		filepath.Join(dir, "apps", "web", ".mcp.json"),
 		filepath.Join(dir, "apps", "web", ".claude", "skills", "niwa-mesh", "SKILL.md"),
 	} {
 		fi, err := os.Stat(p)
@@ -842,94 +816,3 @@ func TestWriteIdempotent_MatchingContentSkipsWrite(t *testing.T) {
 	}
 }
 
-func TestEnsureGitInfoExclude(t *testing.T) {
-	t.Run("appends pattern when info dir exists and pattern absent", func(t *testing.T) {
-		repo := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		// Pre-existing exclude content with one unrelated entry.
-		excludePath := filepath.Join(repo, ".git", "info", "exclude")
-		if err := os.WriteFile(excludePath, []byte("# git ls-files --others --exclude-from=.git/info/exclude\n*.swp\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
-			t.Fatalf("ensureGitInfoExclude: %v", err)
-		}
-		got, _ := os.ReadFile(excludePath)
-		if !strings.Contains(string(got), ".mcp.json") {
-			t.Errorf(".mcp.json not appended:\n%s", got)
-		}
-		if !strings.Contains(string(got), "*.swp") {
-			t.Errorf("existing pattern *.swp lost:\n%s", got)
-		}
-	})
-
-	t.Run("idempotent — second call does not duplicate the pattern", func(t *testing.T) {
-		repo := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		for i := 0; i < 3; i++ {
-			if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
-				t.Fatalf("call %d: %v", i, err)
-			}
-		}
-		got, _ := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
-		count := strings.Count(string(got), ".mcp.json")
-		if count != 1 {
-			t.Errorf("expected exactly 1 occurrence of .mcp.json, got %d in:\n%s", count, got)
-		}
-	})
-
-	t.Run("creates exclude file when missing but info dir exists", func(t *testing.T) {
-		repo := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
-			t.Fatalf("ensureGitInfoExclude: %v", err)
-		}
-		got, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
-		if err != nil {
-			t.Fatalf("exclude file not created: %v", err)
-		}
-		if strings.TrimSpace(string(got)) != ".mcp.json" {
-			t.Errorf("expected only .mcp.json, got: %q", got)
-		}
-	})
-
-	t.Run("no-op when .git/info/ does not exist", func(t *testing.T) {
-		repo := t.TempDir()
-		// Only create .git/, not .git/info/.
-		if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
-			t.Errorf("expected no-op when .git/info/ missing, got error: %v", err)
-		}
-		// And no exclude file should be created.
-		if _, err := os.Stat(filepath.Join(repo, ".git", "info", "exclude")); err == nil {
-			t.Errorf("exclude file should not have been created when .git/info/ missing")
-		}
-	})
-
-	t.Run("treats existing entry with surrounding whitespace as already present", func(t *testing.T) {
-		repo := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		excludePath := filepath.Join(repo, ".git", "info", "exclude")
-		// Tab/space-padded entry — git's matching ignores surrounding whitespace.
-		if err := os.WriteFile(excludePath, []byte("  .mcp.json\t\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
-			t.Fatalf("ensureGitInfoExclude: %v", err)
-		}
-		got, _ := os.ReadFile(excludePath)
-		if strings.Count(string(got), ".mcp.json") != 1 {
-			t.Errorf("padded existing entry should be detected; got:\n%s", got)
-		}
-	})
-}

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -31,7 +31,10 @@ func channeledConfig() *config.WorkspaceConfig {
 func seedRepo(t *testing.T, instanceRoot, group, name string) string {
 	t.Helper()
 	repoDir := filepath.Join(instanceRoot, group, name)
-	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+	// Real `git init` creates .git/info/ alongside .git/objects/, .git/refs/,
+	// etc. The channel installer's git-info-exclude write needs the info/
+	// dir to exist; mirror that here so the seed matches real git layout.
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
 		t.Fatalf("seeding repo %s/%s: %v", group, name, err)
 	}
 	return repoDir
@@ -116,10 +119,11 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("daemon.log missing: %v", err)
 	}
 
-	// .mcp.json at instance root (NOT under .claude/). Claude Code's
-	// discovery reads `<cwd>/.mcp.json` at the directory root and walks
-	// up; placing it here makes it visible to coordinator sessions
-	// started either at the instance root or from any sub-repo.
+	// `.mcp.json` lives at every directory root a coordinator might
+	// launch Claude from. Claude Code's MCP discovery is per-cwd (no
+	// parent walk-up), so the instance root and every cloned repo root
+	// each need their own copy. The file is NOT under `.claude/` —
+	// Claude Code reads `.mcp.json` directly at the directory root.
 	instanceMCP := filepath.Join(dir, ".mcp.json")
 	data, err := os.ReadFile(instanceMCP)
 	if err != nil {
@@ -136,18 +140,44 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("instance .mcp.json is not valid JSON: %v", err)
 	}
 
-	// Per-repo `.mcp.json` mirrors are intentionally NOT written; the
-	// instance-root file covers sub-repos via Claude's directory walk-up
-	// (and a per-repo file at the repo root would commit the local
-	// binary path and instance root into upstream history).
+	// `.mcp.json` mirrored to every cloned repo at the repo root (NOT
+	// under `.claude/`). The legacy `.claude/.mcp.json` path must not
+	// be written.
 	for _, role := range []string{"web", "api"} {
 		legacyOld := filepath.Join(dir, "apps", role, ".claude", ".mcp.json")
 		if _, err := os.Stat(legacyOld); err == nil {
 			t.Errorf("legacy per-repo .claude/.mcp.json should not be written for %q", role)
 		}
 		repoRoot := filepath.Join(dir, "apps", role, ".mcp.json")
-		if _, err := os.Stat(repoRoot); err == nil {
-			t.Errorf("per-repo .mcp.json should not be written at repo root for %q", role)
+		repoData, err := os.ReadFile(repoRoot)
+		if err != nil {
+			t.Fatalf("repo %q .mcp.json not written at repo root: %v", role, err)
+		}
+		if !bytes.Equal(repoData, data) {
+			t.Errorf("repo %q .mcp.json content differs from instance copy", role)
+		}
+	}
+
+	// The per-repo `.mcp.json` carries absolute paths that must not be
+	// committed upstream. Niwa appends the entry to each repo's
+	// `.git/info/exclude` so it stays out of `git status`.
+	for _, role := range []string{"web", "api"} {
+		excludePath := filepath.Join(dir, "apps", role, ".git", "info", "exclude")
+		excludeBytes, err := os.ReadFile(excludePath)
+		if err != nil {
+			t.Errorf("repo %q .git/info/exclude unreadable: %v", role, err)
+			continue
+		}
+		found := false
+		for _, line := range strings.Split(string(excludeBytes), "\n") {
+			if strings.TrimSpace(line) == ".mcp.json" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("repo %q .git/info/exclude does not list .mcp.json:\n%s",
+				role, excludeBytes)
 		}
 	}
 
@@ -442,10 +472,11 @@ func TestInstallChannelInfrastructure_DirAndFileModes(t *testing.T) {
 		t.Fatalf("walking .niwa/: %v", err)
 	}
 
-	// .mcp.json (instance root) and SKILL.md also must be 0600.
+	// .mcp.json (instance root + per-repo) and SKILL.md must all be 0600.
 	for _, p := range []string{
 		filepath.Join(dir, ".mcp.json"),
 		filepath.Join(dir, ".claude", "skills", "niwa-mesh", "SKILL.md"),
+		filepath.Join(dir, "apps", "web", ".mcp.json"),
 		filepath.Join(dir, "apps", "web", ".claude", "skills", "niwa-mesh", "SKILL.md"),
 	} {
 		fi, err := os.Stat(p)
@@ -809,4 +840,96 @@ func TestWriteIdempotent_MatchingContentSkipsWrite(t *testing.T) {
 	if !before.ModTime().Equal(after.ModTime()) {
 		t.Errorf("mtime changed on byte-identical rewrite: %v -> %v", before.ModTime(), after.ModTime())
 	}
+}
+
+func TestEnsureGitInfoExclude(t *testing.T) {
+	t.Run("appends pattern when info dir exists and pattern absent", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Pre-existing exclude content with one unrelated entry.
+		excludePath := filepath.Join(repo, ".git", "info", "exclude")
+		if err := os.WriteFile(excludePath, []byte("# git ls-files --others --exclude-from=.git/info/exclude\n*.swp\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
+			t.Fatalf("ensureGitInfoExclude: %v", err)
+		}
+		got, _ := os.ReadFile(excludePath)
+		if !strings.Contains(string(got), ".mcp.json") {
+			t.Errorf(".mcp.json not appended:\n%s", got)
+		}
+		if !strings.Contains(string(got), "*.swp") {
+			t.Errorf("existing pattern *.swp lost:\n%s", got)
+		}
+	})
+
+	t.Run("idempotent — second call does not duplicate the pattern", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 3; i++ {
+			if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
+				t.Fatalf("call %d: %v", i, err)
+			}
+		}
+		got, _ := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+		count := strings.Count(string(got), ".mcp.json")
+		if count != 1 {
+			t.Errorf("expected exactly 1 occurrence of .mcp.json, got %d in:\n%s", count, got)
+		}
+	})
+
+	t.Run("creates exclude file when missing but info dir exists", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
+			t.Fatalf("ensureGitInfoExclude: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+		if err != nil {
+			t.Fatalf("exclude file not created: %v", err)
+		}
+		if strings.TrimSpace(string(got)) != ".mcp.json" {
+			t.Errorf("expected only .mcp.json, got: %q", got)
+		}
+	})
+
+	t.Run("no-op when .git/info/ does not exist", func(t *testing.T) {
+		repo := t.TempDir()
+		// Only create .git/, not .git/info/.
+		if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
+			t.Errorf("expected no-op when .git/info/ missing, got error: %v", err)
+		}
+		// And no exclude file should be created.
+		if _, err := os.Stat(filepath.Join(repo, ".git", "info", "exclude")); err == nil {
+			t.Errorf("exclude file should not have been created when .git/info/ missing")
+		}
+	})
+
+	t.Run("treats existing entry with surrounding whitespace as already present", func(t *testing.T) {
+		repo := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, ".git", "info"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		excludePath := filepath.Join(repo, ".git", "info", "exclude")
+		// Tab/space-padded entry — git's matching ignores surrounding whitespace.
+		if err := os.WriteFile(excludePath, []byte("  .mcp.json\t\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureGitInfoExclude(repo, ".mcp.json"); err != nil {
+			t.Fatalf("ensureGitInfoExclude: %v", err)
+		}
+		got, _ := os.ReadFile(excludePath)
+		if strings.Count(string(got), ".mcp.json") != 1 {
+			t.Errorf("padded existing entry should be detected; got:\n%s", got)
+		}
+	})
 }

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -130,6 +130,12 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 	if !strings.Contains(string(data), dir) {
 		t.Errorf("instance .mcp.json missing instanceRoot %q: %s", dir, data)
 	}
+	if !strings.Contains(string(data), "NIWA_SESSION_ROLE") {
+		t.Errorf("instance .mcp.json missing NIWA_SESSION_ROLE: %s", data)
+	}
+	if !strings.Contains(string(data), `"coordinator"`) {
+		t.Errorf("instance .mcp.json NIWA_SESSION_ROLE must be coordinator: %s", data)
+	}
 	var mcpDoc map[string]any
 	if err := json.Unmarshal(data, &mcpDoc); err != nil {
 		t.Errorf("instance .mcp.json is not valid JSON: %v", err)

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -68,9 +68,10 @@ func TestInstallChannelInfrastructure_NoopWhenDisabled(t *testing.T) {
 // TestInstallChannelInfrastructure_CreatesRoleLayout checks AC-P1, AC-P2,
 // AC-R1, AC-P5, AC-P6, AC-P7, AC-P8, AC-P15: for every enumerated role
 // (coordinator + topology-derived), the full per-role inbox tree is
-// present, plus .niwa/tasks/, daemon.pid/log, .mcp.json mirrored per
-// repo, SKILL.md mirrored per repo, and a ## Channels section in
-// workspace-context.md with the four required items.
+// present, plus .niwa/tasks/, daemon.pid/log, an instance-root .mcp.json
+// (the single project-scoped file Claude Code's discovery reads via
+// directory-tree walk-up), SKILL.md mirrored per repo, and a ## Channels
+// section in workspace-context.md with the four required items.
 func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 	dir := t.TempDir()
 	seedRepo(t, dir, "apps", "web")
@@ -115,8 +116,11 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("daemon.log missing: %v", err)
 	}
 
-	// .mcp.json at instance root.
-	instanceMCP := filepath.Join(dir, ".claude", ".mcp.json")
+	// .mcp.json at instance root (NOT under .claude/). Claude Code's
+	// discovery reads `<cwd>/.mcp.json` at the directory root and walks
+	// up; placing it here makes it visible to coordinator sessions
+	// started either at the instance root or from any sub-repo.
+	instanceMCP := filepath.Join(dir, ".mcp.json")
 	data, err := os.ReadFile(instanceMCP)
 	if err != nil {
 		t.Fatalf("instance .mcp.json not written: %v", err)
@@ -132,11 +136,18 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("instance .mcp.json is not valid JSON: %v", err)
 	}
 
-	// .mcp.json mirrored to each repo.
+	// Per-repo `.mcp.json` mirrors are intentionally NOT written; the
+	// instance-root file covers sub-repos via Claude's directory walk-up
+	// (and a per-repo file at the repo root would commit the local
+	// binary path and instance root into upstream history).
 	for _, role := range []string{"web", "api"} {
-		p := filepath.Join(dir, "apps", role, ".claude", ".mcp.json")
-		if _, err := os.Stat(p); err != nil {
-			t.Errorf("repo .mcp.json for %q missing: %v", role, err)
+		legacyOld := filepath.Join(dir, "apps", role, ".claude", ".mcp.json")
+		if _, err := os.Stat(legacyOld); err == nil {
+			t.Errorf("legacy per-repo .claude/.mcp.json should not be written for %q", role)
+		}
+		repoRoot := filepath.Join(dir, "apps", role, ".mcp.json")
+		if _, err := os.Stat(repoRoot); err == nil {
+			t.Errorf("per-repo .mcp.json should not be written at repo root for %q", role)
 		}
 	}
 
@@ -290,7 +301,7 @@ func TestInstallChannelInfrastructure_Idempotent(t *testing.T) {
 	}
 
 	skillPath := filepath.Join(dir, ".claude", "skills", "niwa-mesh", "SKILL.md")
-	mcpPath := filepath.Join(dir, ".claude", ".mcp.json")
+	mcpPath := filepath.Join(dir, ".mcp.json")
 
 	firstSkill, _ := os.ReadFile(skillPath)
 	firstMCP, _ := os.ReadFile(mcpPath)
@@ -431,11 +442,10 @@ func TestInstallChannelInfrastructure_DirAndFileModes(t *testing.T) {
 		t.Fatalf("walking .niwa/: %v", err)
 	}
 
-	// .mcp.json and SKILL.md also must be 0600.
+	// .mcp.json (instance root) and SKILL.md also must be 0600.
 	for _, p := range []string{
-		filepath.Join(dir, ".claude", ".mcp.json"),
+		filepath.Join(dir, ".mcp.json"),
 		filepath.Join(dir, ".claude", "skills", "niwa-mesh", "SKILL.md"),
-		filepath.Join(dir, "apps", "web", ".claude", ".mcp.json"),
 		filepath.Join(dir, "apps", "web", ".claude", "skills", "niwa-mesh", "SKILL.md"),
 	} {
 		fi, err := os.Stat(p)

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -69,8 +69,8 @@ func TestInstallChannelInfrastructure_NoopWhenDisabled(t *testing.T) {
 // AC-R1, AC-P5, AC-P6, AC-P7, AC-P8, AC-P15: for every enumerated role
 // (coordinator + topology-derived), the full per-role inbox tree is
 // present, plus .niwa/tasks/, daemon.pid/log, an instance-root .mcp.json
-// (the single project-scoped file Claude Code's discovery reads via
-// directory-tree walk-up), SKILL.md mirrored per repo, and a ## Channels
+// (project-scoped file Claude Code reads from <cwd>/.mcp.json; per-cwd,
+// no parent walk-up), SKILL.md mirrored per repo, and a ## Channels
 // section in workspace-context.md with the four required items.
 func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 	dir := t.TempDir()
@@ -116,12 +116,9 @@ func TestInstallChannelInfrastructure_CreatesRoleLayout(t *testing.T) {
 		t.Errorf("daemon.log missing: %v", err)
 	}
 
-	// `.mcp.json` lives at the instance root only. Claude Code's MCP
-	// discovery is per-cwd (no parent walk-up); the PRD's headline
-	// scenario is "open one Claude at the instance root and ask it to
-	// delegate," so the instance root is the only cwd niwa needs to
-	// cover. The file is NOT under `.claude/` — Claude Code reads
-	// `.mcp.json` directly at the directory root.
+	// `.mcp.json` lives at the instance root only — at the directory
+	// root, not under `.claude/`. Rationale lives at the call site in
+	// channels.go.
 	instanceMCP := filepath.Join(dir, ".mcp.json")
 	data, err := os.ReadFile(instanceMCP)
 	if err != nil {
@@ -781,7 +778,10 @@ func TestInjectChannelHooks_PrependToExisting(t *testing.T) {
 
 func TestBuildMCPContent_InstanceRootEscaping(t *testing.T) {
 	instanceRoot := "/some/path/with spaces"
-	data := buildMCPContent(instanceRoot)
+	data, err := buildMCPContent(instanceRoot)
+	if err != nil {
+		t.Fatalf("buildMCPContent: %v", err)
+	}
 
 	var doc map[string]any
 	if err := json.Unmarshal(data, &doc); err != nil {
@@ -794,6 +794,18 @@ func TestBuildMCPContent_InstanceRootEscaping(t *testing.T) {
 	got := env["NIWA_INSTANCE_ROOT"].(string)
 	if got != instanceRoot {
 		t.Errorf("NIWA_INSTANCE_ROOT: got %q, want %q", got, instanceRoot)
+	}
+}
+
+// TestBuildMCPContent_RejectsInvalidUTF8 documents the contract that
+// invalid UTF-8 in the instance root surfaces as a build error rather
+// than producing malformed JSON. Reachable in production only on
+// filesystems with mojibake-encoded paths; covered here as a defense
+// against a regression that would silently ship a broken .mcp.json.
+func TestBuildMCPContent_RejectsInvalidUTF8(t *testing.T) {
+	bad := "/path/with/invalid\xff\xfeutf8"
+	if _, err := buildMCPContent(bad); err == nil {
+		t.Errorf("expected error for invalid UTF-8 in instance root, got nil")
 	}
 }
 

--- a/test/functional/features/mesh.feature
+++ b/test/functional/features/mesh.feature
@@ -232,6 +232,103 @@ Feature: Cross-session mesh (Issue #10 harness)
     And the file "apps/backend/.mcp.json" does not exist in instance "mcp-layout"
     And the file "apps/backend/.claude/.mcp.json" does not exist in instance "mcp-layout"
 
+  # Single-repo channeled workspace: the simplest topology that engages
+  # per-repo role enumeration without exercising multi-repo collision
+  # logic. Asserts the instance-root .mcp.json is the sole MCP config
+  # written (the per-repo dir gets its niwa-mesh skill but no .mcp.json).
+  @critical
+  Scenario: single-repo channeled workspace provisions instance-root .mcp.json only
+    Given a clean niwa environment
+    And a local git server is set up
+    And a single-repo channeled workspace "single-repo-mcp" exists
+    When I run "niwa create single-repo-mcp"
+    Then the exit code is 0
+    And the file ".mcp.json" exists in instance "single-repo-mcp"
+    And the file "apps/app/.mcp.json" does not exist in instance "single-repo-mcp"
+    And the file "apps/app/.claude/.mcp.json" does not exist in instance "single-repo-mcp"
+    And the file "apps/app/.claude/skills/niwa-mesh/SKILL.md" exists in instance "single-repo-mcp"
+    And the file ".niwa/roles/coordinator/inbox" exists in instance "single-repo-mcp"
+    And the file ".niwa/roles/app/inbox" exists in instance "single-repo-mcp"
+
+  # Drift recovery: the channels installer's writeIdempotent path must
+  # restore a managed file after a user manually removes it. Without
+  # this, an operator who clears `.mcp.json` thinking they're "resetting"
+  # would silently lose the niwa MCP server and `niwa apply` would
+  # fix nothing on the next run.
+  @critical
+  Scenario: niwa apply restores manually-deleted instance .mcp.json
+    Given a clean niwa environment
+    And a local git server is set up
+    And a multi-repo channeled workspace "mcp-drift" with web and backend exists
+    When I run "niwa create mcp-drift"
+    Then the exit code is 0
+    And the file ".mcp.json" exists in instance "mcp-drift"
+    When I delete file ".mcp.json" in instance "mcp-drift"
+    And I run "niwa apply mcp-drift"
+    Then the exit code is 0
+    And the file ".mcp.json" exists in instance "mcp-drift"
+
+  # Pre-1.0 migration: the channel installer's migratePre1Layout helper
+  # must remove .niwa/sessions/<uuid>/ directories on the first apply
+  # under the new model. The legacy session dirs predate the role-based
+  # mesh and would otherwise bloat .niwa/ across upgrades.
+  @critical
+  Scenario: niwa apply --channels migrates a pre-1.0 .niwa/sessions/ layout
+    Given a clean niwa environment
+    And a local git server is set up
+    And a single-repo channeled workspace "mcp-migrate" exists
+    When I run "niwa create mcp-migrate"
+    Then the exit code is 0
+    # Plant a legacy session directory and rewind the new layout so the
+    # migration helper sees pre-1.0 state on the next apply (it short-
+    # circuits when .niwa/roles/ already exists).
+    When I delete directory ".niwa/roles" in instance "mcp-migrate"
+    And I plant a legacy session directory "11111111-2222-4333-8444-555555555555" in instance "mcp-migrate"
+    And I run "niwa apply mcp-migrate"
+    Then the exit code is 0
+    And the file ".niwa/sessions/11111111-2222-4333-8444-555555555555" does not exist in instance "mcp-migrate"
+    And the file ".niwa/roles/coordinator/inbox" exists in instance "mcp-migrate"
+
+  # Virtual-peer roles: a workspace with [channels.mesh.roles] entries
+  # whose values are empty strings creates inboxes for those roles
+  # without requiring a corresponding cloned repo. Useful for peers
+  # that exist outside the workspace topology (for example a host-side
+  # human or a separate process that participates as a niwa role).
+  # Asserts that the inbox tree is provisioned and no per-repo writes
+  # are attempted for paths that don't exist.
+  @critical
+  Scenario: virtual-peer roles via [channels.mesh.roles] provision inboxes only
+    Given a clean niwa environment
+    And a local git server is set up
+    And a channeled workspace "virtual-peer-ws" exists
+    When I run "niwa create virtual-peer-ws"
+    Then the exit code is 0
+    And the file ".mcp.json" exists in instance "virtual-peer-ws"
+    And the file ".niwa/roles/coordinator/inbox" exists in instance "virtual-peer-ws"
+    And the file ".niwa/roles/worker/inbox" exists in instance "virtual-peer-ws"
+    And the file ".niwa/roles/coordinator/inbox/in-progress" exists in instance "virtual-peer-ws"
+    And the file ".niwa/roles/worker/inbox/expired" exists in instance "virtual-peer-ws"
+
+  # --no-channels disable round-trip: enable channels via the synthesized
+  # path (--channels flag, no [channels.mesh] in config), then re-apply
+  # with --no-channels. Asserts the instance-root .mcp.json and the
+  # niwa-mesh skill are removed from ManagedFiles by cleanRemovedFiles.
+  # Runtime artifacts under .niwa/roles/ and .niwa/tasks/ are left in
+  # place — see issue #75 for the proper teardown design.
+  @critical
+  Scenario: niwa apply --no-channels removes the instance-root .mcp.json
+    Given a clean niwa environment
+    And a local git server is set up
+    And a single-repo channeled workspace "mcp-toggle" exists
+    When I run "niwa create mcp-toggle"
+    Then the exit code is 0
+    And the file ".mcp.json" exists in instance "mcp-toggle"
+    And the file ".claude/skills/niwa-mesh/SKILL.md" exists in instance "mcp-toggle"
+    When I run "niwa apply mcp-toggle --no-channels"
+    Then the exit code is 0
+    And the file ".mcp.json" does not exist in instance "mcp-toggle"
+    And the file ".claude/skills/niwa-mesh/SKILL.md" does not exist in instance "mcp-toggle"
+
   # ---------------------------------------------------------------------
   # @channels-e2e (Issue #11): real `claude -p` scenarios. These cover
   # niwa surface the deterministic fake worker cannot reach — namely

--- a/test/functional/features/mesh.feature
+++ b/test/functional/features/mesh.feature
@@ -207,7 +207,7 @@ Feature: Cross-session mesh (Issue #10 harness)
   # ---------------------------------------------------------------------
   # @channels-e2e (Issue #11): real `claude -p` scenarios. These cover
   # niwa surface the deterministic fake worker cannot reach — namely
-  # (1) that Claude Code can load `.claude/.mcp.json`, launch
+  # (1) that Claude Code can load the instance-root `.mcp.json`, launch
   # `niwa mcp-serve`, and the first MCP tool call succeeds, and (2) that
   # niwa's fixed bootstrap prompt drives a real LLM to call
   # `niwa_check_messages` and then `niwa_finish_task` to completion.
@@ -224,14 +224,14 @@ Feature: Cross-session mesh (Issue #10 harness)
   # ---------------------------------------------------------------------
 
   @channels-e2e
-  Scenario: MCP-config loadability — claude -p can load .claude/.mcp.json and call niwa_check_messages
+  Scenario: MCP-config loadability — claude -p can load instance-root .mcp.json and call niwa_check_messages
     Given a clean niwa environment
     And claude is available
     And a local git server is set up
     And a channeled workspace "mcp-loadability" exists
     When I run "niwa create mcp-loadability"
     Then the exit code is 0
-    And the file ".claude/.mcp.json" exists in instance "mcp-loadability"
+    And the file ".mcp.json" exists in instance "mcp-loadability"
     When I run claude -p preserving case from instance root "mcp-loadability" with prompt:
       """
       Use the niwa_check_messages tool to check your inbox and output exactly: CHECKED:<count>, where <count> is the number of messages. Do not explain.

--- a/test/functional/features/mesh.feature
+++ b/test/functional/features/mesh.feature
@@ -204,6 +204,33 @@ Feature: Cross-session mesh (Issue #10 harness)
     Then the exit code is 0
     Then an unauthorized MCP call for instance "auth-neg-ws" receives NOT_TASK_PARTY
 
+  # MCP config layout regression: Claude Code's MCP discovery loads
+  # `<cwd>/.mcp.json` at the directory root and does not walk parents.
+  # The file therefore lives at the directory root of every cwd a
+  # coordinator might launch Claude in: the instance root and every
+  # cloned repo. The legacy `.claude/.mcp.json` path is never read by
+  # Claude Code's discovery and must not be written; if niwa writes
+  # there, the headline scenario (open Claude in the instance root,
+  # delegate work) silently lacks niwa MCP tools.
+  #
+  # This scenario does not invoke claude — it asserts the on-disk
+  # layout is correct. The bug it guards against shipped in v0.9.0
+  # because every test that did invoke claude bypassed discovery via
+  # `--mcp-config <path> --strict-mcp-config`.
+  @critical
+  Scenario: MCP config layout — instance-root and per-repo files at directory roots
+    Given a clean niwa environment
+    And a local git server is set up
+    And a multi-repo channeled workspace "mcp-layout" with web and backend exists
+    When I run "niwa create mcp-layout"
+    Then the exit code is 0
+    And the file ".mcp.json" exists in instance "mcp-layout"
+    And the file ".claude/.mcp.json" does not exist in instance "mcp-layout"
+    And the file "apps/web/.mcp.json" exists in instance "mcp-layout"
+    And the file "apps/web/.claude/.mcp.json" does not exist in instance "mcp-layout"
+    And the file "apps/backend/.mcp.json" exists in instance "mcp-layout"
+    And the file "apps/backend/.claude/.mcp.json" does not exist in instance "mcp-layout"
+
   # ---------------------------------------------------------------------
   # @channels-e2e (Issue #11): real `claude -p` scenarios. These cover
   # niwa surface the deterministic fake worker cannot reach — namely

--- a/test/functional/features/mesh.feature
+++ b/test/functional/features/mesh.feature
@@ -205,20 +205,21 @@ Feature: Cross-session mesh (Issue #10 harness)
     Then an unauthorized MCP call for instance "auth-neg-ws" receives NOT_TASK_PARTY
 
   # MCP config layout regression: Claude Code's MCP discovery loads
-  # `<cwd>/.mcp.json` at the directory root and does not walk parents.
-  # The file therefore lives at the directory root of every cwd a
-  # coordinator might launch Claude in: the instance root and every
-  # cloned repo. The legacy `.claude/.mcp.json` path is never read by
-  # Claude Code's discovery and must not be written; if niwa writes
-  # there, the headline scenario (open Claude in the instance root,
-  # delegate work) silently lacks niwa MCP tools.
+  # `<cwd>/.mcp.json` at the directory root and does not walk parent
+  # directories. Niwa writes only `<instance>/.mcp.json` — the PRD's
+  # headline scenario opens Claude at the instance root, where that
+  # file is what discovery resolves. No per-repo files: writing
+  # `<repoDir>/.mcp.json` would collide destructively with any project
+  # that ships its own MCP config (see issue #78). The legacy
+  # `.claude/.mcp.json` path Claude Code never reads must not be
+  # written either.
   #
   # This scenario does not invoke claude — it asserts the on-disk
   # layout is correct. The bug it guards against shipped in v0.9.0
   # because every test that did invoke claude bypassed discovery via
   # `--mcp-config <path> --strict-mcp-config`.
   @critical
-  Scenario: MCP config layout — instance-root and per-repo files at directory roots
+  Scenario: MCP config layout — instance-root only, no per-repo files
     Given a clean niwa environment
     And a local git server is set up
     And a multi-repo channeled workspace "mcp-layout" with web and backend exists
@@ -226,9 +227,9 @@ Feature: Cross-session mesh (Issue #10 harness)
     Then the exit code is 0
     And the file ".mcp.json" exists in instance "mcp-layout"
     And the file ".claude/.mcp.json" does not exist in instance "mcp-layout"
-    And the file "apps/web/.mcp.json" exists in instance "mcp-layout"
+    And the file "apps/web/.mcp.json" does not exist in instance "mcp-layout"
     And the file "apps/web/.claude/.mcp.json" does not exist in instance "mcp-layout"
-    And the file "apps/backend/.mcp.json" exists in instance "mcp-layout"
+    And the file "apps/backend/.mcp.json" does not exist in instance "mcp-layout"
     And the file "apps/backend/.claude/.mcp.json" does not exist in instance "mcp-layout"
 
   # ---------------------------------------------------------------------

--- a/test/functional/features/mesh.feature
+++ b/test/functional/features/mesh.feature
@@ -309,6 +309,20 @@ Feature: Cross-session mesh (Issue #10 harness)
     And the file ".niwa/roles/coordinator/inbox/in-progress" exists in instance "virtual-peer-ws"
     And the file ".niwa/roles/worker/inbox/expired" exists in instance "virtual-peer-ws"
 
+  # AC-P5: the channels installer must create .niwa/sessions/sessions.json
+  # at apply time so `niwa session list` and the coordinator-session
+  # registry probes find a well-formed file from the start, not a lazy-
+  # create on first `niwa session register`. The file is created only
+  # if absent — re-apply must not overwrite a populated registry.
+  @critical
+  Scenario: niwa create provisions .niwa/sessions/sessions.json (AC-P5)
+    Given a clean niwa environment
+    And a local git server is set up
+    And a single-repo channeled workspace "session-registry-ws" exists
+    When I run "niwa create session-registry-ws"
+    Then the exit code is 0
+    And the file ".niwa/sessions/sessions.json" exists in instance "session-registry-ws"
+
   # --no-channels disable round-trip: enable channels via the synthesized
   # path (--channels flag, no [channels.mesh] in config), then re-apply
   # with --no-channels. Asserts the instance-root .mcp.json and the

--- a/test/functional/mesh_steps_test.go
+++ b/test/functional/mesh_steps_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/tsukumogami/niwa/internal/mcp"
+	"github.com/tsukumogami/niwa/internal/workspace"
 )
 
 // mesh_steps_test.go holds the step definitions introduced by Issue #10
@@ -1192,14 +1193,20 @@ func runClaudePPreservingCaseCtx(ctx context.Context, s *testState, cwd, prompt 
 	// sandboxed PATH doesn't include one. We set the role explicitly here
 	// so the MCP child inherits it from the coordinator claude's env.
 	env = append(env, "NIWA_SESSION_ROLE=coordinator")
-	mcpConfigPath := filepath.Join(cwd, ".mcp.json")
-	// Flags mirror the daemon's spawnWorker (see mesh_watch.go): acceptEdits
-	// + explicit mcp__niwa__* allow-list. Without the allow-list the
-	// coordinator blocks on the first MCP tool-approval prompt (headless
-	// `-p` mode cannot answer it). The canonical list lives in
+	mcpConfigPath := workspace.InstanceMCPConfigPath(cwd)
+	// This launcher pins the MCP config explicitly via --mcp-config +
+	// --strict-mcp-config because the test sandbox cannot rely on
+	// cwd-rooted discovery (no host-installed claude config). Real
+	// human-launched coordinators DO rely on discovery and must NOT pass
+	// these flags — see internal/cli/mesh_watch.go::spawnWorker for the
+	// asymmetry between the worker and coordinator launch contracts.
+	//
+	// --permission-mode=acceptEdits + --allowed-tools mirrors the worker
+	// argv because in headless `-p` mode the coordinator can't answer
+	// approval prompts either. The canonical allowed-tools list lives in
 	// internal/mcp/allowed_tools.go; both spawnWorker and this launcher
-	// must reference it so a new MCP tool added in one place can't
-	// silently fail to be approved in the other.
+	// reference it so a new MCP tool added in one place can't silently
+	// fail to be approved in the other.
 	cmd := exec.CommandContext(ctx, claudeBin,
 		"-p", prompt,
 		"--permission-mode=acceptEdits",

--- a/test/functional/mesh_steps_test.go
+++ b/test/functional/mesh_steps_test.go
@@ -58,6 +58,105 @@ worker = ""
 	return ctx, nil
 }
 
+// iSetUpSingleRepoChanneledWorkspace creates one bare source repo named
+// "app" under group "apps" plus a config repo with [channels.mesh]. After
+// `niwa create` the instance layout is `<instance>/apps/app/`, and channel
+// role derivation yields "coordinator" (instance root) + "app". Use to
+// exercise the simplest topology that triggers per-repo role enumeration
+// without engaging multi-repo collision logic.
+func iSetUpSingleRepoChanneledWorkspace(ctx context.Context, name string) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	url, err := s.gitServer.Repo("app")
+	if err != nil {
+		return ctx, fmt.Errorf("creating source repo %q: %w", "app", err)
+	}
+	s.repoURLs["app"] = url
+
+	body := fmt.Sprintf(`[workspace]
+name = %q
+
+[channels.mesh]
+
+[groups.apps]
+
+[repos.app]
+url = %q
+group = "apps"
+`, name, url)
+	cfgURL, err := s.gitServer.ConfigRepo(name, body)
+	if err != nil {
+		return ctx, fmt.Errorf("creating config repo %q: %w", name, err)
+	}
+	s.repoURLs[name] = cfgURL
+	if err := runNiwa(s, s.workspaceRoot, "niwa init --from "+cfgURL); err != nil {
+		return ctx, err
+	}
+	if s.exitCode != 0 {
+		return ctx, fmt.Errorf("niwa init exit=%d\nstdout:\n%s\nstderr:\n%s",
+			s.exitCode, s.stdout, s.stderr)
+	}
+	return ctx, nil
+}
+
+// iDeleteFileInInstance removes a file at relPath under the named
+// instance. Errors when the file isn't there (drift-recovery scenarios
+// must start from a known-present state); use this to simulate manual
+// deletion of a managed file the next apply must restore.
+func iDeleteFileInInstance(ctx context.Context, relPath, instance string) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	path := filepath.Join(s.workspaceRoot, instance, relPath)
+	if _, err := os.Stat(path); err != nil {
+		return ctx, fmt.Errorf("cannot delete %q: %w", path, err)
+	}
+	if err := os.Remove(path); err != nil {
+		return ctx, fmt.Errorf("removing %s: %w", path, err)
+	}
+	return ctx, nil
+}
+
+// iDeleteDirectoryInInstance recursively removes a directory at relPath
+// under the named instance. Errors when the path isn't there; use to
+// simulate operator state-resets the next apply must reconcile.
+func iDeleteDirectoryInInstance(ctx context.Context, relPath, instance string) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	path := filepath.Join(s.workspaceRoot, instance, relPath)
+	if _, err := os.Stat(path); err != nil {
+		return ctx, fmt.Errorf("cannot delete %q: %w", path, err)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return ctx, fmt.Errorf("removing %s: %w", path, err)
+	}
+	return ctx, nil
+}
+
+// iPlantLegacySessionDir creates a `.niwa/sessions/<uuid>/` directory in
+// the named instance to simulate a pre-1.0 mesh layout. The next
+// `niwa apply --channels` is expected to detect and remove it.
+func iPlantLegacySessionDir(ctx context.Context, uuid, instance string) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	dir := filepath.Join(s.workspaceRoot, instance, ".niwa", "sessions", uuid)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return ctx, fmt.Errorf("planting legacy session dir: %w", err)
+	}
+	// Drop a marker file so we can later assert the directory was actually removed.
+	if err := os.WriteFile(filepath.Join(dir, "marker"), []byte("legacy"), 0o600); err != nil {
+		return ctx, fmt.Errorf("writing marker: %w", err)
+	}
+	return ctx, nil
+}
+
 // iSetUpMultiRepoChanneledWorkspace creates two bare source repos named
 // "web" and "backend", then a config repo whose workspace.toml places both
 // under group "apps" and enables [channels.mesh] with topology-derived

--- a/test/functional/mesh_steps_test.go
+++ b/test/functional/mesh_steps_test.go
@@ -1192,7 +1192,7 @@ func runClaudePPreservingCaseCtx(ctx context.Context, s *testState, cwd, prompt 
 	// sandboxed PATH doesn't include one. We set the role explicitly here
 	// so the MCP child inherits it from the coordinator claude's env.
 	env = append(env, "NIWA_SESSION_ROLE=coordinator")
-	mcpConfigPath := filepath.Join(cwd, ".claude", ".mcp.json")
+	mcpConfigPath := filepath.Join(cwd, ".mcp.json")
 	// Flags mirror the daemon's spawnWorker (see mesh_watch.go): acceptEdits
 	// + explicit mcp__niwa__* allow-list. Without the allow-list the
 	// coordinator blocks on the first MCP tool-approval prompt (headless

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -303,6 +303,10 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 
 	// --- @channels-e2e-graph: real coordinator -> real workers delegation graph ---
 	ctx.Step(`^a multi-repo channeled workspace "([^"]*)" with web and backend exists$`, iSetUpMultiRepoChanneledWorkspace)
+	ctx.Step(`^a single-repo channeled workspace "([^"]*)" exists$`, iSetUpSingleRepoChanneledWorkspace)
+	ctx.Step(`^I plant a legacy session directory "([^"]*)" in instance "([^"]*)"$`, iPlantLegacySessionDir)
+	ctx.Step(`^I delete file "([^"]*)" in instance "([^"]*)"$`, iDeleteFileInInstance)
+	ctx.Step(`^I delete directory "([^"]*)" in instance "([^"]*)"$`, iDeleteDirectoryInInstance)
 	ctx.Step(`^I run claude -p preserving case from instance root "([^"]*)" within (\d+) seconds with prompt:$`, iRunClaudePFromInstanceRootPreservingCaseWithin)
 	ctx.Step(`^the file "([^"]*)" in repo "([^"]*)" of instance "([^"]*)" exactly matches "([^"]*)"$`, theFileInRepoOfInstanceExactlyMatches)
 	ctx.Step(`^exactly (\d+) tasks in instance "([^"]*)" are in state "completed"$`, func(ctx context.Context, n int, instance string) error {


### PR DESCRIPTION
Two bugs prevented the coordinator MCP server from working when \`claude\` is opened at the instance root. First, \`niwa apply --channels\` wrote the MCP config to \`<instance>/.claude/.mcp.json\` — a path Claude Code's discovery never reads. Discovery loads \`<cwd>/.mcp.json\` at the directory root only. Second, the generated config's env block only included \`NIWA_INSTANCE_ROOT\`; without \`NIWA_SESSION_ROLE\`, the MCP server had no role and every inbox tool (\`niwa_check_messages\`, \`niwa_send_message\`, \`niwa_ask\`) returned "no inbox dir configured" on every call. Daemon-spawned workers were unaffected by both bugs because \`spawnWorker\` passes \`--mcp-config <abs-path>\` explicitly and injects \`NIWA_SESSION_ROLE\` via env overrides — which also explains why the existing \`@channels-e2e\` scenarios didn't catch either bug.

The fix moves the config to \`<instance>/.mcp.json\` and adds \`"NIWA_SESSION_ROLE": "coordinator"\` to the env block. The instance-root config is the coordinator's config; workers always receive \`NIWA_SESSION_ROLE\` from the daemon's spawn contract.

Additional changes in this PR:

- Extract \`workspace.InstanceMCPConfigPath(instanceRoot)\` so the channels installer, \`spawnWorker\`, and the functional-test coordinator launcher all reference one path instead of computing it independently.
- Add a \`utf8.ValidString\` guard in \`buildMCPContent\` so invalid bytes in the binary path or instance root surface as a clear apply-time error rather than a silent U+FFFD substitution in the generated JSON.
- Provision \`.niwa/sessions/sessions.json\` at apply time (AC-P5); previously the file was created lazily on first \`niwa session register\`, leaving \`niwa session list\` failing on a fresh instance.
- Add six \`@critical\` scenarios covering the MCP config layout regression, single-repo topology, drift recovery, pre-1.0 migration, virtual-peer roles, and session-registry provisioning.
- Update the design doc, PRD, and user guide to document the workspace-root-only model and the \`--mcp-config\` escape hatch for sub-repo cwd launches.

Per-repo \`.mcp.json\` files are intentionally not written: a file at \`<repoDir>/.mcp.json\` would collide with any project that ships its own MCP config. Sub-repo cwd launches are reachable via \`--mcp-config=<instance>/.mcp.json\`. Issue #78 tracks the longer-term strategy. The \`cleanRemovedFiles\` mechanism in \`apply.go\` handles existing workspaces on the next apply: the old \`.claude/.mcp.json\` paths drop out of \`InstanceState.ManagedFiles\` and are removed automatically.

---

## What This Fixes

**Path bug:** Claude Code's MCP discovery reads \`<cwd>/.mcp.json\` at the directory root. Niwa was writing the config under \`.claude/\`, which discovery never reads. A coordinator opened at the instance root never had the niwa MCP server available.

**Missing role bug:** Even after the path fix, the generated config's env block only contained \`NIWA_INSTANCE_ROOT\`. The MCP server uses \`NIWA_SESSION_ROLE\` to locate its inbox directory; without it, \`niwa_check_messages\` and all other inbox tools failed immediately on every call.

Both bugs shipped in v0.9.0.

## Test Plan

- [x] \`go vet ./...\` — clean
- [x] \`go test -race ./... -count=1\` — clean
- [x] \`make test-functional-critical\` — 56 scenarios pass in ~12 s, including six new \`@critical\` scenarios this PR adds:
  - \`MCP config layout — instance-root only, no per-repo files\` (regression guard)
  - \`single-repo channeled workspace provisions instance-root .mcp.json only\`
  - \`niwa apply restores manually-deleted instance .mcp.json\` (drift recovery)
  - \`niwa apply --channels migrates a pre-1.0 .niwa/sessions/ layout\`
  - \`virtual-peer roles via [channels.mesh.roles] provision inboxes only\`
  - \`niwa apply --no-channels removes the instance-root .mcp.json\`
- [x] \`make test-functional NIWA_TEST_TAGS=channels-e2e\` — both real-claude scenarios pass (~12 s each): MCP-config loadability confirms \`claude -p\` at the instance root discovers \`.mcp.json\` and \`niwa_check_messages\` returns a valid result; bootstrap-prompt effectiveness confirms the daemon can spawn real workers to completion
- [x] \`TestSpawnArgvShape_FixedShape\` asserts the \`--mcp-config\` argument shape in daemon spawn

## Follow-up issues

Six findings from exploratory QA predate this PR and are tracked separately:

| # | Severity | Summary |
|---|---|---|
| #80 | important | Daemon does not refresh fsnotify watch set when apply adds/renames a role |
| #81 | nice-to-have | Stale role inboxes left behind after rename / role removal |
| #82 | important | \`niwa apply --no-channels\` leaves the daemon running |
| #83 | nice-to-have | Drift warnings duplicated for channels-managed files |
| #84 | blocker | \`niwa destroy\` leaves orphan daemon when \`daemon.pid\` is empty (reachable via #82) |
| #78 | strategy | Per-repo MCP config strategy — collision with upstream \`.mcp.json\` |

Fixes #76