### PR TITLE
fix(workspace): write absolute hook paths in per-repo settings.local.json

### DIFF
--- a/internal/workspace/materialize.go
+++ b/internal/workspace/materialize.go
@@ -477,13 +477,14 @@ func (s *SettingsMaterializer) Materialize(ctx *MaterializeContext) ([]string, e
 	}
 
 	doc, err := buildSettingsDoc(BuildSettingsConfig{
-		Settings:        settings,
-		InstalledHooks:  hooks,
-		ResolvedEnvVars: resolvedEnv,
-		Plugins:         plugins,
-		Marketplaces:    marketplaces,
-		RepoIndex:       ctx.RepoIndex,
-		BaseDir:         ctx.RepoDir,
+		Settings:         settings,
+		InstalledHooks:   hooks,
+		ResolvedEnvVars:  resolvedEnv,
+		Plugins:          plugins,
+		Marketplaces:     marketplaces,
+		RepoIndex:        ctx.RepoIndex,
+		BaseDir:          ctx.RepoDir,
+		UseAbsolutePaths: true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/workspace/materialize_test.go
+++ b/internal/workspace/materialize_test.go
@@ -521,8 +521,9 @@ func TestSettingsMaterializerHooksOnly(t *testing.T) {
 	if hookCmd["type"] != "command" {
 		t.Errorf("type = %v, want %q", hookCmd["type"], "command")
 	}
-	if hookCmd["command"] != ".claude/hooks/pre_tool_use/gate.local.sh" {
-		t.Errorf("command = %v, want %q", hookCmd["command"], ".claude/hooks/pre_tool_use/gate.local.sh")
+	wantCmd := filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.local.sh")
+	if hookCmd["command"] != wantCmd {
+		t.Errorf("command = %v, want %q", hookCmd["command"], wantCmd)
 	}
 }
 
@@ -577,8 +578,8 @@ func TestSettingsMaterializerSettingsAndHooks(t *testing.T) {
 		event   string
 		command string
 	}{
-		{"PreToolUse", ".claude/hooks/pre_tool_use/gate.local.sh"},
-		{"Stop", ".claude/hooks/stop/stop.local.sh"},
+		{"PreToolUse", filepath.Join(repoDir, ".claude", "hooks", "pre_tool_use", "gate.local.sh")},
+		{"Stop", filepath.Join(repoDir, ".claude", "hooks", "stop", "stop.local.sh")},
 	} {
 		entries, ok := hooksDoc[tc.event].([]any)
 		if !ok {


### PR DESCRIPTION
`SettingsMaterializer.Materialize` called `buildSettingsDoc` without `UseAbsolutePaths: true`, so hook command paths in per-repo `settings.local.json` were written as relative paths (e.g., `.claude/hooks/stop/workflow-continue.local.sh`). Claude Code resolves those paths relative to the process cwd, which is not guaranteed to be the repo root — any navigation into a subdirectory during a session causes the path to fail, producing a stop hook error on every session close.

`InstallWorkspaceRootSettings` already passes `UseAbsolutePaths: true` when writing the instance-root `settings.json`. This change applies the same flag to the per-repo path in `SettingsMaterializer`, making both call sites consistent. `BuildSettingsConfig.UseAbsolutePaths` and the absolute-path branch in `buildSettingsDoc` already existed — no new types or logic were needed. Two unit tests that asserted relative path output are updated to assert absolute paths.

---

## Root cause

`materialize.go:479` — `buildSettingsDoc` called without `UseAbsolutePaths: true`. The working counterpart at `workspace_context.go:234` already sets the flag.

## What this fixes

Stop hook error appearing on every Claude Code session close in workspace-managed repos:

```
Stop hook error: Failed with non-blocking status code:
  /bin/sh: 1: .claude/hooks/stop/workflow-continue.local.sh: not found
```