### PR TITLE
fix: accept --allow-plaintext-secrets and --allow-missing-secrets on niwa create

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -20,15 +20,22 @@ func init() {
 	createCmd.Flags().BoolVar(&createChannels, "channels", false, "enable channel infrastructure for this invocation (overrides NIWA_CHANNELS)")
 	createCmd.Flags().BoolVar(&createNoChannels, "no-channels", false, "disable channel infrastructure for this invocation (overrides --channels and NIWA_CHANNELS)")
 	createCmd.Flags().BoolVar(&createNoInstallPlugins, "no-install-plugins", false, "skip auto-installing the embedded niwa Claude Code plugin (otherwise installed once when a rank-2 source is detected)")
+	createCmd.Flags().BoolVar(&createAllowMissingSecrets, "allow-missing-secrets", false,
+		"downgrade unresolved vault:// references to empty strings with stderr warnings. "+
+			"Does NOT override *.required misses. One-shot -- re-evaluated each invocation.")
+	createCmd.Flags().BoolVar(&createAllowPlaintextSecrets, "allow-plaintext-secrets", false,
+		"bypass the public-repo plaintext-secrets guardrail. Strictly one-shot -- no state persistence.")
 	createCmd.ValidArgsFunction = completeWorkspaceNames
 }
 
 var (
-	createName             string
-	createRepo             string
-	createChannels         bool
-	createNoChannels       bool
-	createNoInstallPlugins bool
+	createName                  string
+	createRepo                  string
+	createChannels              bool
+	createNoChannels            bool
+	createNoInstallPlugins      bool
+	createAllowMissingSecrets   bool
+	createAllowPlaintextSecrets bool
 )
 
 var createCmd = &cobra.Command{
@@ -149,6 +156,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// install. Without this seam the install is a silent no-op even
 	// when the rank-2 notice surfaces.
 	configurePluginAutoInstall(applier, createNoInstallPlugins)
+	applier.AllowMissingSecrets = createAllowMissingSecrets
+	applier.AllowPlaintextSecrets = createAllowPlaintextSecrets
 
 	// Wire up the global config overlay so vault resolution and personal-wins
 	// merging work during create. ConfigSourceURL is a fallback for overlay

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -225,3 +225,58 @@ func TestFindRepoDir_SkipsDotDirs(t *testing.T) {
 		t.Errorf("expected 'not found' in error, got: %v", err)
 	}
 }
+
+// TestCreateCmd_HasAllowMissingSecretsFlag mirrors the apply-side check.
+// The flag plumbs into workspace.Applier.AllowMissingSecrets, which the
+// Applier honors uniformly for both Create and Apply (it routes through
+// the same runPipeline).
+func TestCreateCmd_HasAllowMissingSecretsFlag(t *testing.T) {
+	flag := createCmd.Flags().Lookup("allow-missing-secrets")
+	if flag == nil {
+		t.Fatal("expected --allow-missing-secrets flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("expected default false, got %q", flag.DefValue)
+	}
+}
+
+// TestCreateCmd_HasAllowPlaintextSecretsFlag mirrors the apply-side check.
+// The error message emitted by the public-remote materializer guardrail
+// recommends this flag; this test pins it so the suggestion stays
+// actionable from create.
+func TestCreateCmd_HasAllowPlaintextSecretsFlag(t *testing.T) {
+	flag := createCmd.Flags().Lookup("allow-plaintext-secrets")
+	if flag == nil {
+		t.Fatal("expected --allow-plaintext-secrets flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("expected default false, got %q", flag.DefValue)
+	}
+}
+
+// TestCreateCmd_AllowFlagsThreadToApplier mirrors the apply-side check
+// that the parsed flags populate package-level vars runCreate copies
+// onto the Applier struct. The pipeline integration that the Applier
+// then honors these fields is already covered by the workspace and
+// guardrail tests.
+func TestCreateCmd_AllowFlagsThreadToApplier(t *testing.T) {
+	savedMissing := createAllowMissingSecrets
+	savedPlain := createAllowPlaintextSecrets
+	t.Cleanup(func() {
+		createAllowMissingSecrets = savedMissing
+		createAllowPlaintextSecrets = savedPlain
+	})
+
+	createAllowMissingSecrets = false
+	createAllowPlaintextSecrets = false
+
+	if err := createCmd.ParseFlags([]string{"--allow-missing-secrets", "--allow-plaintext-secrets"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if !createAllowMissingSecrets {
+		t.Error("expected createAllowMissingSecrets to be true after --allow-missing-secrets")
+	}
+	if !createAllowPlaintextSecrets {
+		t.Error("expected createAllowPlaintextSecrets to be true after --allow-plaintext-secrets")
+	}
+}


### PR DESCRIPTION
Declare `--allow-plaintext-secrets` and `--allow-missing-secrets` on `niwa create` and thread them onto the `Applier` struct before `applier.Create`, mirroring the wiring on `niwa apply`. The materializer's public-remote guardrail and the vault resolver already read these fields off the `Applier`, so no workspace-side changes are needed — `Create` and `Apply` share `runPipeline`. Three CLI tests pin the flag registration and the package-level var plumbing, parallel to the existing apply-side tests.

---

Fixes #141

## Why

The materializer guardrail's error message recommends `--allow-plaintext-secrets` as the bypass, but until this change the flag was only declared on `niwa apply`. Users hitting the guardrail on first `niwa create` saw `unknown flag: --allow-plaintext-secrets` when they followed the suggestion. `--allow-missing-secrets` is added alongside for symmetry with `apply` — both flags are vault-related and users hitting the public-remote guardrail are often the same users who later hit `*.required` misses.

## Verification

```
$ niwa create --help | grep -E 'allow-(plaintext|missing)'
      --allow-missing-secrets     downgrade unresolved vault:// references to empty strings with stderr warnings. Does NOT override *.required misses. One-shot -- re-evaluated each invocation.
      --allow-plaintext-secrets   bypass the public-repo plaintext-secrets guardrail. Strictly one-shot -- no state persistence.

$ go test ./internal/cli/ -count=1
ok  	github.com/tsukumogami/niwa/internal/cli	12.919s
```

## Out of scope

No `@critical` Gherkin scenario is added. The apply-side `--allow-plaintext-secrets` flag has no functional-test coverage either; the unit tests in `internal/workspace/env_example_prepass_test.go`, `internal/guardrail/githubpublic_test.go`, and `internal/cli/apply_test.go` collectively pin the behavior end-to-end at the Go-test level. Adding Gherkin coverage symmetrically across both commands feels like its own follow-up rather than a piggyback here.

The related observation in #141 about the entropy heuristic flagging `host.docker.internal` is separately scoped and not addressed in this PR.