### PR TITLE
fix(apply): treat the overlay repo as a normal workspace repo

### DIFF
--- a/internal/config/overlay.go
+++ b/internal/config/overlay.go
@@ -214,14 +214,6 @@ func DeriveOverlayURL(sourceURL string) (conventionURL string, ok bool) {
 	return org + "/" + repo + "-overlay", true
 }
 
-// OverlayRepoName extracts the repository name from an overlay URL.
-// Accepts HTTPS URLs, SSH URLs, or shorthand (org/repo). Returns ok=false
-// when the URL cannot be parsed.
-func OverlayRepoName(overlayURL string) (string, bool) {
-	_, repo, ok := parseOrgRepo(overlayURL)
-	return repo, ok
-}
-
 // parseOrgRepo extracts (org, repo) from an HTTPS URL, SSH URL, or shorthand.
 // Strips a trailing ".git" suffix from the repo name.
 func parseOrgRepo(s string) (org, repo string, ok bool) {

--- a/internal/config/overlay_test.go
+++ b/internal/config/overlay_test.go
@@ -102,33 +102,6 @@ func TestDeriveOverlayURL(t *testing.T) {
 	}
 }
 
-func TestOverlayRepoName(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		wantName string
-		wantOK   bool
-	}{
-		{"shorthand", "myorg/myrepo-overlay", "myrepo-overlay", true},
-		{"https", "https://github.com/myorg/myrepo-overlay.git", "myrepo-overlay", true},
-		{"ssh", "git@github.com:myorg/myrepo-overlay.git", "myrepo-overlay", true},
-		{"no git suffix", "myorg/myrepo-overlay", "myrepo-overlay", true},
-		{"invalid", "notavalidurl", "", false},
-		{"empty", "", "", false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := OverlayRepoName(tc.input)
-			if ok != tc.wantOK {
-				t.Errorf("OverlayRepoName(%q) ok=%v, want %v", tc.input, ok, tc.wantOK)
-			}
-			if ok && got != tc.wantName {
-				t.Errorf("OverlayRepoName(%q) = %q, want %q", tc.input, got, tc.wantName)
-			}
-		})
-	}
-}
-
 func TestOverlayDir_WithXDGConfigHome(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -734,13 +734,6 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 		}
 	}
 
-	// Determine the active overlay URL for repo filtering below.
-	// Either branch 2 (opts.overlayURL) or branch 3 (pipelineOverlayURL) may have set it.
-	activeOverlayURL := opts.overlayURL
-	if activeOverlayURL == "" {
-		activeOverlayURL = pipelineOverlayURL
-	}
-
 	// Step 0.6: Parse and merge the overlay config when overlayDir is set.
 	// The merged config replaces cfg for all subsequent pipeline steps, including
 	// discoverAllRepos, so overlay sources contribute repos to discovery.
@@ -817,24 +810,17 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 	}
 
 	// Step 1: Discover repos from all sources (base + overlay after merge).
+	// An overlay repo (e.g. <workspace>-overlay) picked up by org auto-scan
+	// is treated as a normal workspace repo here. Do not re-introduce a
+	// filter at this step — issue #137 deliberately removed one because it
+	// conflated two distinct concerns: the canonical overlay config (read
+	// from OverlayDir(overlayURL) in Step 0.6) and the workspace working
+	// copy (a regular cloned repo under the instance root). A working copy
+	// never affects apply until it is pushed and re-synced into the XDG
+	// snapshot.
 	allRepos, err := a.discoverAllRepos(ctx, cfg.Sources)
 	if err != nil {
 		return nil, err
-	}
-
-	// Filter the overlay repo itself out of allRepos. When the overlay repo lives
-	// in the same org as the workspace source, the org-level auto-scan picks it up
-	// as a regular workspace repo. Leaving it in causes spurious output like
-	// "skipped fake-dot-niwa-overlay (dirty working tree)" — R22 requires zero
-	// output referencing the overlay in standard apply mode.
-	if overlayRepoName, ok := config.OverlayRepoName(activeOverlayURL); ok {
-		filtered := allRepos[:0]
-		for _, r := range allRepos {
-			if r.Name != overlayRepoName {
-				filtered = append(filtered, r)
-			}
-		}
-		allRepos = filtered
 	}
 
 	// Step 2: Classify repos into groups.

--- a/internal/workspace/apply_test.go
+++ b/internal/workspace/apply_test.go
@@ -2935,3 +2935,70 @@ visibility = "public"
 		t.Errorf("Apply did not write *.local* to .gitignore, got:\n%s", string(data))
 	}
 }
+
+// TestOverlayRepoFlowsThroughDiscoveryAndClassify is the regression guard for
+// issue #137: previously, the overlay repo (e.g. `test-ws-overlay`) was
+// unconditionally filtered out of the discovered repo list between
+// discoverAllRepos and Classify, so it could never be a workspace component
+// regardless of how the user declared their groups. With the filter gone,
+// an org auto-scan that picks up `<workspace>-overlay` produces a repo entry
+// that flows through Classify like any other repo and ends up in whichever
+// group matches its visibility.
+//
+// This test pins the seam where the filter used to live (discoverAllRepos →
+// Classify) rather than driving runPipeline end-to-end. A filter
+// re-introduced inside runPipeline between those two calls would not fail
+// this test directly, but the load-bearing claim — that no filter sits
+// between discovery and classification — is what we are guarding against.
+func TestOverlayRepoFlowsThroughDiscoveryAndClassify(t *testing.T) {
+	mockClient := &mockGitHubClient{
+		repos: map[string][]github.Repo{
+			"testorg": {
+				{Name: "repo1", Visibility: "private", SSHURL: "git@github.com:testorg/repo1.git"},
+				{Name: "test-ws-overlay", Visibility: "private", SSHURL: "git@github.com:testorg/test-ws-overlay.git"},
+			},
+		},
+	}
+
+	applier := NewApplier(mockClient)
+	discovered, err := applier.discoverAllRepos(context.Background(), []config.SourceConfig{
+		{Org: "testorg"},
+	})
+	if err != nil {
+		t.Fatalf("discoverAllRepos: %v", err)
+	}
+
+	// Both repos must appear in the discovered list — no filter strips the overlay.
+	names := make(map[string]bool, len(discovered))
+	for _, r := range discovered {
+		names[r.Name] = true
+	}
+	if !names["test-ws-overlay"] {
+		t.Errorf("overlay repo missing from discovery: got %v", names)
+	}
+	if !names["repo1"] {
+		t.Errorf("regular repo missing from discovery: got %v", names)
+	}
+
+	// Both must classify into the private group.
+	groups := map[string]config.GroupConfig{
+		"private": {Visibility: "private"},
+	}
+	classified, warnings, err := Classify(discovered, groups)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected classify warnings: %v", warnings)
+	}
+	classifiedNames := make(map[string]string, len(classified))
+	for _, c := range classified {
+		classifiedNames[c.Repo.Name] = c.Group
+	}
+	if classifiedNames["test-ws-overlay"] != "private" {
+		t.Errorf("overlay repo not classified into private group: got %v", classifiedNames)
+	}
+	if classifiedNames["repo1"] != "private" {
+		t.Errorf("regular repo not classified into private group: got %v", classifiedNames)
+	}
+}


### PR DESCRIPTION
Delete the unconditional filter at internal/workspace/apply.go that stripped the overlay repo from the discovered repo list between discoverAllRepos and Classify. The filter conflated two distinct concerns: the canonical overlay config source-of-truth (managed under <xdg>/niwa/overlays/...) and the ability to have a working copy of the overlay repo as a workspace component for worktrees, sessions, and agent roles. With the filter gone, an overlay repo discovered via an org [[source]] now flows through Classify like any other repo and joins whichever group its visibility matches.

Also delete the activeOverlayURL plumbing that fed only the filter, and the config.OverlayRepoName helper that has no remaining production callers. parseOrgRepo stays — still used by DeriveOverlayURL and OverlayDir. The XDG snapshot remains the source of truth for applying overlay config; edits to a workspace working copy of the overlay repo take effect only after a push and re-sync, consistent with current behavior.

Add a Step 1 anchor comment in apply.go referencing this issue and explicitly forbidding re-introduction of a filter at the same site, so the obvious next mistake (silencing a dirty-tree warning by adding the filter back) is actively guarded.

Add TestOverlayRepoFlowsThroughDiscoveryAndClassify in apply_test.go: with a mock GitHub client returning both repo1 and test-ws-overlay from the same org, both repos must appear in the discovered list and classify into the matching private group with zero warnings.

---

## What This Fixes

Before: even with `[groups.private]` declared in a workspace overlay, the overlay repo itself was silently dropped between discovery and classification. The only workaround was an awkward `[repos.<overlay-name>] url = "..." group = "..."` block with a redundant URL, which used the external-repo code path inappropriately.

After: the overlay repo is treated uniformly with every other repo. If its visibility matches a group, it gets included.

## Implementation Notes

- The filter's stated justification (R22) was misappropriated — R22 is actually the secret-redaction rule. The real concern was suppressing functional-test noise. Once the overlay is reconceptualized as a normal repo, the noise is correct output.
- The new regression test is a slice-level guard (discoverAllRepos → Classify), not a full runPipeline integration test. The docstring acknowledges this limitation.

## Test Plan

- `go test ./...` (passes — 1 new regression test, 1 deleted test for the removed helper).
- `go vet ./...` (clean).
- Validation script from the issue body (passes).
- Existing TestApplyOverlay* tests continue to pass with no fixture changes (none asserted overlay-absent behavior).

Fixes #137