### PR TITLE
fix(workspace): coordinator settings.json receives vault-resolved env vars

### DIFF
--- a/internal/workspace/apply_vault_test.go
+++ b/internal/workspace/apply_vault_test.go
@@ -1133,3 +1133,108 @@ visibility = "public"
 		t.Errorf("expected exactly 1 hit on universal-auth endpoint (proving overlay vault token injection ran), got %d", authHits)
 	}
 }
+
+// TestApplyCoordinatorReceivesVaultResolvedEnv confirms that after apply,
+// the coordinator (workspace root) settings.json receives the vault-resolved
+// plaintext for a claude.env promoted key — not the redacted "***" placeholder
+// that the former resolveEnvFromConfig code path produced. It also verifies
+// that settings.json is written with 0o600 permissions.
+func TestApplyCoordinatorReceivesVaultResolvedEnv(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	const resolvedToken = "ghp_coordinator-vault-resolved-xxxxx"
+
+	configTOML := `
+[workspace]
+name = "coordinator-vault-ws"
+
+[[sources]]
+org = "testorg"
+
+[groups.default]
+repos = ["app"]
+
+[vault.provider]
+kind = "fake"
+
+[vault.provider.values]
+GH_TOKEN = "` + resolvedToken + `"
+
+[env.secrets]
+GH_TOKEN = "vault://GH_TOKEN"
+
+[claude.env]
+promote = ["GH_TOKEN"]
+`
+
+	tmpDir := t.TempDir()
+	niwaDir := filepath.Join(tmpDir, ".niwa")
+	if err := os.MkdirAll(niwaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(niwaDir, "workspace.toml"), []byte(configTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := config.Load(filepath.Join(niwaDir, "workspace.toml"))
+	if err != nil {
+		t.Fatalf("loading workspace config: %v", err)
+	}
+	cfg := result.Config
+
+	mockClient := &mockGitHubClient{
+		repos: map[string][]github.Repo{
+			"testorg": {
+				{Name: "app", SSHURL: "git@github.com:testorg/app.git"},
+			},
+		},
+	}
+
+	workspaceRoot := tmpDir
+	instanceRoot := filepath.Join(workspaceRoot, "coordinator-vault-ws")
+
+	groupDir := filepath.Join(instanceRoot, "default")
+	if err := os.MkdirAll(filepath.Join(groupDir, "app", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(groupDir, "app", ".gitignore"), []byte("*.local*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	applier := NewApplier(mockClient)
+	applier.Cloner = &Cloner{}
+
+	if _, err := applier.Create(context.Background(), cfg, niwaDir, workspaceRoot, cfg.Workspace.Name); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	settingsPath := filepath.Join(instanceRoot, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("reading coordinator settings.json: %v", err)
+	}
+	content := string(data)
+
+	// The resolved plaintext must reach the coordinator settings.json.
+	wantEntry := `"GH_TOKEN": "` + resolvedToken + `"`
+	if !strings.Contains(content, wantEntry) {
+		t.Errorf("coordinator settings.json missing %q\ngot:\n%s", wantEntry, content)
+	}
+	// The redacted placeholder must not appear.
+	if strings.Contains(content, "***") {
+		t.Errorf("coordinator settings.json must not contain redacted placeholder:\n%s", content)
+	}
+	// The raw vault:// URI must not appear.
+	if strings.Contains(content, "vault://GH_TOKEN") {
+		t.Errorf("coordinator settings.json must not contain unresolved vault URI:\n%s", content)
+	}
+
+	// settings.json containing vault plaintext must be written with 0o600.
+	info, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat coordinator settings.json: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("coordinator settings.json mode = %o, want 0o600", got)
+	}
+}

--- a/internal/workspace/workspace_context.go
+++ b/internal/workspace/workspace_context.go
@@ -198,20 +198,27 @@ func InstallWorkspaceRootSettings(cfg *config.WorkspaceConfig, configDir, instan
 		}
 	}
 
-	// Resolve env vars.
-	envResult := make(map[string]string)
-	if len(cfg.Claude.Env.Promote) > 0 || len(cfg.Claude.Env.Vars.Values) > 0 {
-		if len(cfg.Claude.Env.Promote) > 0 {
-			resolved, _ := resolveEnvFromConfig(cfg, configDir)
-			for _, key := range cfg.Claude.Env.Promote {
-				if val, ok := resolved[key]; ok {
-					envResult[key] = val
-				}
-			}
+	// Resolve env vars using the same pipeline as repo sessions so vault-resolved
+	// secrets are revealed correctly (not redacted to "***" by .String()).
+	wsEnvFile, _, _ := DiscoverEnvFiles(configDir)
+	relWsEnv := wsEnvFile
+	if relWsEnv != "" {
+		if r, err := filepath.Rel(configDir, relWsEnv); err == nil {
+			relWsEnv = r
 		}
-		for k, v := range cfg.Claude.Env.Vars.Values {
-			envResult[k] = v.String()
-		}
+	}
+	mctx := &MaterializeContext{
+		Config:    cfg,
+		Effective: effective,
+		RepoDir:   instanceRoot,
+		ConfigDir: configDir,
+		DiscoveredEnv: &DiscoveredEnv{
+			WorkspaceFile: relWsEnv,
+		},
+	}
+	envResult, _, err := resolveClaudeEnvVars(mctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving env vars for workspace root: %w", err)
 	}
 
 	includeGit := false
@@ -239,7 +246,7 @@ func InstallWorkspaceRootSettings(cfg *config.WorkspaceConfig, configDir, instan
 	claudeDir := filepath.Join(instanceRoot, ".claude")
 	os.MkdirAll(claudeDir, 0o755)
 	settingsPath := filepath.Join(claudeDir, "settings.json")
-	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+	if err := os.WriteFile(settingsPath, data, secretFileMode); err != nil {
 		return nil, fmt.Errorf("writing workspace root settings: %w", err)
 	}
 
@@ -288,28 +295,6 @@ func InstallGlobalClaudeContent(globalConfigDir, instanceRoot string) ([]string,
 	}
 
 	return []string{destPath}, nil
-}
-
-// resolveEnvFromConfig resolves env vars from config files without a full
-// MaterializeContext.
-func resolveEnvFromConfig(cfg *config.WorkspaceConfig, configDir string) (map[string]string, error) {
-	vars := make(map[string]string)
-	for _, f := range cfg.Env.Files {
-		parsed, err := parseEnvFile(filepath.Join(configDir, f))
-		if err != nil {
-			continue
-		}
-		for k, v := range parsed {
-			vars[k] = v
-		}
-	}
-	for k, v := range cfg.Env.Vars.Values {
-		vars[k] = v.String()
-	}
-	for k, v := range cfg.Env.Secrets.Values {
-		vars[k] = v.String()
-	}
-	return vars, nil
 }
 
 // mapMarketplaceSourceWithIndex converts a niwa marketplace source string to the


### PR DESCRIPTION
Replace the divergent `resolveEnvFromConfig` helper in `InstallWorkspaceRootSettings` with a `MaterializeContext` that calls `resolveClaudeEnvVars`, which is the same pipeline used by repo sessions. The old helper called `.String()` on `config.MaybeSecret`, which redacts vault-resolved secrets to `***`. The new path calls `maybeSecretString()` via `ResolveEnvVars`, which calls `reveal.UnsafeReveal` to expose the actual plaintext value.

The fix also corrects the file permissions for the coordinator's `settings.json` from `0o644` to `secretFileMode` (`0o600`), since the file now contains vault plaintext. A new integration test `TestApplyCoordinatorReceivesVaultResolvedEnv` in `apply_vault_test.go` verifies the end-to-end behaviour using the fake vault backend.

---

Fixes #89

**Root Cause**

`resolveEnvFromConfig` iterated `cfg.Claude.Env.Promote`, looked each name up in `effectiveEnv`, and called `v.String()` to get the value. `MaybeSecret.String()` always redacts vault-resolved secrets; it exists specifically to prevent accidental logging. The repo session path uses `maybeSecretString()` / `reveal.UnsafeReveal` and has always worked correctly.

**What Changed**

- `workspace_context.go`: deleted `resolveEnvFromConfig`, replaced env resolution block in `InstallWorkspaceRootSettings` with a `MaterializeContext` + `resolveClaudeEnvVars` call; changed `settings.json` write mode from `0o644` to `secretFileMode`
- `apply_vault_test.go`: added `TestApplyCoordinatorReceivesVaultResolvedEnv` verifying coordinator `settings.json` contains vault plaintext, not `***`, and has `0o600` permissions