### PR TITLE
fix(init): bind bootstrap repo to its group so apply classifies it

### DIFF
--- a/docs/guides/init-bootstrap.md
+++ b/docs/guides/init-bootstrap.md
@@ -204,6 +204,9 @@ repos = ["<bootstrap-repo>"]
 
 [groups.<vis-key>]
 visibility = "<vis-value>"
+# Bind the bootstrap repo to this group by name: explicit-repos sources carry
+# no live visibility, so name membership is what places the repo in a group.
+repos = ["<bootstrap-repo>"]
 
 # Bootstrap enabled mesh channels. Remove this block (and the [channels.mesh] line below) to disable.
 [channels.mesh]

--- a/docs/prds/PRD-init-bootstrap-empty-source.md
+++ b/docs/prds/PRD-init-bootstrap-empty-source.md
@@ -849,6 +849,9 @@ repos = ["<bootstrap-repo>"]
 
 [groups.<vis-key>]
 visibility = "<vis-value>"
+# Bind the bootstrap repo to this group by name: explicit-repos sources carry
+# no live visibility, so name membership is what places the repo in a group.
+repos = ["<bootstrap-repo>"]
 
 # Bootstrap enabled mesh channels. Remove this block (and the [channels.mesh] line below) to disable.
 [channels.mesh]

--- a/internal/workspace/bootstrap_classify_test.go
+++ b/internal/workspace/bootstrap_classify_test.go
@@ -1,0 +1,90 @@
+package workspace
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/github"
+)
+
+// failingGitHubClient fails the test if the GitHub API is touched. The
+// explicit-repos discovery path must not call ListRepos, so this guards
+// that contract while we exercise classification offline.
+type failingGitHubClient struct{ t *testing.T }
+
+func (f *failingGitHubClient) ListRepos(context.Context, string) ([]github.Repo, error) {
+	f.t.Helper()
+	f.t.Fatal("ListRepos called: an explicit-repos [[sources]] block must not hit the GitHub API")
+	return nil, nil
+}
+
+// TestScaffoldFromSource_ClassifiesOwnRepo is the regression test for the
+// bootstrap classification gap. The scaffold writes an explicit-repos source
+// (no live visibility) alongside its group block; discoverRepos builds those
+// repos with an empty Visibility, so the scaffold MUST bind the repo to its
+// group by name. Otherwise the repo matches no group, apply produces zero
+// repos and no role, and bootstrap dies at session-create with
+// "unknown role: role <repo> not found".
+//
+// This drives the real apply chain (scaffold -> config.Load -> discoverRepos
+// -> Classify) end to end — the seam that the stubbed bootstrap tests skip.
+func TestScaffoldFromSource_ClassifiesOwnRepo(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		private   bool
+		wantGroup string
+	}{
+		{"public", false, "public"},
+		{"private", true, "private"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			opts := ScaffoldOptions{
+				Name:           "ws",
+				Org:            "owner",
+				Repo:           "bootstrap-repo",
+				Private:        tc.private,
+				IncludeGitkeep: true,
+			}
+			if err := ScaffoldFromSource(dir, opts); err != nil {
+				t.Fatalf("ScaffoldFromSource: %v", err)
+			}
+
+			result, err := config.Load(filepath.Join(dir, StateDir, WorkspaceConfigFile))
+			if err != nil {
+				t.Fatalf("loading scaffolded config: %v", err)
+			}
+			cfg := result.Config
+
+			// Mirror apply: discover each source's repos, then classify.
+			applier := NewApplier(&failingGitHubClient{t: t})
+			var discovered []github.Repo
+			for _, src := range cfg.Sources {
+				repos, derr := applier.discoverRepos(context.Background(), src)
+				if derr != nil {
+					t.Fatalf("discoverRepos: %v", derr)
+				}
+				discovered = append(discovered, repos...)
+			}
+
+			classified, warnings, cerr := Classify(discovered, cfg.Groups)
+			if cerr != nil {
+				t.Fatalf("Classify: %v", cerr)
+			}
+			if len(warnings) != 0 {
+				t.Errorf("scaffolded repo failed to match its group: %v", warnings)
+			}
+			if len(classified) != 1 {
+				t.Fatalf("expected 1 classified repo, got %d: %+v", len(classified), classified)
+			}
+			if got := classified[0].Repo.Name; got != "bootstrap-repo" {
+				t.Errorf("classified repo name = %q, want bootstrap-repo", got)
+			}
+			if got := classified[0].Group; got != tc.wantGroup {
+				t.Errorf("classified into group %q, want %q", got, tc.wantGroup)
+			}
+		})
+	}
+}

--- a/internal/workspace/scaffold.go
+++ b/internal/workspace/scaffold.go
@@ -139,6 +139,9 @@ repos = ["<bootstrap-repo>"]
 
 [groups.<vis-key>]
 visibility = "<vis-value>"
+# Bind the bootstrap repo to this group by name: explicit-repos sources carry
+# no live visibility, so name membership is what places the repo in a group.
+repos = ["<bootstrap-repo>"]
 
 # Bootstrap enabled mesh channels. Remove this block (and the [channels.mesh] line below) to disable.
 [channels.mesh]

--- a/internal/workspace/scaffold_test.go
+++ b/internal/workspace/scaffold_test.go
@@ -154,6 +154,9 @@ repos = ["<bootstrap-repo>"]
 
 [groups.<vis-key>]
 visibility = "<vis-value>"
+# Bind the bootstrap repo to this group by name: explicit-repos sources carry
+# no live visibility, so name membership is what places the repo in a group.
+repos = ["<bootstrap-repo>"]
 
 # Bootstrap enabled mesh channels. Remove this block (and the [channels.mesh] line below) to disable.
 [channels.mesh]


### PR DESCRIPTION
Bind the bootstrap repo to its visibility group by name in the `--bootstrap` scaffold template so apply's classifier matches the repo and creates its role. `discoverRepos` builds explicit-repos source entries without a GitHub API call, leaving `Visibility` empty, so the prior scaffold could not match the visibility-only `[groups.<vis>]` block it emitted. Update the Appendix A golden, the init-bootstrap guide, and the PRD in lockstep, and add a regression test that drives scaffold → config.Load → discoverRepos → Classify end to end.

---

## What This Fixes

`niwa init <name> --from <org/repo> --bootstrap` exited with `bootstrap step=session-create: unknown role: role "<repo>" not found` after warning `repo "<repo>" matches no group, skipping` and reporting `0 repos`. Reproducible against any empty GitHub repo, public or private.

## Root Cause

The `--bootstrap` scaffold (introduced in #144) emitted an explicit-repos source paired with a visibility-only group:

```toml
[[sources]]
org = "<source-org>"
repos = ["<bootstrap-repo>"]

[groups.<vis-key>]
visibility = "<vis-value>"
```

At apply time, `discoverRepos` (`internal/workspace/apply.go:1729`) deliberately builds explicit-repos entries without a GitHub API call, so `github.Repo.Visibility` is left empty. `matchesGroup` (`internal/workspace/classify.go:52`) needs `repo.Visibility == group.Visibility` (empty ≠ `"public"`) or `slices.Contains(group.Repos, repo.Name)` (group repos list was empty) — neither held, so the repo was skipped. No member repo means no per-repo role, and bootstrap aborted at `session-create` when it tried to open a session for the bootstrap repo's role.

This aligns with `DESIGN-explicit-repos.md`: repos that bypass the GitHub API can't auto-classify by visibility and must declare group membership explicitly. The scaffold was relying on visibility-based classification for an API-bypassing source — the two halves couldn't connect.

## Changes

- `internal/workspace/scaffold.go`: Add `repos = ["<bootstrap-repo>"]` to the scaffold's group block with a one-line rationale comment.
- `internal/workspace/scaffold_test.go`: Update `appendixAGolden` to match.
- `internal/workspace/bootstrap_classify_test.go`: New regression test driving `scaffold → config.Load → discoverRepos → Classify` end to end. A `failingGitHubClient` asserts no API call is made for explicit-repos sources. Fails on `main` with the production warning `repo "bootstrap-repo" matches no group, skipping`; passes on this branch.
- `docs/prds/PRD-init-bootstrap-empty-source.md`: Update Appendix A golden.
- `docs/guides/init-bootstrap.md`: Update template snippet.

## Related

- #146 — broader follow-up: the same composition (`[[sources]] repos = [...]` + visibility-only group) trips hand-written configs too.
- #147 — happy-path bootstrap `@critical` functional scenario gap and the harness infra it needs.
