### PR TITLE
fix(workspace): persist overlay HEAD SHA after branch-2 sync

### DIFF
--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -504,8 +504,8 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 	//   1. NoOverlay=true  → skip entirely; overlayDir stays empty.
 	//   2. OverlayURL set  → sync existing clone; hard error on sync failure.
 	//   3. Neither         → attempt convention discovery from ConfigSourceURL.
-	var pipelineOverlayURL string    // non-empty when convention discovery sets OverlayURL
-	var pipelineOverlayCommit string // non-empty when convention discovery sets OverlayCommit
+	var pipelineOverlayURL string    // non-empty when overlay sync or discovery records the current URL
+	var pipelineOverlayCommit string // non-empty when overlay sync or discovery records the HEAD SHA
 	if !opts.noOverlay {
 		switch {
 		case opts.overlayURL != "":
@@ -521,13 +521,15 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 			}
 			// Sync succeeded. Check whether the overlay has advanced.
 			sha, shaErr := a.headSHA(dir)
-			if shaErr == nil && opts.existingState != nil && opts.existingState.OverlayCommit != "" {
-				if sha != opts.existingState.OverlayCommit {
+			if shaErr == nil {
+				if opts.existingState != nil && opts.existingState.OverlayCommit != "" && sha != opts.existingState.OverlayCommit {
 					a.Reporter.DeferWarn("workspace overlay has new commits since last apply (was %s, now %s)",
 						opts.existingState.OverlayCommit[:min(7, len(opts.existingState.OverlayCommit))],
 						sha[:min(7, len(sha))],
 					)
 				}
+				pipelineOverlayURL = opts.overlayURL
+				pipelineOverlayCommit = sha
 			}
 			overlayDir = dir
 

--- a/internal/workspace/apply_test.go
+++ b/internal/workspace/apply_test.go
@@ -1682,6 +1682,127 @@ visibility = "public"
 	}
 }
 
+// TestApplyOverlaySHAMismatchUpdatesState verifies that after apply detects a SHA
+// mismatch and warns, the new SHA is persisted so a second apply does not repeat
+// the warning. Scenario 18b.
+func TestApplyOverlaySHAMismatchUpdatesState(t *testing.T) {
+	overlayTOML := `
+[[sources]]
+org = "overlayorg"
+repos = ["extra-repo"]
+`
+	overlayDir := setupOverlayDir(t, overlayTOML)
+
+	configTOML := `
+[workspace]
+name = "test-ws"
+
+[[sources]]
+org = "testorg"
+
+[groups.all]
+visibility = "public"
+`
+	niwaDir, instanceRoot := setupTestWorkspace(t, configTOML, nil, []struct{ group, name string }{
+		{"all", "repo1"},
+		{"all", "extra-repo"},
+	})
+
+	result, err := config.Load(filepath.Join(niwaDir, "workspace.toml"))
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	cfg := result.Config
+
+	mockClient := &mockGitHubClient{
+		repos: map[string][]github.Repo{
+			"testorg": {
+				{Name: "repo1", Visibility: "public", SSHURL: "git@github.com:testorg/repo1.git"},
+			},
+			"overlayorg": {
+				{Name: "extra-repo", Visibility: "public", SSHURL: "git@github.com:overlayorg/extra-repo.git"},
+			},
+		},
+	}
+
+	initialState := &InstanceState{
+		SchemaVersion:  SchemaVersion,
+		InstanceName:   "test-ws",
+		InstanceNumber: 1,
+		Root:           instanceRoot,
+		OverlayURL:     "testorg/test-ws-overlay",
+		OverlayCommit:  "abc123",
+	}
+	if err := SaveState(instanceRoot, initialState); err != nil {
+		t.Fatal(err)
+	}
+
+	cloneFn := func(_ context.Context, url, dir string) (bool, error) {
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			return false, err
+		}
+		data, err := os.ReadFile(filepath.Join(overlayDir, "workspace-overlay.toml"))
+		if err != nil {
+			return false, err
+		}
+		return false, os.WriteFile(filepath.Join(dir, "workspace-overlay.toml"), data, 0o644)
+	}
+	headFn := func(dir string) (string, error) {
+		return "def456newsha", nil
+	}
+
+	applier := NewApplier(mockClient)
+	applier.Cloner = &Cloner{}
+	applier.cloneOrSync = cloneFn
+	applier.headSHA = headFn
+
+	if err := applier.Apply(context.Background(), cfg, niwaDir, instanceRoot); err != nil {
+		t.Fatalf("first apply failed: %v", err)
+	}
+
+	saved, loadErr := LoadState(instanceRoot)
+	if loadErr != nil {
+		t.Fatalf("loading state after first apply: %v", loadErr)
+	}
+	if saved.OverlayCommit != "def456newsha" {
+		t.Errorf("state OverlayCommit after first apply: got %q, want %q", saved.OverlayCommit, "def456newsha")
+	}
+
+	// Second apply must not warn again because the state now reflects the current SHA.
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("creating pipe: %v", pipeErr)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+
+	if err := applier.Apply(context.Background(), cfg, niwaDir, instanceRoot); err != nil {
+		os.Stderr = oldStderr
+		w.Close()
+		t.Fatalf("second apply failed: %v", err)
+	}
+
+	os.Stderr = oldStderr
+	w.Close()
+	var stderrBuf strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			stderrBuf.Write(buf[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	r.Close()
+
+	const warnSubstr = "workspace overlay has new commits since last apply"
+	if strings.Contains(stderrBuf.String(), warnSubstr) {
+		t.Errorf("second apply should not warn about SHA mismatch; got stderr: %s", stderrBuf.String())
+	}
+}
+
 // TestApplyOverlayWithValidOverlay verifies that when an overlay is active, overlay
 // repos/groups/content appear in the pipeline output. Scenario 19.
 //


### PR DESCRIPTION
In the overlay sync path for existing clones (branch 2 of `runPipeline`), `pipelineOverlayURL` and `pipelineOverlayCommit` were never set after a successful sync. The state-saving logic in `Apply` only updates `OverlayCommit` when `result.overlayURL` is non-empty, so every apply on this path wrote the old SHA back to disk. The result was the "workspace overlay has new commits since last apply" warning firing on every subsequent apply rather than just once.

The fix sets `pipelineOverlayURL` and `pipelineOverlayCommit` after a successful sync in branch 2, mirroring what branch 3 (convention discovery) already does. A new test, `TestApplyOverlaySHAMismatchUpdatesState`, verifies that the state is updated after the first apply and that the warning does not repeat on a second apply.

---

Fixes the regression where `niwa apply` emits the overlay SHA mismatch warning on every run once an overlay has new commits, instead of only once.

**Root cause:** `pipelineOverlayURL`/`pipelineOverlayCommit` were only assigned in branch 3 (convention discovery). Branch 2 (sync existing overlay) detected the mismatch and warned but never propagated the new SHA, so `SaveState` always preserved the stale value.