### PR TITLE
fix(mesh): generate per-spawn worker MCP config with correct NIWA_SESSION_ROLE

### DIFF
--- a/internal/cli/mesh_watch.go
+++ b/internal/cli/mesh_watch.go
@@ -832,7 +832,42 @@ func handleInboxEvent(evt inboxEvent, s spawnContext) {
 // pipeline intentionally does not cover this case.
 func spawnWorker(evt inboxEvent, taskDir string, s spawnContext) {
 	prompt := fmt.Sprintf(bootstrapPromptTemplate, evt.taskID)
-	mcpConfigPath := workspace.InstanceMCPConfigPath(s.instanceRoot)
+
+	// Generate a per-spawn worker MCP config with the worker's actual role
+	// and task ID in the env block. Using the instance-root .mcp.json
+	// directly would cause Claude Code's env-block merge to override
+	// NIWA_SESSION_ROLE with "coordinator" (the value baked in for the
+	// coordinator path), so all workers would look in the coordinator inbox
+	// and find no task — producing retry_cap_exceeded on every delegation.
+	workerMCPContent, werr := workspace.WorkerMCPConfig(s.instanceRoot, evt.role, evt.taskID)
+	workerMCPPath := workspace.WorkerMCPConfigPath(s.instanceRoot, evt.taskID)
+	if werr == nil {
+		werr = os.WriteFile(workerMCPPath, workerMCPContent, 0o600)
+	}
+	if werr != nil {
+		s.logger.Printf("spawn_err role=%s task=%s worker_mcp_err=%v", evt.role, evt.taskID, werr)
+		_ = mcp.UpdateState(taskDir, func(cur *mcp.TaskState) (*mcp.TaskState, *mcp.TransitionLogEntry, error) {
+			if cur.State != mcp.TaskStateRunning {
+				return nil, nil, nil
+			}
+			now := time.Now().UTC().Format(time.RFC3339Nano)
+			next := *cur
+			next.State = mcp.TaskStateAbandoned
+			next.UpdatedAt = now
+			next.Reason = json.RawMessage(fmt.Sprintf(`{"error":"spawn_failed","detail":%q}`, werr.Error()))
+			next.StateTransitions = append(next.StateTransitions,
+				mcp.StateTransition{From: mcp.TaskStateRunning, To: mcp.TaskStateAbandoned, At: now})
+			entry := &mcp.TransitionLogEntry{
+				Kind: "spawn_failed",
+				From: mcp.TaskStateRunning,
+				To:   mcp.TaskStateAbandoned,
+				At:   now,
+				Actor: &mcp.TransitionActor{Kind: "daemon", PID: os.Getpid()},
+			}
+			return &next, entry, nil
+		})
+		return
+	}
 
 	// --permission-mode=acceptEdits auto-approves file edits but does NOT
 	// auto-approve MCP tool calls; a worker running in headless `-p` mode
@@ -854,7 +889,7 @@ func spawnWorker(evt inboxEvent, taskDir string, s spawnContext) {
 		s.spawnBin,
 		"-p", prompt,
 		"--permission-mode=acceptEdits",
-		"--mcp-config="+mcpConfigPath,
+		"--mcp-config="+workerMCPPath,
 		"--strict-mcp-config",
 		"--allowed-tools", strings.Join(mcp.ClaudeAllowedTools, ","),
 	)

--- a/internal/workspace/channels.go
+++ b/internal/workspace/channels.go
@@ -44,6 +44,46 @@ func InstanceMCPConfigPath(instanceRoot string) string {
 	return filepath.Join(instanceRoot, instanceMCPConfigName)
 }
 
+// WorkerMCPConfigPath returns the path where spawnWorker writes the per-spawn
+// worker MCP config. Lives inside the task directory so it is co-located with
+// envelope.json and state.json.
+func WorkerMCPConfigPath(instanceRoot, taskID string) string {
+	return filepath.Join(instanceRoot, ".niwa", "tasks", taskID, "worker.mcp.json")
+}
+
+// WorkerMCPConfig generates the JSON content for a per-spawn worker MCP
+// config. The generated file is passed to `claude -p` via --mcp-config so
+// that Claude Code's env-block processing delivers the correct
+// NIWA_SESSION_ROLE (the worker's actual role, not "coordinator") and
+// NIWA_TASK_ID to the niwa mcp-serve subprocess.
+//
+// Using a per-spawn config prevents the instance-root .mcp.json's hardcoded
+// NIWA_SESSION_ROLE=coordinator from overriding the worker's actual role when
+// Claude Code merges the env block on top of the inherited process environment.
+func WorkerMCPConfig(instanceRoot, role, taskID string) ([]byte, error) {
+	cmdPath, err := os.Executable()
+	if err != nil || cmdPath == "" {
+		cmdPath = "niwa"
+	}
+	if !utf8.ValidString(cmdPath) {
+		return nil, fmt.Errorf("niwa binary path is not valid UTF-8: %q", cmdPath)
+	}
+	if !utf8.ValidString(instanceRoot) {
+		return nil, fmt.Errorf("instance root is not valid UTF-8: %q", instanceRoot)
+	}
+	if !utf8.ValidString(role) {
+		return nil, fmt.Errorf("role is not valid UTF-8: %q", role)
+	}
+	if !utf8.ValidString(taskID) {
+		return nil, fmt.Errorf("task ID is not valid UTF-8: %q", taskID)
+	}
+	cmdJSON, _ := json.Marshal(cmdPath)
+	rootJSON, _ := json.Marshal(instanceRoot)
+	roleJSON, _ := json.Marshal(role)
+	taskIDJSON, _ := json.Marshal(taskID)
+	return []byte(fmt.Sprintf(workerMCPTemplate, string(cmdJSON), string(rootJSON), string(roleJSON), string(taskIDJSON))), nil
+}
+
 // channelsMCPTemplate is the template for the instance-root `.mcp.json`.
 // It registers the niwa mcp-serve command with NIWA_INSTANCE_ROOT baked in
 // so Claude Code can start the MCP server without any user configuration.
@@ -60,6 +100,30 @@ const channelsMCPTemplate = `{
       "env": {
         "NIWA_INSTANCE_ROOT": %s,
         "NIWA_SESSION_ROLE": "coordinator"
+      }
+    }
+  }
+}
+`
+
+// workerMCPTemplate is the per-spawn template for worker MCP config files.
+// Unlike channelsMCPTemplate (which hardcodes NIWA_SESSION_ROLE=coordinator
+// for the coordinator), this template takes the actual target role and task
+// ID as format arguments so each worker gets the right env block values.
+// Claude Code's env-block processing applies these on top of the spawned
+// process's inherited environment — having the correct values here ensures
+// the MCP subprocess always picks up the right role regardless of env
+// inheritance semantics.
+const workerMCPTemplate = `{
+  "mcpServers": {
+    "niwa": {
+      "type": "stdio",
+      "command": %s,
+      "args": ["mcp-serve"],
+      "env": {
+        "NIWA_INSTANCE_ROOT": %s,
+        "NIWA_SESSION_ROLE": %s,
+        "NIWA_TASK_ID": %s
       }
     }
   }

--- a/internal/workspace/channels_test.go
+++ b/internal/workspace/channels_test.go
@@ -829,6 +829,105 @@ func TestBuildMCPContent_RejectsInvalidUTF8(t *testing.T) {
 	}
 }
 
+// TestWorkerMCPConfigPath documents the path convention used by
+// spawnWorker (which writes the config) and the test harness (which
+// may need to read it). The file lives inside the task directory so
+// daemon and test can locate it with only instanceRoot + taskID.
+func TestWorkerMCPConfigPath(t *testing.T) {
+	got := WorkerMCPConfigPath("/inst", "abc-123")
+	want := "/inst/.niwa/tasks/abc-123/worker.mcp.json"
+	if got != want {
+		t.Errorf("WorkerMCPConfigPath = %q, want %q", got, want)
+	}
+}
+
+// TestWorkerMCPConfig_RoleAndTaskID verifies that WorkerMCPConfig bakes
+// the caller-supplied role and task ID into the env block, not the
+// coordinator role. This is the property that prevents Claude Code's
+// env-block merge from overriding NIWA_SESSION_ROLE=coordinator into
+// every worker.
+func TestWorkerMCPConfig_RoleAndTaskID(t *testing.T) {
+	instanceRoot := "/my/instance"
+	role := "web"
+	taskID := "task-42"
+
+	data, err := WorkerMCPConfig(instanceRoot, role, taskID)
+	if err != nil {
+		t.Fatalf("WorkerMCPConfig: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("invalid JSON: %v\ncontent: %s", err, data)
+	}
+	servers := doc["mcpServers"].(map[string]any)
+	niwa := servers["niwa"].(map[string]any)
+	env := niwa["env"].(map[string]any)
+
+	if got := env["NIWA_INSTANCE_ROOT"].(string); got != instanceRoot {
+		t.Errorf("NIWA_INSTANCE_ROOT: got %q, want %q", got, instanceRoot)
+	}
+	if got := env["NIWA_SESSION_ROLE"].(string); got != role {
+		t.Errorf("NIWA_SESSION_ROLE: got %q, want %q (must not be hardcoded coordinator)", got, role)
+	}
+	if got := env["NIWA_TASK_ID"].(string); got != taskID {
+		t.Errorf("NIWA_TASK_ID: got %q, want %q", got, taskID)
+	}
+}
+
+// TestWorkerMCPConfig_CoordinatorRole verifies that the coordinator role
+// is also handled correctly — coordinator tasks spawned by the daemon
+// (e.g. niwa_ask replies) must get NIWA_SESSION_ROLE=coordinator, not
+// "worker" or any other default.
+func TestWorkerMCPConfig_CoordinatorRole(t *testing.T) {
+	data, err := WorkerMCPConfig("/inst", "coordinator", "t-99")
+	if err != nil {
+		t.Fatalf("WorkerMCPConfig: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	env := doc["mcpServers"].(map[string]any)["niwa"].(map[string]any)["env"].(map[string]any)
+	if got := env["NIWA_SESSION_ROLE"].(string); got != "coordinator" {
+		t.Errorf("NIWA_SESSION_ROLE for coordinator spawn: got %q, want %q", got, "coordinator")
+	}
+}
+
+// TestWorkerMCPConfig_DistinctFromInstanceMCP confirms that a worker
+// config for a non-coordinator role differs from the instance-root
+// .mcp.json in exactly the NIWA_SESSION_ROLE and NIWA_TASK_ID fields.
+// This guards against a future refactor accidentally collapsing the two
+// templates back into one.
+func TestWorkerMCPConfig_DistinctFromInstanceMCP(t *testing.T) {
+	instanceRoot := "/inst"
+	workerData, err := WorkerMCPConfig(instanceRoot, "backend", "t-1")
+	if err != nil {
+		t.Fatalf("WorkerMCPConfig: %v", err)
+	}
+	coordData, err := buildMCPContent(instanceRoot)
+	if err != nil {
+		t.Fatalf("buildMCPContent: %v", err)
+	}
+
+	var workerDoc, coordDoc map[string]any
+	_ = json.Unmarshal(workerData, &workerDoc)
+	_ = json.Unmarshal(coordData, &coordDoc)
+
+	wEnv := workerDoc["mcpServers"].(map[string]any)["niwa"].(map[string]any)["env"].(map[string]any)
+	cEnv := coordDoc["mcpServers"].(map[string]any)["niwa"].(map[string]any)["env"].(map[string]any)
+
+	if wEnv["NIWA_SESSION_ROLE"] == cEnv["NIWA_SESSION_ROLE"] {
+		t.Errorf("worker and coordinator configs have the same NIWA_SESSION_ROLE=%q; worker must carry its actual role", wEnv["NIWA_SESSION_ROLE"])
+	}
+	if _, ok := wEnv["NIWA_TASK_ID"]; !ok {
+		t.Errorf("worker config is missing NIWA_TASK_ID")
+	}
+	if _, ok := cEnv["NIWA_TASK_ID"]; ok {
+		t.Errorf("coordinator config should not have NIWA_TASK_ID")
+	}
+}
+
 func TestWriteIdempotent_MatchingContentSkipsWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sub", "file.txt")

--- a/test/functional/features/mesh.feature
+++ b/test/functional/features/mesh.feature
@@ -390,6 +390,25 @@ Feature: Cross-session mesh (Issue #10 harness)
     When I queue a niwa_finish_task instruction for role "coordinator" in instance "bootstrap-e2e"
     Then the task state in instance "bootstrap-e2e" eventually becomes "completed" within 120 seconds
 
+  # Regression guard: workers dispatched to non-coordinator roles must
+  # receive NIWA_SESSION_ROLE=<their-role> in the MCP env block, not
+  # "coordinator". Before the per-spawn worker.mcp.json fix, Claude Code's
+  # env-block merge overrode NIWA_SESSION_ROLE to "coordinator" for every
+  # worker — they looked in the coordinator inbox, found no task, and
+  # exited without calling niwa_finish_task, producing retry_cap_exceeded.
+  @channels-e2e
+  Scenario: Worker with non-coordinator role receives correct role in MCP env block
+    Given a clean niwa environment
+    And claude is available
+    And a local git server is set up
+    And a channeled workspace "worker-role-e2e" exists
+    And the daemon uses the real claude worker spawn path
+    When I run "niwa create worker-role-e2e"
+    Then the exit code is 0
+    And the file ".niwa/daemon.pid" exists in instance "worker-role-e2e"
+    When I queue a niwa_finish_task instruction for role "worker" in instance "worker-role-e2e"
+    Then the task state in instance "worker-role-e2e" eventually becomes "completed" within 120 seconds
+
   # ---------------------------------------------------------------------
   # @channels-e2e-graph: full delegation graph with real LLMs on both
   # sides of the exchange. A coordinator `claude -p` runs at the instance


### PR DESCRIPTION
Add `WorkerMCPConfig` and `WorkerMCPConfigPath` to `workspace/channels.go`. Each daemon-spawned worker now gets a per-task `worker.mcp.json` written to its task directory, with the actual target role and task ID in the env block. `spawnWorker` in `cli/mesh_watch.go` writes this config before starting the worker process and passes it via `--mcp-config` instead of the instance-root `.mcp.json`.

---

## What This Fixes

The instance-root `.mcp.json` hardcodes `NIWA_SESSION_ROLE=coordinator` in its env block so the coordinator MCP server picks up the right role when Claude Code opens at the instance root. Workers also received this file via `--mcp-config`, so Claude Code's env-block merge overwrote `NIWA_SESSION_ROLE` with `coordinator` for every spawned worker. Workers then searched the coordinator inbox, found no task envelope, and exited without calling `niwa_finish_task`. After four attempts the daemon marked each task `abandoned` with `retry_cap_exceeded`.

The coordinator path is unchanged and continues to use the instance-root `.mcp.json`.

## Changes

- `internal/workspace/channels.go`: add `WorkerMCPConfig` (generates per-spawn JSON) and `WorkerMCPConfigPath` (path under `<taskDir>/worker.mcp.json`)
- `internal/cli/mesh_watch.go`: `spawnWorker` writes `worker.mcp.json` before `cmd.Start()` and passes it via `--mcp-config`
- `internal/workspace/channels_test.go`: four unit tests covering path contract, role/task-ID content, coordinator round-trip, and structural diff vs coordinator config
- `test/functional/features/mesh.feature`: new `@channels-e2e` scenario delegates to the `worker` role and asserts the task reaches `completed` — this scenario would have failed before the fix