### PR TITLE
fix(destroy): scan for unpushed work on per-instance destroy too

### DIFF
--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -106,17 +106,24 @@ func runDestroyInstance(cmd *cobra.Command, instanceDir, landingPath string, for
 	}
 
 	if !force {
-		dirty, err := workspace.CheckUncommittedChanges(instanceDir)
+		scan, err := workspace.ScanInstance(instanceDir)
 		if err != nil {
-			return fmt.Errorf("checking for uncommitted changes: %w", err)
+			return fmt.Errorf("scanning instance for unpushed work: %w", err)
 		}
-		if len(dirty) > 0 {
-			sort.Strings(dirty)
-			fmt.Fprintf(cmd.ErrOrStderr(), "Repos with uncommitted changes:\n")
-			for _, name := range dirty {
-				fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", name)
+		if scan.HasLoss() {
+			workspace.FormatScans([]workspace.InstanceScan{scan}, cmd.ErrOrStderr(), scan.InstanceName)
+
+			if !IsStdinTTY() {
+				return fmt.Errorf("instance has unpushed work and stdin is not a terminal; aborting (resolve unpushed work, or use --force to destroy without confirmation)")
 			}
-			return fmt.Errorf("instance has uncommitted changes in %d repo(s); use --force to override", len(dirty))
+
+			matched, err := ReadConfirmation("> ", scan.InstanceName, os.Stdin, cmd.ErrOrStderr())
+			if err != nil {
+				return fmt.Errorf("confirmation aborted: %w", err)
+			}
+			if !matched {
+				return fmt.Errorf("confirmation did not match instance name; aborting")
+			}
 		}
 	}
 

--- a/internal/cli/destroy_test.go
+++ b/internal/cli/destroy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -276,6 +277,129 @@ func TestRunDestroy_FromInsideWritesLandingPath(t *testing.T) {
 	got := strings.TrimRight(string(data), "\n")
 	if got != root {
 		t.Errorf("landing path: got %q, want %q (workspace root)", got, root)
+	}
+}
+
+// TestRunDestroy_PerInstanceScansForUnpushedWorkAndRefusesNonTTY confirms
+// that runDestroyInstance now runs the comprehensive non-pushed-work scan
+// (ScanInstance, not the narrower CheckUncommittedChanges) when --force
+// is absent. With stdin not a TTY (always true in unit tests), the
+// typed-confirmation path can't fire, so the command must refuse with the
+// non-TTY error rather than proceeding silently.
+//
+// Setup uses a real git repo with an unpushed commit so the scan finds
+// LossUnpushedCommits — a state the OLD CheckUncommittedChanges helper
+// would have missed.
+func TestRunDestroy_PerInstanceScansForUnpushedWorkAndRefusesNonTTY(t *testing.T) {
+	root := destroyTestSetup(t, []string{"alpha"})
+	chdirTo(t, root)
+
+	repoDir := filepath.Join(root, "alpha", "myrepo")
+	scanInitGitRepoForCLITest(t, repoDir)
+	// Create + commit a file beyond the initial push so the branch is
+	// ahead of upstream — LossUnpushedCommits.
+	gitRunForCLITest(t, repoDir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(repoDir, "second.txt"), []byte("ahead\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRunForCLITest(t, repoDir, "add", "second.txt")
+	gitRunForCLITest(t, repoDir, "commit", "-m", "ahead")
+
+	cmd := destroyCmd
+	cmd.SetOut(&bytes.Buffer{})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	err := runDestroy(cmd, nil)
+	if err == nil {
+		t.Fatal("expected non-TTY refusal when scan finds unpushed work")
+	}
+	if !strings.Contains(err.Error(), "unpushed work") {
+		t.Errorf("error should mention unpushed work; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not a terminal") {
+		t.Errorf("error should mention non-TTY; got: %v", err)
+	}
+	// Stderr should contain the FormatScans rendering — proves the
+	// broader scan ran rather than the narrow CheckUncommittedChanges.
+	if !strings.Contains(stderr.String(), "unpushed") && !strings.Contains(stderr.String(), "ahead") {
+		t.Errorf("stderr should contain scan output (unpushed/ahead); got: %q", stderr.String())
+	}
+	// And the instance must NOT be removed.
+	if _, err := os.Stat(filepath.Join(root, "alpha")); err != nil {
+		t.Errorf("instance should still exist after refusal; got Stat err = %v", err)
+	}
+}
+
+// TestRunDestroy_PerInstanceForceSkipsScan confirms that --force still
+// bypasses the broader scan, matching the documented bypass semantics.
+func TestRunDestroy_PerInstanceForceSkipsScan(t *testing.T) {
+	root := destroyTestSetup(t, []string{"alpha"})
+	chdirTo(t, root)
+
+	repoDir := filepath.Join(root, "alpha", "myrepo")
+	scanInitGitRepoForCLITest(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "second.txt"), []byte("ahead\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRunForCLITest(t, repoDir, "add", "second.txt")
+	gitRunForCLITest(t, repoDir, "commit", "-m", "ahead")
+
+	cmd := destroyCmd
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	prevForce := destroyForce
+	destroyForce = true
+	t.Cleanup(func() { destroyForce = prevForce })
+
+	if err := runDestroy(cmd, []string{"alpha"}); err != nil {
+		t.Fatalf("runDestroy with --force should succeed even with unpushed work: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "alpha")); !os.IsNotExist(err) {
+		t.Errorf("instance should be removed; got: %v", err)
+	}
+}
+
+// scanInitGitRepoForCLITest is a local copy of the workspace package's
+// scanInitGitRepo — duplicated here because the cli package can't import
+// internal test helpers from another package. Initializes a git repo
+// with one committed file pushed to a bare remote.
+func scanInitGitRepoForCLITest(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bare := dir + ".bare"
+	if err := os.MkdirAll(bare, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "init", "--bare", "--initial-branch=main", bare).Run(); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+	gitRunForCLITest(t, dir, "init", "--initial-branch=main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRunForCLITest(t, dir, "add", "README.md")
+	gitRunForCLITest(t, dir, "commit", "-m", "initial")
+	gitRunForCLITest(t, dir, "remote", "add", "origin", bare)
+	gitRunForCLITest(t, dir, "push", "-u", "origin", "main")
+}
+
+func gitRunForCLITest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@example.com",
+		"HOME="+t.TempDir(),
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
 	}
 }
 

--- a/internal/workspace/scan.go
+++ b/internal/workspace/scan.go
@@ -478,19 +478,26 @@ func ScanInstancesParallel(workspaceRoot string, instanceDirs []string, workers 
 // workspaceName is shown in the closing prompt line; pass the
 // EffectiveConfigName-derived string from the caller.
 func FormatScans(scans []InstanceScan, w io.Writer, workspaceName string) {
-	any := false
+	losing := 0
 	for _, s := range scans {
 		if s.HasLoss() {
-			any = true
-			break
+			losing++
 		}
 	}
-	if !any {
-		fmt.Fprintln(w, "No unpushed work detected across instances.")
+	if losing == 0 {
+		if len(scans) == 1 {
+			fmt.Fprintln(w, "No unpushed work detected.")
+		} else {
+			fmt.Fprintln(w, "No unpushed work detected across instances.")
+		}
 		return
 	}
 
-	fmt.Fprintln(w, "The following instances have unpushed work:")
+	if losing == 1 {
+		fmt.Fprintln(w, "The following instance has unpushed work:")
+	} else {
+		fmt.Fprintln(w, "The following instances have unpushed work:")
+	}
 	fmt.Fprintln(w)
 	for _, s := range scans {
 		if !s.HasLoss() {


### PR DESCRIPTION
Replace the narrow `CheckUncommittedChanges` call in `runDestroyInstance` with the comprehensive `ScanInstance` + `FormatScans` + typed-confirmation flow that already gates the workspace-wipe path. Closes a gap in v0.10.2 where running `niwa destroy` from inside (or by name at) an instance would only catch uncommitted working-tree changes, silently destroying unpushed commits, stashes, local-only branches, and worktree state.

Every per-instance destroy path now runs the broader scan when `--force` is absent. If anything would be lost, niwa lists the affected repos, worktrees, and branches and prompts for typed confirmation against the **instance name** (workspace-wipe still uses the workspace name). `--force` still bypasses the scan entirely.

`workspace.CheckUncommittedChanges` itself stays untouched — `niwa reset` still uses it with the original narrower semantics. `FormatScans` pluralizes its header ("The following instance has unpushed work:" vs "The following instances...") so single-instance output reads naturally.

---

## Behavior change

**Before** (v0.10.2): `niwa destroy` from inside a dirty instance:
```
Repos with uncommitted changes:
  myrepo
Error: instance has uncommitted changes in 1 repo(s); use --force to override
```
And unpushed commits, stashes, and worktree state were not detected at all.

**After**: `niwa destroy` from inside an instance with any unpushed work:
```
The following instance has unpushed work:

  myws:
    myrepo:
      unpushed: feature/foo — ahead 2

Type "myws" to confirm deletion (or Ctrl-C to abort):
> 
```
Or in non-TTY:
```
Error: instance has unpushed work and stdin is not a terminal; aborting
       (resolve unpushed work, or use --force to destroy without confirmation)
```

Scripts that grepped on the old "instance has uncommitted changes" wording need to update; the exit code is unchanged (non-zero on refusal, zero on confirmed destroy).

## Test plan

- [x] New tests in `internal/cli/destroy_test.go`:
  - `TestRunDestroy_PerInstanceScansForUnpushedWorkAndRefusesNonTTY` — sets up an instance with an unpushed commit (`LossUnpushedCommits`, which the old narrow check missed), asserts the broader scan runs and the non-TTY refusal fires.
  - `TestRunDestroy_PerInstanceForceSkipsScan` — confirms `--force` still bypasses the scan even when work would be lost.
- [x] Existing destroy tests (control-flow, landing-path, picker non-TTY, named-instance) all still pass.
- [x] `internal/workspace/scan_test.go` and other unaffected suites green.
- [x] Pre-existing `TestConcurrentApply_SingleDaemon` flake is unrelated to this change (fails on main too).