### PR TITLE
fix(session): add tab completion and actionable missing-arg errors for session subcommands

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/mcp"
 	"github.com/tsukumogami/niwa/internal/workspace"
 )
 
@@ -77,6 +78,41 @@ func completeRepoNames(cmd *cobra.Command, args []string, toComplete string) ([]
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	return filterPrefix(names, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeSessionIDs is the completion closure for positions that accept a
+// session ID: the positional arg of `niwa session destroy`,
+// `niwa session attach`, and `niwa session detach`. It enumerates session
+// lifecycle state files under <instanceRoot>/.niwa/sessions/ via
+// mcp.ListSessionLifecycleStates.
+//
+// Instance resolution matches the runtime path used by the same commands
+// (resolveInstanceRoot): NIWA_INSTANCE_ROOT wins if set, otherwise we walk
+// up from cwd. Diverging here would create a discoverability trap where
+// tab completion returns empty even though the command itself runs fine.
+//
+// Errors are swallowed to match the convention used by the other
+// completers in this file: a transient failure should not surface a
+// completion banner.
+func completeSessionIDs(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	instanceRoot, err := resolveInstanceRoot()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	sessionsDir := filepath.Join(instanceRoot, ".niwa", "sessions")
+	states, err := mcp.ListSessionLifecycleStates(sessionsDir)
+	if err != nil || len(states) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ids := make([]string, 0, len(states))
+	for _, s := range states {
+		ids = append(ids, s.SessionID)
+	}
+	sort.Strings(ids)
+	return filterPrefix(ids, toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
 // completeGoTarget is the specialized closure for `niwa go [target]`. It

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/tsukumogami/niwa/internal/mcp"
 	"github.com/tsukumogami/niwa/internal/workspace"
 )
 
@@ -321,5 +323,148 @@ func TestCompleteGoTarget_NoArgs_EmptyWhenNothingMatches(t *testing.T) {
 	}
 	if len(out) != 0 {
 		t.Errorf("expected empty, got %v", out)
+	}
+}
+
+// writeSessionState writes a minimal SessionLifecycleState JSON file under
+// <instanceRoot>/.niwa/sessions/<id>.json so completeSessionIDs can pick
+// it up. The schema mirrors what mcp.WriteSessionLifecycleState produces,
+// but we write directly to bypass the regexp guard on session ID format
+// (the test IDs are all valid 8-hex anyway).
+func writeSessionState(t *testing.T, instanceRoot, id string) {
+	t.Helper()
+	sessionsDir := filepath.Join(instanceRoot, ".niwa", "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state := mcp.SessionLifecycleState{
+		V:         1,
+		SessionID: id,
+		Repo:      "test-repo",
+		Status:    "active",
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionsDir, id+".json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCompleteSessionIDs_EnumeratesSessions(t *testing.T) {
+	sandboxHome(t)
+	wsRoot := t.TempDir()
+	workspaceSkeleton(t, wsRoot, "myws")
+	instanceRoot := makeInstance(t, wsRoot, "myws", 1, nil)
+	writeSessionState(t, instanceRoot, "aabbccdd")
+	writeSessionState(t, instanceRoot, "11223344")
+
+	t.Chdir(instanceRoot)
+
+	out, directive := completeSessionIDs(&cobra.Command{}, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	want := []string{"11223344", "aabbccdd"}
+	if !slices.Equal(out, want) {
+		t.Errorf("got %v, want %v", out, want)
+	}
+}
+
+func TestCompleteSessionIDs_PrefixFilter(t *testing.T) {
+	sandboxHome(t)
+	wsRoot := t.TempDir()
+	workspaceSkeleton(t, wsRoot, "myws")
+	instanceRoot := makeInstance(t, wsRoot, "myws", 1, nil)
+	writeSessionState(t, instanceRoot, "aabbccdd")
+	writeSessionState(t, instanceRoot, "11223344")
+	writeSessionState(t, instanceRoot, "aaaaaaaa")
+
+	t.Chdir(instanceRoot)
+
+	out, _ := completeSessionIDs(&cobra.Command{}, nil, "aa")
+	want := []string{"aaaaaaaa", "aabbccdd"}
+	if !slices.Equal(out, want) {
+		t.Errorf("got %v, want %v", out, want)
+	}
+}
+
+func TestCompleteSessionIDs_HonorsNiwaInstanceRoot(t *testing.T) {
+	// Operators (and the test suite itself) set NIWA_INSTANCE_ROOT to point
+	// at an instance without chdir-ing into it. The runtime path
+	// (resolveInstanceRoot) honors that env var; the completer must match
+	// so tab completion works wherever the runtime command works.
+	sandboxHome(t)
+	wsRoot := t.TempDir()
+	workspaceSkeleton(t, wsRoot, "myws")
+	instanceRoot := makeInstance(t, wsRoot, "myws", 1, nil)
+	writeSessionState(t, instanceRoot, "deadbeef")
+
+	// cwd is outside the instance; only the env var connects us.
+	t.Chdir(t.TempDir())
+	t.Setenv("NIWA_INSTANCE_ROOT", instanceRoot)
+
+	out, _ := completeSessionIDs(&cobra.Command{}, nil, "")
+	want := []string{"deadbeef"}
+	if !slices.Equal(out, want) {
+		t.Errorf("got %v, want %v (NIWA_INSTANCE_ROOT not honored?)", out, want)
+	}
+}
+
+func TestCompleteSessionIDs_OutsideInstance(t *testing.T) {
+	sandboxHome(t)
+	t.Chdir(t.TempDir())
+
+	out, directive := completeSessionIDs(&cobra.Command{}, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty (no instance), got %v", out)
+	}
+}
+
+func TestCompleteSessionIDs_SkipsAtPosition2(t *testing.T) {
+	// At positions >0 we suppress completion: completeSessionIDs is wired
+	// onto session destroy/attach/detach, each of which takes a single
+	// session-id positional. If cobra ever asks for completions past that
+	// first position, we must not surface a second round of session IDs.
+	out, directive := completeSessionIDs(&cobra.Command{}, []string{"already-supplied"}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty at position >0, got %v", out)
+	}
+}
+
+func TestCompleteSessionCreateArgs_FirstArgIsRepo(t *testing.T) {
+	sandboxHome(t)
+	wsRoot := t.TempDir()
+	workspaceSkeleton(t, wsRoot, "myws")
+	instanceRoot := makeInstance(t, wsRoot, "myws", 1, map[string][]string{
+		"group": {"alpha", "beta"},
+	})
+	t.Chdir(instanceRoot)
+
+	out, directive := completeSessionCreateArgs(&cobra.Command{}, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	want := []string{"alpha", "beta"}
+	if !slices.Equal(out, want) {
+		t.Errorf("got %v, want %v", out, want)
+	}
+}
+
+func TestCompleteSessionCreateArgs_SecondArgSuppressed(t *testing.T) {
+	// <purpose> is freeform; the completer must not offer filename completion.
+	out, directive := completeSessionCreateArgs(&cobra.Command{}, []string{"alpha"}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want NoFileComp", directive)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty at position 2 (purpose), got %v", out)
 	}
 }

--- a/internal/cli/session_attach_register.go
+++ b/internal/cli/session_attach_register.go
@@ -45,10 +45,11 @@ or the propagated claude exit code (capped at 125).`,
 	// generic message. RunE validates arg count itself and returns an
 	// *sessionattach.ExitCodeError with Code=2 plus the PRD-mandated usage
 	// string when no session_id is supplied.
-	Args:          cobra.MaximumNArgs(1),
-	RunE:          runSessionAttach,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeSessionIDs,
+	RunE:              runSessionAttach,
+	SilenceErrors:     true,
+	SilenceUsage:      true,
 }
 
 var sessionDetachCmd = &cobra.Command{
@@ -68,10 +69,11 @@ With --force: SIGTERMs the holder, waits NIWA_DESTROY_GRACE_SECONDS
 code 4 to signal that a live holder was killed.`,
 	// Same reasoning as sessionAttachCmd: RunE handles missing-arg with the
 	// PRD R10 usage string and exit code 2.
-	Args:          cobra.MaximumNArgs(1),
-	RunE:          runSessionDetach,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeSessionIDs,
+	RunE:              runSessionDetach,
+	SilenceErrors:     true,
+	SilenceUsage:      true,
 }
 
 func runSessionAttach(cmd *cobra.Command, args []string) error {

--- a/internal/cli/session_lifecycle_cmd.go
+++ b/internal/cli/session_lifecycle_cmd.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/tsukumogami/niwa/internal/cli/sessionattach"
 	"github.com/tsukumogami/niwa/internal/mcp"
 	"github.com/tsukumogami/niwa/internal/workspace"
 )
@@ -26,8 +27,13 @@ Scaffolds a git worktree under .niwa/worktrees/<repo>-<session-id>/,
 writes the session lifecycle state, and starts the per-worktree daemon.
 
 On success the shell wrapper navigates to the new worktree directory.`,
-	Args: cobra.ExactArgs(2),
-	RunE: runSessionCreate,
+	// We don't use cobra.ExactArgs because its default error exits 1 with a
+	// generic "accepts 2 arg(s), received 0" message. RunE validates arg count
+	// itself and returns an *sessionattach.ExitCodeError with Code=2 plus a
+	// usage string naming <repo> and <purpose>.
+	Args:              cobra.MaximumNArgs(2),
+	ValidArgsFunction: completeSessionCreateArgs,
+	RunE:              runSessionCreate,
 }
 
 var sessionDestroyCmd = &cobra.Command{
@@ -36,8 +42,28 @@ var sessionDestroyCmd = &cobra.Command{
 	Long: `Destroy a session: kill running workers, mark the session ended,
 stop the per-worktree daemon, remove the worktree, and delete the session
 branch (only if already merged; use --force to delete regardless).`,
-	Args: cobra.ExactArgs(1),
-	RunE: runSessionDestroy,
+	// Same reasoning as sessionCreateCmd: RunE handles missing-arg with a
+	// usage string and exit code 2 via *sessionattach.ExitCodeError.
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeSessionIDs,
+	RunE:              runSessionDestroy,
+}
+
+// completeSessionCreateArgs returns repo completions for the first
+// positional argument and suppresses filename completion for the second
+// (<purpose> is freeform text).
+//
+// The switch shape is intentional: each case represents a positional slot,
+// so adding a future positional means adding a case rather than rewriting
+// the dispatcher. The single-arg completers in this file use a plain
+// `if len(args) > 0` guard instead because they only have one slot.
+func completeSessionCreateArgs(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	switch len(args) {
+	case 0:
+		return completeRepoNames(cmd, args, toComplete)
+	default:
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 }
 
 var sessionDestroyForce bool
@@ -47,6 +73,13 @@ func init() {
 }
 
 func runSessionCreate(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return &sessionattach.ExitCodeError{
+			Code: 2,
+			Msg: "niwa: usage: niwa session create <repo> <purpose>. " +
+				"Run `niwa session create --help` for details.",
+		}
+	}
 	instanceRoot, err := resolveInstanceRoot()
 	if err != nil {
 		return err
@@ -89,6 +122,13 @@ func runSessionCreate(cmd *cobra.Command, args []string) error {
 }
 
 func runSessionDestroy(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return &sessionattach.ExitCodeError{
+			Code: 2,
+			Msg: "niwa: usage: niwa session destroy <session-id> [--force]. " +
+				"Run `niwa session list` to discover existing sessions.",
+		}
+	}
 	instanceRoot, err := resolveInstanceRoot()
 	if err != nil {
 		return err

--- a/internal/cli/session_lifecycle_cmd_test.go
+++ b/internal/cli/session_lifecycle_cmd_test.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/tsukumogami/niwa/internal/cli/sessionattach"
 	"github.com/tsukumogami/niwa/internal/mcp"
 )
 
@@ -261,6 +263,105 @@ func TestSessionList_AttachedAndAvailableMutuallyExclusive(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("error message = %q, want substring 'mutually exclusive'", err.Error())
+	}
+}
+
+// TestRunSessionCreate_NoArgsReturnsUsageError verifies issue #135 behavior:
+// invoking `niwa session create` with no args must return
+// *sessionattach.ExitCodeError with Code=2 and a usage string that names the
+// expected positional arguments and points at --help. Cobra's default
+// ExactArgs error ("accepts 2 arg(s), received 0") exits 1 with a generic
+// message; this guard ensures we don't regress to that behavior.
+func TestRunSessionCreate_NoArgsReturnsUsageError(t *testing.T) {
+	err := runSessionCreate(sessionCreateCmd, nil)
+	if err == nil {
+		t.Fatalf("want ExitCodeError, got nil")
+	}
+	var ece *sessionattach.ExitCodeError
+	if !errors.As(err, &ece) {
+		t.Fatalf("err is not *ExitCodeError: %T", err)
+	}
+	if ece.Code != 2 {
+		t.Errorf("Code = %d, want 2 (usage error)", ece.Code)
+	}
+	wantSubstrs := []string{
+		"niwa: usage",
+		"niwa session create",
+		"<repo>",
+		"<purpose>",
+		"niwa session create --help",
+	}
+	for _, s := range wantSubstrs {
+		if !strings.Contains(ece.Msg, s) {
+			t.Errorf("missing %q in usage message: %q", s, ece.Msg)
+		}
+	}
+}
+
+// TestRunSessionCreate_OneArgReturnsUsageError covers the partial-args case:
+// only <repo> supplied. The behavior should match the no-args case.
+func TestRunSessionCreate_OneArgReturnsUsageError(t *testing.T) {
+	err := runSessionCreate(sessionCreateCmd, []string{"some-repo"})
+	if err == nil {
+		t.Fatalf("want ExitCodeError, got nil")
+	}
+	var ece *sessionattach.ExitCodeError
+	if !errors.As(err, &ece) {
+		t.Fatalf("err is not *ExitCodeError: %T", err)
+	}
+	if ece.Code != 2 {
+		t.Errorf("Code = %d, want 2", ece.Code)
+	}
+}
+
+// TestRunSessionDestroy_NoArgsReturnsUsageError verifies issue #135 behavior
+// for destroy: usage error names <session-id> and points at
+// `niwa session list` (not --status active, since destroy operates on any
+// status).
+func TestRunSessionDestroy_NoArgsReturnsUsageError(t *testing.T) {
+	err := runSessionDestroy(sessionDestroyCmd, nil)
+	if err == nil {
+		t.Fatalf("want ExitCodeError, got nil")
+	}
+	var ece *sessionattach.ExitCodeError
+	if !errors.As(err, &ece) {
+		t.Fatalf("err is not *ExitCodeError: %T", err)
+	}
+	if ece.Code != 2 {
+		t.Errorf("Code = %d, want 2 (usage error)", ece.Code)
+	}
+	wantSubstrs := []string{
+		"niwa: usage",
+		"niwa session destroy",
+		"<session-id>",
+		"[--force]",
+		"niwa session list",
+	}
+	for _, s := range wantSubstrs {
+		if !strings.Contains(ece.Msg, s) {
+			t.Errorf("missing %q in usage message: %q", s, ece.Msg)
+		}
+	}
+}
+
+// TestSessionCommands_HaveCompletion verifies that the four session
+// positional-arg subcommands all expose a ValidArgsFunction. This is a
+// regression guard: removing the wiring should fail this test, since
+// dropping completion is what issue #135 fixed.
+func TestSessionCommands_HaveCompletion(t *testing.T) {
+	cmds := []struct {
+		name string
+		fn   any
+	}{
+		{"session create", sessionCreateCmd.ValidArgsFunction},
+		{"session destroy", sessionDestroyCmd.ValidArgsFunction},
+		{"session attach", sessionAttachCmd.ValidArgsFunction},
+		{"session detach", sessionDetachCmd.ValidArgsFunction},
+	}
+	for _, c := range cmds {
+		if c.fn == nil {
+			t.Errorf("%s: ValidArgsFunction is nil, want a completion function", c.name)
+		}
 	}
 }
 


### PR DESCRIPTION
Wire ValidArgsFunction on all four niwa session positional-arg subcommands (create, destroy, attach, detach), and replace cobra.ExactArgs on create/destroy with a manual len(args) check in RunE that returns *sessionattach.ExitCodeError{Code: 2, Msg: usage}. Adds completeSessionIDs, a new helper in internal/cli/completion.go that enumerates session lifecycle state files via mcp.ListSessionLifecycleStates and honors NIWA_INSTANCE_ROOT the same way the runtime path does. completeSessionCreateArgs dispatches the two positional slots of create: position 0 routes to completeRepoNames, position 1 returns NoFileComp so freeform <purpose> doesn't fall back to filename completion. Session create and destroy now produce the same exit-2 usage-style errors that attach and detach already produce.

---

## What This Fixes

Before: `niwa session create` with no args printed `accepts 2 arg(s), received 0` and exited 1 — no hint of what those args are. Tab completion was absent on all four session subcommands, the only positional-arg niwa commands missing it.

After: `niwa session create` (no args) prints `niwa: usage: niwa session create <repo> <purpose>. Run \`niwa session create --help\` for details.` and exits 2. `niwa session destroy` (no args) points at `niwa session list`. Tab completion works for repo names on `session create`, and for session IDs on the other three commands.

## Implementation Notes

- Mirrors the existing session attach/detach precedent in `internal/cli/session_attach_register.go`. Reuses `sessionattach.ExitCodeError` since `cli.Execute()` already type-asserts on it to set the exit code.
- `completeSessionIDs` calls `resolveInstanceRoot()` so `NIWA_INSTANCE_ROOT` is honored. Without this, tab completion silently returns empty when the env var is set but cwd is outside the instance — a configuration heavily used by the test suite and by operator workflows.

## Test Plan

- `go test ./...` (passes — 11 new tests added covering completion output, missing-arg error shape, and a regression guard that all four session subcommands have a `ValidArgsFunction`).
- `go vet ./...` (clean).
- Validation script from the issue body (passes — exercises create/destroy/attach with no args against a freshly built binary).
- Manual: `niwa __complete session destroy ""` enumerates session IDs from `<instanceRoot>/.niwa/sessions/`.

Fixes #135