### PR TITLE
feat: rename vault audit label from (anonymous) to personal-overlay

### DIFF
--- a/docs/guides/machine-identity-vault-sync.md
+++ b/docs/guides/machine-identity-vault-sync.md
@@ -168,10 +168,10 @@ niwa status --audit-auth
 Sample output:
 
 ```
-KIND       PROJECT-UUID                          SOURCE              FALLBACK
-infisical  550e8400-e29b-41d4-a716-446655440000  local-file          vault:personal
-infisical  660f9511-f40c-52e5-b827-557766551111  vault:personal      —
-infisical  770a0622-a51d-63f6-c938-668877662222  cli-session         —
+KIND       PROJECT-UUID                          SOURCE                     FALLBACK
+infisical  550e8400-e29b-41d4-a716-446655440000  local-file                 vault:personal-overlay
+infisical  660f9511-f40c-52e5-b827-557766551111  vault:personal-overlay     —
+infisical  770a0622-a51d-63f6-c938-668877662222  cli-session                —
 ```
 
 Column meaning:
@@ -180,8 +180,10 @@ Column meaning:
 - `PROJECT-UUID` — the Infisical project the credential was for.
 - `SOURCE` — where the credential came from in the last apply:
   - `local-file` — `~/.config/niwa/provider-auth.toml`.
-  - `vault:<name>` — your personal vault. Anonymous renders as
-    `vault:(anonymous)`.
+  - `vault:personal-overlay` — your personal-overlay vault. The
+    "personal-overlay" label always names the source; if you ever
+    have multiple credential-sync providers, niwa appends the name
+    in parentheses (e.g., `vault:personal-overlay(work)`).
   - `cli-session` — niwa fell through to the backend's active
     session (e.g., `infisical login`).
   - `none` — no source produced a usable credential.
@@ -201,14 +203,14 @@ When at least one `(kind, project)` was sourced from the vault on
 this apply, niwa emits one stderr line per pair:
 
 ```
-auth: infisical/550e8400-... source=vault:personal
+auth: infisical/550e8400-... source=vault:personal-overlay
 ```
 
 When the local file overrode a vault entry, you also see a
 fallback line:
 
 ```
-auth: infisical/660f9511-... source=local-file fallback=vault:personal
+auth: infisical/660f9511-... source=local-file fallback=vault:personal-overlay
 ```
 
 The lines fire BEFORE backend authentication runs, so even an

--- a/docs/prds/PRD-machine-identity-vault-sync.md
+++ b/docs/prds/PRD-machine-identity-vault-sync.md
@@ -463,13 +463,14 @@ infisical  880b1733-b62e-74a7-d949-779988773333  none                —
 |--------|---------|
 | `KIND` | Backend kind (e.g., `infisical`) |
 | `PROJECT-UUID` | The `(kind, project)` identifier niwa needed credentials for |
-| `SOURCE` | Where the credential came from in the last apply: `local-file`, `vault:<name>` (provider name), `cli-session`, or `none`. When the credential-sync provider is the anonymous `[global.vault.provider]`, the column renders `vault:(anonymous)`. niwa MUST NOT emit a bare trailing colon (`vault:`) — `(anonymous)` is the literal placeholder. |
-| `FALLBACK` | The non-active source that ALSO had an entry, if any. `vault:<name>` (or `vault:(anonymous)`) when the local file won; otherwise `—` |
+| `SOURCE` | Where the credential came from in the last apply: `local-file`, `vault:personal-overlay` (anonymous credential-sync source), `vault:personal-overlay(<name>)` (named credential-sync source — reserved for a future extension), `cli-session`, or `none`. niwa MUST NOT emit a bare `vault:` with a trailing colon. |
+| `FALLBACK` | The non-active source that ALSO had an entry, if any. `vault:personal-overlay` (with the optional `(<name>)` disambiguator) when the local file won; otherwise `—` |
 
 When the same `(kind, project)` has entries in both layers, the
 SOURCE column shows the layer that won (local-file) and FALLBACK
-shows the layer that lost (vault:<name>). When only one layer has
-an entry, FALLBACK is `—`.
+shows the layer that lost (`vault:personal-overlay`, optionally
+suffixed with `(<name>)`). When only one layer has an entry,
+FALLBACK is `—`.
 
 Exit codes:
 
@@ -489,8 +490,8 @@ bytes. Concretely, the JSON schema for one row is:
 
 ```json
 {
-  "source":   "local-file" | "vault:<name>" | "vault:(anonymous)" | "cli-session" | "none",
-  "fallback": "vault:<name>" | "vault:(anonymous)" | ""
+  "source":   "local-file" | "vault:personal-overlay" | "vault:personal-overlay(<name>)" | "cli-session" | "none",
+  "fallback": "vault:personal-overlay" | "vault:personal-overlay(<name>)" | ""
 }
 ```
 
@@ -505,13 +506,14 @@ MUST emit one stderr line per **unique `(kind, project)` pair**
 sourced from the vault. Shape:
 
 ```
-auth: <kind>/<project-uuid> source=vault:<name>
+auth: <kind>/<project-uuid> source=vault:personal-overlay
 ```
 
-When the credential-sync provider is the anonymous
-`[global.vault.provider]`, `<name>` renders as `(anonymous)` —
-the same convention as R11's audit column. niwa MUST NOT emit a
-bare trailing colon.
+When the credential-sync provider has a name (a future extension —
+under v1, only the anonymous `[global.vault.provider]` may serve
+as the credential-sync source), the line renders as
+`source=vault:personal-overlay(<name>)`. niwa MUST NOT emit a bare
+`vault:` with a trailing colon.
 
 Two `(kind, project)` pairs that happen to share a vault provider
 name produce two lines, not one. The grouping is per pair.
@@ -646,7 +648,7 @@ redaction logic.
       declared in their personal overlay sees credential sync
       activate: machine-identity entries are fetched from that
       provider during apply, and `niwa status --audit-auth` renders
-      the SOURCE column as `vault:(anonymous)` for any
+      the SOURCE column as `vault:personal-overlay` for any
       `(kind, project)` pair the vault covered. Verified by
       `internal/config/...` parser tests and
       `internal/workspace/credentialpool_*_test.go`.
@@ -823,14 +825,18 @@ redaction logic.
       vault `Resolve` ref carries `p-<MixedCaseUUID>` preserving the
       original case.
 
-### Anonymous-provider rendering
+### Credential-sync source rendering
 
-- [ ] **AC-39**: When the credential-sync provider is the anonymous
-      `[global.vault.provider]`, `niwa status --audit-auth` renders
-      the SOURCE column as `vault:(anonymous)`, the FALLBACK column
-      uses the same form when applicable, and the R12 stderr line
-      uses `source=vault:(anonymous)`. niwa MUST NOT emit a bare
-      `vault:` token (trailing colon with empty name).
+- [ ] **AC-39**: The credential-sync source label has two parts: a
+      fixed `vault:personal-overlay` prefix that names where every
+      credential-sync source lives, and an optional `(<name>)`
+      disambiguator for named providers (reserved for a future
+      extension; under v1, only the anonymous `[global.vault.provider]`
+      may serve as the credential-sync source, so the `(<name>)`
+      suffix is never emitted in practice). Both `niwa status
+      --audit-auth` (SOURCE and FALLBACK columns) and the R12 stderr
+      line use this rendering. niwa MUST NOT emit a bare `vault:`
+      token with a trailing colon.
 
 ### `p-` key prefix (R7 amendment)
 

--- a/internal/cli/status_audit_auth.go
+++ b/internal/cli/status_audit_auth.go
@@ -14,8 +14,9 @@ import (
 // Kind and Project are split from the state.AuthSources map key
 // "<kind>/<project>"; Source and Fallback come straight from the
 // AuthSourceRecord (already pre-rendered by the credential pool's
-// renderSource / renderVaultProvider helpers, including the AC-39
-// "vault:(anonymous)" form).
+// renderSource / renderVaultProvider helpers; vault sources render
+// as "vault:personal-overlay" or "vault:personal-overlay(<name>)",
+// see PRD AC-39).
 type auditAuthRow struct {
 	Kind     string
 	Project  string
@@ -106,16 +107,20 @@ func buildAuditAuthRows(authSources map[string]workspace.AuthSourceRecord) []aud
 // sees a recognizable empty table rather than blank output.
 func printAuditAuthTable(w io.Writer, rows []auditAuthRow) {
 	// Column widths match PRD R11's example header
-	// `KIND       PROJECT-UUID                          SOURCE              FALLBACK`
+	// `KIND       PROJECT-UUID                          SOURCE                     FALLBACK`
 	// byte-for-byte: KIND padded to 11 chars (allowing two trailing spaces
 	// after the longest kind in current use, "infisical"); PROJECT-UUID
 	// padded to 38 chars (a UUID's 36 chars plus two trailing spaces);
-	// SOURCE padded to 20 chars (longest known value is
-	// "vault:(anonymous)" at 17 chars plus three trailing spaces).
+	// SOURCE padded to 25 chars (longest known value today is
+	// "vault:personal-overlay" at 22 chars plus three trailing spaces).
+	// Future named credential-sync sources render as
+	// "vault:personal-overlay(<name>)" and may exceed this width; the
+	// renderer absorbs the overflow without truncating, at the cost of
+	// FALLBACK shifting right on those rows.
 	const (
 		kindWidth    = 11
 		projectWidth = 38
-		sourceWidth  = 20
+		sourceWidth  = 25
 	)
 	fmt.Fprintf(w, "%-*s%-*s%-*s%s\n",
 		kindWidth, "KIND",

--- a/internal/cli/status_audit_auth_test.go
+++ b/internal/cli/status_audit_auth_test.go
@@ -28,7 +28,7 @@ func TestBuildAuditAuthRows_Empty(t *testing.T) {
 // map key splits correctly into Kind and Project columns.
 func TestBuildAuditAuthRows_KeySplit(t *testing.T) {
 	src := map[string]workspace.AuthSourceRecord{
-		"infisical/uuid-A": {Source: "vault:personal"},
+		"infisical/uuid-A": {Source: "vault:personal-overlay(personal)"},
 	}
 	rows := buildAuditAuthRows(src)
 	if len(rows) != 1 {
@@ -40,8 +40,8 @@ func TestBuildAuditAuthRows_KeySplit(t *testing.T) {
 	if rows[0].Project != "uuid-A" {
 		t.Errorf("Project = %q, want %q", rows[0].Project, "uuid-A")
 	}
-	if rows[0].Source != "vault:personal" {
-		t.Errorf("Source = %q, want %q", rows[0].Source, "vault:personal")
+	if rows[0].Source != "vault:personal-overlay(personal)" {
+		t.Errorf("Source = %q, want %q", rows[0].Source, "vault:personal-overlay(personal)")
 	}
 }
 
@@ -50,9 +50,9 @@ func TestBuildAuditAuthRows_KeySplit(t *testing.T) {
 func TestBuildAuditAuthRows_SortedByKindThenProject(t *testing.T) {
 	src := map[string]workspace.AuthSourceRecord{
 		"infisical/uuid-z":  {Source: "local-file"},
-		"infisical/uuid-a":  {Source: "vault:personal"},
+		"infisical/uuid-a":  {Source: "vault:personal-overlay(personal)"},
 		"sops/whatever":     {Source: "cli-session"},
-		"infisical/uuid-m":  {Source: "vault:(anonymous)"},
+		"infisical/uuid-m":  {Source: "vault:personal-overlay"},
 	}
 	rows := buildAuditAuthRows(src)
 	if len(rows) != 4 {
@@ -79,8 +79,8 @@ func TestBuildAuditAuthRows_SortedByKindThenProject(t *testing.T) {
 func TestPrintAuditAuthTable_HeaderAndColumns(t *testing.T) {
 	var buf bytes.Buffer
 	rows := []auditAuthRow{
-		{Kind: "infisical", Project: "uuid-A", Source: "local-file", Fallback: "vault:personal"},
-		{Kind: "infisical", Project: "uuid-B", Source: "vault:personal", Fallback: ""},
+		{Kind: "infisical", Project: "uuid-A", Source: "local-file", Fallback: "vault:personal-overlay(personal)"},
+		{Kind: "infisical", Project: "uuid-B", Source: "vault:personal-overlay(personal)", Fallback: ""},
 	}
 	printAuditAuthTable(&buf, rows)
 	out := buf.String()
@@ -90,7 +90,7 @@ func TestPrintAuditAuthTable_HeaderAndColumns(t *testing.T) {
 			t.Errorf("header missing column %q. Output:\n%s", want, out)
 		}
 	}
-	for _, want := range []string{"infisical", "uuid-A", "uuid-B", "local-file", "vault:personal"} {
+	for _, want := range []string{"infisical", "uuid-A", "uuid-B", "local-file", "vault:personal-overlay(personal)"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("table missing %q. Output:\n%s", want, out)
 		}
@@ -102,7 +102,7 @@ func TestPrintAuditAuthTable_HeaderAndColumns(t *testing.T) {
 func TestPrintAuditAuthTable_EmDashWhenFallbackEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	rows := []auditAuthRow{
-		{Kind: "infisical", Project: "uuid-A", Source: "vault:personal", Fallback: ""},
+		{Kind: "infisical", Project: "uuid-A", Source: "vault:personal-overlay(personal)", Fallback: ""},
 	}
 	printAuditAuthTable(&buf, rows)
 	out := buf.String()
@@ -113,19 +113,19 @@ func TestPrintAuditAuthTable_EmDashWhenFallbackEmpty(t *testing.T) {
 
 // TestPrintAuditAuthTable_AnonymousVaultRender confirms AC-39:
 // the anonymous credential-sync provider renders as
-// "vault:(anonymous)" in both SOURCE and FALLBACK columns.
+// "vault:personal-overlay" in both SOURCE and FALLBACK columns.
 // The pool's renderVaultProvider helper produces these strings;
 // I4 just outputs them verbatim.
 func TestPrintAuditAuthTable_AnonymousVaultRender(t *testing.T) {
 	var buf bytes.Buffer
 	rows := []auditAuthRow{
-		{Kind: "infisical", Project: "uuid-A", Source: "vault:(anonymous)"},
-		{Kind: "infisical", Project: "uuid-B", Source: "local-file", Fallback: "vault:(anonymous)"},
+		{Kind: "infisical", Project: "uuid-A", Source: "vault:personal-overlay"},
+		{Kind: "infisical", Project: "uuid-B", Source: "local-file", Fallback: "vault:personal-overlay"},
 	}
 	printAuditAuthTable(&buf, rows)
 	out := buf.String()
-	if strings.Count(out, "vault:(anonymous)") != 2 {
-		t.Errorf("expected 'vault:(anonymous)' to appear in both rows. Output:\n%s", out)
+	if strings.Count(out, "vault:personal-overlay") != 2 {
+		t.Errorf("expected 'vault:personal-overlay' to appear in both rows. Output:\n%s", out)
 	}
 	if strings.Contains(out, "vault: ") || strings.Contains(out, "vault:\n") {
 		t.Errorf("output must not contain bare 'vault:'. Output:\n%s", out)
@@ -155,15 +155,15 @@ func TestPrintAuditAuthTable_HeaderEvenWhenEmpty(t *testing.T) {
 // audit, and confirms exit code 0 plus the rendered table.
 func TestRunAuditAuth_HappyPath(t *testing.T) {
 	dir := writeInstanceForAuditTest(t, map[string]workspace.AuthSourceRecord{
-		"infisical/uuid-A": {Source: "vault:personal"},
-		"infisical/uuid-B": {Source: "local-file", Fallback: "vault:personal"},
+		"infisical/uuid-A": {Source: "vault:personal-overlay(personal)"},
+		"infisical/uuid-B": {Source: "local-file", Fallback: "vault:personal-overlay(personal)"},
 	})
 
 	out, err := runAuditAuthInDir(t, dir)
 	if err != nil {
 		t.Fatalf("runAuditAuth returned error: %v", err)
 	}
-	if !strings.Contains(out, "infisical") || !strings.Contains(out, "vault:personal") {
+	if !strings.Contains(out, "infisical") || !strings.Contains(out, "vault:personal-overlay(personal)") {
 		t.Errorf("expected table output. Got:\n%s", out)
 	}
 }
@@ -173,7 +173,7 @@ func TestRunAuditAuth_HappyPath(t *testing.T) {
 // non-zero).
 func TestRunAuditAuth_ExitNonZeroOnNoneSource(t *testing.T) {
 	dir := writeInstanceForAuditTest(t, map[string]workspace.AuthSourceRecord{
-		"infisical/uuid-A": {Source: "vault:personal"},
+		"infisical/uuid-A": {Source: "vault:personal-overlay(personal)"},
 		"infisical/uuid-B": {Source: "none"},
 	})
 

--- a/internal/workspace/credentialpool.go
+++ b/internal/workspace/credentialpool.go
@@ -559,8 +559,9 @@ func (p *CredentialPool) AuditLog() AuditTrail {
 // line per credential-source decision worth logging, per PRD R12 +
 // AC-13 / AC-14 / AC-15. The emit rules:
 //
-//   - Source == SourceVault → "auth: <kind>/<project> source=vault:<name>"
-//     (anonymous renders as vault:(anonymous), AC-39).
+//   - Source == SourceVault → "auth: <kind>/<project> source=vault:personal-overlay"
+//     (or "vault:personal-overlay(<name>)" when the provider has a
+//     name; see renderVaultProvider for the rendering rule).
 //   - Source == SourceLocalFile && Fallback != "" →
 //     "auth: <kind>/<project> source=local-file fallback=<fallback>"
 //     (the user has a per-machine override active over a vault entry).
@@ -652,7 +653,7 @@ func (a AuditTrail) AsMap() map[string]AuthSourceRecord {
 // --audit-auth`) consume. The mapping:
 //
 //   - SourceLocalFile   → "local-file"
-//   - SourceVault       → "vault:<provider-name>"  (or "vault:(anonymous)" when Provider == "")
+//   - SourceVault       → "vault:personal-overlay"  (anonymous form; or "vault:personal-overlay(<name>)" when named)
 //   - SourceCLISession  → "cli-session"
 //   - SourceNone        → "none"
 //   - any other Source  → "" (defensive; never produced by Lookup)
@@ -676,21 +677,35 @@ func renderSource(rec AuditRecord) string {
 }
 
 // renderVaultProvider formats a vault provider name for the audit
-// surfaces. Anonymous providers (Provider == "") render as
-// "vault:(anonymous)" per PRD AC-39; named providers render as
-// "vault:<name>". Never produces a bare "vault:" with a trailing
-// colon and empty name.
+// surfaces (R11 audit table SOURCE/FALLBACK columns and R12 stderr
+// emission).
 //
-// I7 will call this helper when populating AuditRecord.Fallback —
-// the pool sets Fallback to renderVaultProvider(loader.ProviderName)
-// when the file layer wins and the vault layer also had an entry —
-// so the AC-39 anonymous-rendering rule applies symmetrically to
-// the SOURCE and FALLBACK columns.
+// The label has two parts: a fixed source identifier
+// ("personal-overlay") that names where credential-sync sources live,
+// and an optional disambiguator (the provider's name, when set) for
+// users who eventually configure multiple credential-sync providers
+// in the same overlay.
+//
+// Renderings:
+//   - Anonymous personal-overlay vault (the only credential-sync
+//     shape Alt 2 currently allows): "vault:personal-overlay".
+//   - Named personal-overlay vault (reserved for a future extension
+//     where named providers may serve as credential-sync sources):
+//     "vault:personal-overlay(<name>)".
+//
+// The source label is consistent regardless of name because, under
+// the Alt 2 design, every credential-sync source lives in the
+// personal overlay — that's the consent property of declaring
+// `[global.vault.provider]`. Names disambiguate among siblings; they
+// never identify a different origin.
+//
+// Never emits a bare "vault:" with a trailing colon.
 func renderVaultProvider(name string) string {
+	const sourceLabel = "vault:personal-overlay"
 	if name == "" {
-		return "vault:(anonymous)"
+		return sourceLabel
 	}
-	return "vault:" + name
+	return sourceLabel + "(" + name + ")"
 }
 
 // matchFileEntry synthesizes a vault.ProviderSpec for (kind, project)

--- a/internal/workspace/credentialpool_lazyvault_test.go
+++ b/internal/workspace/credentialpool_lazyvault_test.go
@@ -125,14 +125,14 @@ func TestPool_FileWinsWithVaultFallback(t *testing.T) {
 	if rec.Source != SourceLocalFile {
 		t.Errorf("rec.Source = %q, want %q", rec.Source, SourceLocalFile)
 	}
-	if rec.Fallback != "vault:personal" {
-		t.Errorf("rec.Fallback = %q, want %q", rec.Fallback, "vault:personal")
+	if rec.Fallback != "vault:personal-overlay(personal)" {
+		t.Errorf("rec.Fallback = %q, want %q", rec.Fallback, "vault:personal-overlay(personal)")
 	}
 }
 
 // TestPool_FileWinsWithAnonymousVaultFallback locks AC-39 for
 // the anonymous-vault case: the Fallback string renders as
-// "vault:(anonymous)", never bare "vault:".
+// "vault:personal-overlay", never bare "vault:".
 func TestPool_FileWinsWithAnonymousVaultFallback(t *testing.T) {
 	file := []ProviderAuthEntry{
 		{
@@ -153,8 +153,8 @@ func TestPool_FileWinsWithAnonymousVaultFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if rec.Fallback != "vault:(anonymous)" {
-		t.Errorf("rec.Fallback = %q, want vault:(anonymous)", rec.Fallback)
+	if rec.Fallback != "vault:personal-overlay" {
+		t.Errorf("rec.Fallback = %q, want vault:personal-overlay", rec.Fallback)
 	}
 }
 

--- a/internal/workspace/credentialpool_r12_test.go
+++ b/internal/workspace/credentialpool_r12_test.go
@@ -34,14 +34,15 @@ func TestEmitR12Lines_VaultRow(t *testing.T) {
 	}
 	trail.EmitR12Lines(rep)
 	got := buf.String()
-	want := "auth: infisical/uuid-A source=vault:personal\n"
+	want := "auth: infisical/uuid-A source=vault:personal-overlay(personal)\n"
 	if got != want {
 		t.Errorf("output = %q, want %q", got, want)
 	}
 }
 
 // TestEmitR12Lines_AnonymousVaultRow covers AC-39: anonymous
-// renders as vault:(anonymous), never bare vault:.
+// renders as vault:personal-overlay (no name suffix), never bare
+// vault: with a trailing colon.
 func TestEmitR12Lines_AnonymousVaultRow(t *testing.T) {
 	rep, buf := captureReporter()
 	trail := AuditTrail{
@@ -49,7 +50,7 @@ func TestEmitR12Lines_AnonymousVaultRow(t *testing.T) {
 	}
 	trail.EmitR12Lines(rep)
 	got := buf.String()
-	if !strings.Contains(got, "source=vault:(anonymous)") {
+	if !strings.Contains(got, "source=vault:personal-overlay\n") {
 		t.Errorf("anonymous render missing. Got: %q", got)
 	}
 	if strings.Contains(got, "source=vault:\n") || strings.Contains(got, "source=vault: ") {
@@ -62,11 +63,11 @@ func TestEmitR12Lines_AnonymousVaultRow(t *testing.T) {
 func TestEmitR12Lines_FileWithFallback(t *testing.T) {
 	rep, buf := captureReporter()
 	trail := AuditTrail{
-		{Kind: "infisical", Project: "uuid-A", Source: SourceLocalFile, Fallback: "vault:personal"},
+		{Kind: "infisical", Project: "uuid-A", Source: SourceLocalFile, Fallback: "vault:personal-overlay(personal)"},
 	}
 	trail.EmitR12Lines(rep)
 	got := buf.String()
-	want := "auth: infisical/uuid-A source=local-file fallback=vault:personal\n"
+	want := "auth: infisical/uuid-A source=local-file fallback=vault:personal-overlay(personal)\n"
 	if got != want {
 		t.Errorf("output = %q, want %q", got, want)
 	}
@@ -146,8 +147,8 @@ func TestEmitR12Lines_LastWriteWins(t *testing.T) {
 	}
 	trail.EmitR12Lines(rep)
 	got := buf.String()
-	if !strings.Contains(got, "source=vault:personal") {
-		t.Errorf("last-write-wins violation; expected vault:personal. Got: %q", got)
+	if !strings.Contains(got, "source=vault:personal-overlay(personal)") {
+		t.Errorf("last-write-wins violation; expected vault:personal-overlay(personal). Got: %q", got)
 	}
 	if strings.Contains(got, "source=cli-session") {
 		t.Errorf("earlier cli-session record leaked into emit. Got: %q", got)
@@ -172,7 +173,7 @@ func TestEmitR12Lines_MixedTrail(t *testing.T) {
 	rep, buf := captureReporter()
 	trail := AuditTrail{
 		{Kind: "infisical", Project: "uuid-vault", Source: SourceVault, Provider: "personal"},
-		{Kind: "infisical", Project: "uuid-fallback", Source: SourceLocalFile, Fallback: "vault:personal"},
+		{Kind: "infisical", Project: "uuid-fallback", Source: SourceLocalFile, Fallback: "vault:personal-overlay(personal)"},
 		{Kind: "infisical", Project: "uuid-pure", Source: SourceLocalFile, Fallback: ""},
 		{Kind: "infisical", Project: "uuid-cli", Source: SourceCLISession},
 	}
@@ -182,10 +183,10 @@ func TestEmitR12Lines_MixedTrail(t *testing.T) {
 	if lineCount != 2 {
 		t.Errorf("expected 2 lines, got %d: %q", lineCount, got)
 	}
-	if !strings.Contains(got, "auth: infisical/uuid-vault source=vault:personal") {
+	if !strings.Contains(got, "auth: infisical/uuid-vault source=vault:personal-overlay(personal)") {
 		t.Errorf("vault row missing. Got: %q", got)
 	}
-	if !strings.Contains(got, "auth: infisical/uuid-fallback source=local-file fallback=vault:personal") {
+	if !strings.Contains(got, "auth: infisical/uuid-fallback source=local-file fallback=vault:personal-overlay(personal)") {
 		t.Errorf("fallback row missing. Got: %q", got)
 	}
 	if strings.Contains(got, "uuid-pure") {

--- a/internal/workspace/credentialpool_test.go
+++ b/internal/workspace/credentialpool_test.go
@@ -210,8 +210,8 @@ func TestAuditTrail_AsMap_AllSources(t *testing.T) {
 		want AuthSourceRecord
 	}{
 		{"infisical/uuid-A", AuthSourceRecord{Source: "local-file"}},
-		{"infisical/uuid-B", AuthSourceRecord{Source: "vault:personal"}},
-		{"infisical/uuid-C", AuthSourceRecord{Source: "vault:(anonymous)"}}, // AC-39
+		{"infisical/uuid-B", AuthSourceRecord{Source: "vault:personal-overlay(personal)"}},
+		{"infisical/uuid-C", AuthSourceRecord{Source: "vault:personal-overlay"}}, // AC-39
 		{"infisical/uuid-D", AuthSourceRecord{Source: "cli-session"}},
 		{"infisical/uuid-E", AuthSourceRecord{Source: "none"}},
 	}
@@ -240,7 +240,7 @@ func TestAuditTrail_AsMap_FallbackPropagated(t *testing.T) {
 			Kind:     "infisical",
 			Project:  "uuid-X",
 			Source:   SourceLocalFile,
-			Fallback: "vault:personal",
+			Fallback: "vault:personal-overlay(personal)",
 		},
 	}
 	got := trail.AsMap()
@@ -251,8 +251,8 @@ func TestAuditTrail_AsMap_FallbackPropagated(t *testing.T) {
 	if rec.Source != "local-file" {
 		t.Errorf("Source = %q, want %q", rec.Source, "local-file")
 	}
-	if rec.Fallback != "vault:personal" {
-		t.Errorf("Fallback = %q, want %q", rec.Fallback, "vault:personal")
+	if rec.Fallback != "vault:personal-overlay(personal)" {
+		t.Errorf("Fallback = %q, want %q", rec.Fallback, "vault:personal-overlay(personal)")
 	}
 }
 

--- a/internal/workspace/state.go
+++ b/internal/workspace/state.go
@@ -121,11 +121,13 @@ type InstanceState struct {
 // are categorical strings — never credential bytes (PRD R18).
 //
 //   - Source: where the credential came from in the last apply.
-//     One of "local-file", "vault:<name>" (or "vault:(anonymous)"
-//     for the anonymous credential-sync provider per AC-39),
+//     One of "local-file", "vault:personal-overlay" (or
+//     "vault:personal-overlay(<name>)" when the credential-sync
+//     provider has a name; see PRD AC-39 / renderVaultProvider),
 //     "cli-session", or "none".
 //   - Fallback: the non-active source that ALSO had an entry, if
-//     any. "vault:<name>" when the local file won and the vault
+//     any. "vault:personal-overlay" (with the same name-disambiguator
+//     suffix when applicable) when the local file won and the vault
 //     also had an entry; otherwise empty.
 //
 // `niwa status --audit-auth` reads this map (and only this map) to

--- a/internal/workspace/state_test.go
+++ b/internal/workspace/state_test.go
@@ -1042,15 +1042,15 @@ func TestSaveAndLoadStateAuthSources(t *testing.T) {
 		LastApplied:    time.Now(),
 		AuthSources: map[string]AuthSourceRecord{
 			"infisical/uuid-prod": {
-				Source:   "vault:personal",
+				Source:   "vault:personal-overlay(personal)",
 				Fallback: "",
 			},
 			"infisical/uuid-team": {
 				Source:   "local-file",
-				Fallback: "vault:personal",
+				Fallback: "vault:personal-overlay(personal)",
 			},
 			"infisical/uuid-anon": {
-				Source:   "vault:(anonymous)",
+				Source:   "vault:personal-overlay",
 				Fallback: "",
 			},
 			"infisical/uuid-cli": {


### PR DESCRIPTION
Replace the \`vault:(anonymous)\` rendering with \`vault:personal-overlay\` across the credential-source audit surfaces (\`niwa status --audit-auth\` SOURCE/FALLBACK columns and the R12 apply-time stderr line). Named credential-sync providers — reserved for a future extension where named providers may serve as credential-sync sources — render as \`vault:personal-overlay(<name>)\`. The new label uses a positive source identifier that always names where credential-sync sources live, with the optional parenthetical only when needed to disambiguate among siblings.

---

## Why

The \`(anonymous)\` literal carried no information for users and read as a deficiency rather than a positive label, especially in the common case (the empty parenthetical for an unnamed personal-overlay vault). Users reported the line looked like a warning rather than informational status.

The new shape:

| Provider shape | Render |
|---|---|
| Anonymous \`[global.vault.provider]\` (the only credential-sync shape v1 allows) | \`vault:personal-overlay\` |
| Named (future) | \`vault:personal-overlay(<name>)\` |

The \`personal-overlay\` source label is consistent regardless of name because every credential-sync source lives in the personal overlay — that's the consent property of declaring \`[global.vault.provider]\` in the first place. Names disambiguate; they never identify a different origin.

## What changed

- \`renderVaultProvider\` in \`internal/workspace/credentialpool.go\` emits the new format.
- \`internal/cli/status_audit_auth.go\` SOURCE column width bumped 20 → 25 to fit \`vault:personal-overlay\` plus three trailing spaces. The renderer absorbs overflow without truncating if a future named source produces a longer label.
- Test fixtures updated across \`credentialpool_*_test.go\`, \`state_test.go\`, \`status_audit_auth_test.go\`.
- PRD R11 column documentation, R12 stderr spec, AC-1, AC-39, and the \`state.json\` schema JSON example updated.
- User guide sample audit output, stderr examples, and SOURCE column legend updated.

DESIGN doc didn't carry the literal rendering and required no changes.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all packages green
- [ ] Manual: run \`niwa apply\` against a workspace that triggers credential sync; confirm \`niwa status --audit-auth\` shows the new label and the apply-time stderr line uses \`source=vault:personal-overlay\`