### PR TITLE
fix(workspace): emit team-config rank-2 notice + install plugin from niwa create

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -122,17 +122,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	applier.Reporter = workspace.NewReporterWithTTY(os.Stderr, !noProgress && term.IsTerminal(int(os.Stderr.Fd())))
 	applier.NoPull = applyNoPull
 	applier.AllowDirty = applyAllowDirty
-	// Wire the auto-installer + opt-outs. SkipPluginInstall ORs the
-	// per-invocation --no-install-plugins flag with the persistent
-	// auto_install_plugins = false global-config setting (PRD R19).
-	// The global config load failure here is non-fatal — the per-flag
-	// fallback ships the user-visible behavior either way.
-	skipFromGlobal := false
-	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
-		skipFromGlobal = globalCfg.SkipPluginInstall()
-	}
-	applier.SkipPluginInstall = applyNoInstallPlugins || skipFromGlobal
-	applier.InstallNiwaPlugin = installNiwaPluginAdapter
+	configurePluginAutoInstall(applier, applyNoInstallPlugins)
 	if applyAllowDirty {
 		// PRD R32: --allow-dirty is meaningless under the snapshot
 		// model and slated for removal in v1.1. Print the deprecation

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -19,14 +19,16 @@ func init() {
 	createCmd.Flags().StringVarP(&createRepo, "repo", "r", "", "land in this repo after creation")
 	createCmd.Flags().BoolVar(&createChannels, "channels", false, "enable channel infrastructure for this invocation (overrides NIWA_CHANNELS)")
 	createCmd.Flags().BoolVar(&createNoChannels, "no-channels", false, "disable channel infrastructure for this invocation (overrides --channels and NIWA_CHANNELS)")
+	createCmd.Flags().BoolVar(&createNoInstallPlugins, "no-install-plugins", false, "skip auto-installing the embedded niwa Claude Code plugin (otherwise installed once when a rank-2 source is detected)")
 	createCmd.ValidArgsFunction = completeWorkspaceNames
 }
 
 var (
-	createName       string
-	createRepo       string
-	createChannels   bool
-	createNoChannels bool
+	createName             string
+	createRepo             string
+	createChannels         bool
+	createNoChannels       bool
+	createNoInstallPlugins bool
 )
 
 var createCmd = &cobra.Command{
@@ -142,6 +144,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	applier := workspace.NewApplier(gh)
 	applier.Reporter = workspace.NewReporterWithTTY(os.Stderr, !noProgress && term.IsTerminal(int(os.Stderr.Fd())))
+	// Wire the plugin auto-installer so the rank-2 overlay notice
+	// fired inside runPipeline can trigger `/niwa:migrate-config`
+	// install. Without this seam the install is a silent no-op even
+	// when the rank-2 notice surfaces.
+	configurePluginAutoInstall(applier, createNoInstallPlugins)
 
 	// Wire up the global config overlay so vault resolution and personal-wins
 	// merging work during create. ConfigSourceURL is a fallback for overlay

--- a/internal/cli/plugin_adapter.go
+++ b/internal/cli/plugin_adapter.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/tsukumogami/niwa/internal/config"
 	"github.com/tsukumogami/niwa/internal/plugin"
 	"github.com/tsukumogami/niwa/internal/workspace"
 )
@@ -12,4 +13,22 @@ import (
 // supplies the implementation at construction time.
 func installNiwaPluginAdapter(state *workspace.InstanceState, reporter *workspace.Reporter, skipInstall bool) {
 	plugin.Install(state, reporter, plugin.InstallOpts{SkipInstall: skipInstall})
+}
+
+// configurePluginAutoInstall wires the plugin auto-installer onto an
+// Applier. The applier's InstallNiwaPlugin function-field seam stays
+// nil if this helper is never called — meaning the rank-2-triggered
+// install is a no-op. Every CLI surface that constructs an Applier
+// (apply, create, reset, …) must call this helper so the auto-install
+// fires consistently regardless of which command surfaced the rank-2
+// notice. flagOptOut is the per-invocation --no-install-plugins value;
+// the persistent auto_install_plugins = false global-config setting
+// is OR'd in here so callers don't have to load GlobalConfig twice.
+func configurePluginAutoInstall(applier *workspace.Applier, flagOptOut bool) {
+	skipFromGlobal := false
+	if globalCfg, gErr := config.LoadGlobalConfig(); gErr == nil {
+		skipFromGlobal = globalCfg.SkipPluginInstall()
+	}
+	applier.SkipPluginInstall = flagOptOut || skipFromGlobal
+	applier.InstallNiwaPlugin = installNiwaPluginAdapter
 }

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -110,6 +110,12 @@ func runReset(cmd *cobra.Command, args []string) error {
 	gh := github.NewAPIClient(token)
 
 	applier := workspace.NewApplier(gh)
+	// Reset runs runPipeline; wire the plugin auto-installer so the
+	// rank-2 overlay notice fired during the pipeline triggers
+	// /niwa:migrate-config install. Reset doesn't surface its own
+	// --no-install-plugins flag — the persistent
+	// auto_install_plugins=false global setting is honored.
+	configurePluginAutoInstall(applier, false)
 	registryName, err := resolveEffectiveWorkspaceName(workspaceRoot, cfg)
 	if err != nil {
 		return err

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -251,6 +251,18 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 	// discovery and without depending on workspace repos being cloned.
 	initState, _ := LoadState(workspaceRoot)
 
+	// Refresh the team config snapshot (PRD R10-R13). This was
+	// previously only done by Apply(); doing it here too means
+	// `niwa create` picks up upstream maintainer changes AND emits
+	// the rank-2 deprecation notice for users upgrading from a
+	// pre-discovery niwa release.
+	fetcher, _ := a.GitHubClient.(FetchClient)
+	configConverted, teamConfigRank, err := EnsureConfigSnapshotWithStatus(ctx, configDir, config.TeamConfigMarkerSet(), fetcher, a.Reporter)
+	if err != nil {
+		_ = os.RemoveAll(instanceRoot)
+		return "", fmt.Errorf("refreshing team config: %w", err)
+	}
+
 	// Resolve the effective workspace name early. Doing this before
 	// runPipeline gives two benefits: a tampered ConfigNameOverride
 	// (defense in depth per Security §4) fails immediately rather than
@@ -285,6 +297,27 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 	if err != nil {
 		_ = os.RemoveAll(instanceRoot)
 		return "", err
+	}
+
+	// PRD R28: emit the lazy-conversion `note:` once per workspace.
+	if configConverted && !sliceContains(initDisclosedNotices, noticeConfigConverted) {
+		a.Reporter.Log("note: %s converted from working tree to snapshot. Manual edits inside this directory will no longer persist.", configDir)
+		result.disclosedNotices = append(result.disclosedNotices, noticeConfigConverted)
+	}
+
+	// PRD R10: emit the rank-2 deprecation notice for the team config
+	// once per workspace when the source resolves to the legacy
+	// whole-repo layout, and trigger the niwa plugin auto-install.
+	if teamConfigRank == 2 && !sliceContains(initDisclosedNotices, NoticeIDRank2TeamConfig) {
+		identifier := a.ConfigSourceURL
+		if identifier == "" {
+			identifier = configDir
+		}
+		EmitRank2Notice(NoticeIDRank2TeamConfig, identifier, a.Reporter)
+		result.disclosedNotices = append(result.disclosedNotices, NoticeIDRank2TeamConfig)
+		if a.InstallNiwaPlugin != nil {
+			a.InstallNiwaPlugin(nil, a.Reporter, a.SkipPluginInstall)
+		}
 	}
 
 	// Use the effective configName (resolved earlier above) for the


### PR DESCRIPTION
Refresh the team-config snapshot from `Create()` so `niwa create`
also emits the PRD R10 rank-2 deprecation notice (previously fired
only from `niwa apply`), and wire the niwa plugin auto-install seam
in `cli/create.go` and `cli/reset.go` so the install actually runs
when the rank-2 notice surfaces from those commands.

Extracts the shared `configurePluginAutoInstall` helper into
`cli/plugin_adapter.go` so apply, create, and reset use identical
wiring (per-invocation `--no-install-plugins` flag OR'd with the
persistent `auto_install_plugins = false` global-config setting).
Adds the `--no-install-plugins` flag to `niwa create` for parity.

---

## What This Fixes

A user upgraded from niwa v0.10.4 (pre-discovery) to v0.11.0 and
ran `niwa create` against their workspace. The team config source
(`tsukumogami/dot-niwa`) is rank-2 layout (`workspace.toml` at repo
root) — exactly the case the v0.11.0 deprecation-notice machinery
was designed to surface. They saw the rank-2 notice for the
auto-discovered overlay (`tsukumogami/dot-niwa-overlay`) but
neither the team-config rank-2 notice nor the auto-installed
`/niwa:migrate-config` plugin appeared.

Two independent bugs caused this:

1. **Team-config notice scope was too narrow.** `Apply()` refreshed
   the team-config snapshot via `EnsureConfigSnapshotWithStatus` and
   emitted the rank-2 notice based on the returned rank. `Create()`
   skipped that path and went straight to `runPipeline`. Users
   reaching `niwa create` before their first `niwa apply` never saw
   the team-config notice.

2. **Plugin auto-install seam was wired only from apply.**
   `cli/apply.go` set `applier.InstallNiwaPlugin = installNiwaPluginAdapter`
   during Applier construction. `cli/create.go` and `cli/reset.go`
   built their Applier without that line, so when the rank-2 overlay
   notice fired from inside `runPipeline` during create/reset, the
   install call was a silent no-op because of the
   `if a.InstallNiwaPlugin != nil` guard.

## Example

Before this fix:

```
$ niwa create
note: source tsukumogami/dot-niwa-overlay uses the deprecated rank-2 layout...
# (no team-config notice, no plugin installed)
$ ls ~/.claude/plugins/marketplaces/
# (empty)
```

After this fix:

```
$ niwa create
note: source tsukumogami/dot-niwa uses the deprecated rank-2 layout (workspace.toml at repo root). Run /niwa:migrate-config to migrate the source to the rank-1 layout (.niwa/workspace.toml).
note: source tsukumogami/dot-niwa-overlay uses the deprecated rank-2 layout (workspace.toml at repo root). Run /niwa:migrate-config to migrate the source to the rank-1 layout (.niwa/workspace.toml).
note: niwa Claude Code plugin installed at ~/.claude/plugins/marketplaces/niwa/...
$ ls ~/.claude/plugins/marketplaces/niwa/
manifest.json  skills/
```

## Test Plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [ ] Manual: `niwa create` against a rank-2 team-config workspace from a fresh `~/.claude/` reproduces the install behavior.
- [ ] CI green.

## Implementation Notes

`Create()` now calls `EnsureConfigSnapshotWithStatus` before
`runPipeline`, mirroring `Apply()`. This is a behavior addition —
previously `niwa create` did not refresh the team-config snapshot,
relying on init to have done it. The refresh picks up upstream
maintainer changes and is necessary for the rank to be determined.

The shared `configurePluginAutoInstall` helper accepts a per-flag
opt-out and ORs in the persistent global setting; both opt-outs
honor PRD R19.