### PR TITLE
fix(init): register bootstrapped workspaces in the global registry

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -93,6 +93,42 @@ var materializeFromSource = workspace.MaterializeFromSource
 // re-derive from a return value across error paths.
 var runBootstrap = defaultRunBootstrap
 
+// runBootstrapOrchestrator is the test seam for workspace.RunBootstrap.
+// Tests stub it to drive defaultRunBootstrap end to end (e.g. asserting
+// the post-orchestrator registry write) without standing up a real
+// applier, git invoker, or session worktree.
+var runBootstrapOrchestrator = workspace.RunBootstrap
+
+// registerInGlobalRegistry writes (or refreshes) the global registry entry
+// for the workspace at workspaceRoot so it is discoverable via `niwa go`
+// and shell tab completion. The non-bootstrap clone path in runInit writes
+// the entry inline; defaultRunBootstrap calls this helper after the
+// bootstrap orchestrator returns so both paths leave a successfully
+// initialized workspace registered.
+func registerInGlobalRegistry(workspaceRoot, configPath, registryName, source string) error {
+	absRoot, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return fmt.Errorf("resolving workspace root: %w", err)
+	}
+	absConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return fmt.Errorf("resolving config path: %w", err)
+	}
+	globalCfg, err := config.LoadGlobalConfig()
+	if err != nil {
+		return fmt.Errorf("loading global config: %w", err)
+	}
+	entry := config.RegistryEntry{
+		Root:   absRoot,
+		Source: absConfigPath,
+	}
+	if source != "" {
+		entry.SourceURL = source
+	}
+	globalCfg.SetRegistryEntry(registryName, entry)
+	return config.SaveGlobalConfig(globalCfg)
+}
+
 func defaultRunBootstrap(ctx context.Context, cmd *cobra.Command, workspaceRoot, workspaceName string, src sourcepkg.Source, source string, disarm func()) error {
 	// Step 1: visibility lookup via GetRepo. R17 soft-fail to Private=false
 	// on any error; emit the cause-classified note to stderr and keep going.
@@ -164,7 +200,7 @@ func defaultRunBootstrap(ctx context.Context, cmd *cobra.Command, workspaceRoot,
 		})
 	}
 
-	result, runErr := workspace.RunBootstrap(ctx, workspace.BootstrapParams{
+	result, runErr := runBootstrapOrchestrator(ctx, workspace.BootstrapParams{
 		WorkspaceRoot:  workspaceRoot,
 		WorkspaceName:  workspaceName,
 		InstanceName:   workspaceName,
@@ -178,6 +214,16 @@ func defaultRunBootstrap(ctx context.Context, cmd *cobra.Command, workspaceRoot,
 	})
 	if runErr != nil {
 		return runErr
+	}
+
+	// Register in the global registry. runInit's non-bootstrap clone path
+	// writes this entry inline; the bootstrap branch returns from runInit
+	// via this function before reaching that block, so we replicate it
+	// here. Failure is non-fatal — the workspace is fully usable, only
+	// `niwa go` / tab-completion discovery is lost.
+	configPath := filepath.Join(workspaceRoot, workspace.StateDir, workspace.WorkspaceConfigFile)
+	if regErr := registerInGlobalRegistry(workspaceRoot, configPath, workspaceName, source); regErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not update registry: %v\n", regErr)
 	}
 
 	// R19 success block (Appendix B byte-equality contract). Preceded

--- a/internal/cli/init_bootstrap_registry_test.go
+++ b/internal/cli/init_bootstrap_registry_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tsukumogami/niwa/internal/config"
+	sourcepkg "github.com/tsukumogami/niwa/internal/source"
+	"github.com/tsukumogami/niwa/internal/workspace"
+)
+
+// TestDefaultRunBootstrap_RegistersWorkspaceInGlobalRegistry is the regression
+// test for the bootstrap-registry gap: defaultRunBootstrap must write a global
+// registry entry after the orchestrator returns nil, so a successfully
+// bootstrapped workspace is discoverable via `niwa go` and tab completion.
+//
+// Before this fix, runInit's bootstrap branch returned via defaultRunBootstrap
+// without reaching the registry-write block in the non-bootstrap clone path,
+// leaving the workspace orphaned in the global registry even though everything
+// else (instance dir, role, session worktree, scaffold commit) landed.
+func TestDefaultRunBootstrap_RegistersWorkspaceInGlobalRegistry(t *testing.T) {
+	// Sandbox XDG_CONFIG_HOME so global config writes land in tmp.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+
+	// Stub the GitHub API base URL: defaultRunBootstrap's R17 visibility
+	// lookup will hit this fake instead of api.github.com.
+	ghSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/foo" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"foo","visibility":"public","private":false,"clone_url":"https://github.com/owner/foo.git","ssh_url":"git@github.com:owner/foo.git"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(ghSrv.Close)
+	t.Setenv("NIWA_GITHUB_API_URL", ghSrv.URL)
+	// No env token; defeat the `gh auth token` fallback by stripping PATH.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("PATH", "")
+
+	// Stub the orchestrator so we don't need a real applier, git invoker,
+	// or session worktree — only the post-orchestrator tail (registry
+	// write, success block) needs to run.
+	origOrch := runBootstrapOrchestrator
+	runBootstrapOrchestrator = func(_ context.Context, p workspace.BootstrapParams) (workspace.BootstrapResult, error) {
+		instancePath := filepath.Join(p.WorkspaceRoot, p.InstanceName)
+		return workspace.BootstrapResult{
+			InstancePath: instancePath,
+			WorktreePath: filepath.Join(instancePath, ".niwa", "worktrees", "stub"),
+			BranchName:   "niwa-bootstrap/stub",
+		}, nil
+	}
+	t.Cleanup(func() { runBootstrapOrchestrator = origOrch })
+
+	workspaceRoot := filepath.Join(tmpHome, "ws", "demo")
+	cmd := &cobra.Command{}
+	cmd.SetErr(io.Discard)
+	cmd.SetOut(io.Discard)
+
+	src := sourcepkg.Source{Owner: "owner", Repo: "foo"}
+
+	if err := defaultRunBootstrap(context.Background(), cmd, workspaceRoot, "demo", src, "owner/foo", func() {}); err != nil {
+		t.Fatalf("defaultRunBootstrap: %v", err)
+	}
+
+	cfg, err := config.LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig: %v", err)
+	}
+	entry := cfg.LookupWorkspace("demo")
+	if entry == nil {
+		t.Fatal(`expected registry entry "demo" after successful bootstrap; got none`)
+	}
+
+	absRoot, _ := filepath.Abs(workspaceRoot)
+	if entry.Root != absRoot {
+		t.Errorf("registry Root = %q, want %q", entry.Root, absRoot)
+	}
+	wantSource := filepath.Join(absRoot, workspace.StateDir, workspace.WorkspaceConfigFile)
+	if entry.Source != wantSource {
+		t.Errorf("registry Source = %q, want %q", entry.Source, wantSource)
+	}
+	if entry.SourceURL != "owner/foo" {
+		t.Errorf(`registry SourceURL = %q, want "owner/foo"`, entry.SourceURL)
+	}
+}


### PR DESCRIPTION
Extract the global-registry write that runInit's non-bootstrap clone path performs inline into a `registerInGlobalRegistry` helper and call it from `defaultRunBootstrap` right after the orchestrator returns. The non-bootstrap path is left untouched to minimize blast radius; both paths now leave a successfully initialized workspace registered. Introduce a `runBootstrapOrchestrator` seam (defaulting to `workspace.RunBootstrap`) so a regression test can drive `defaultRunBootstrap` end to end without spawning a real applier, git invoker, or session worktree, and use it to assert the registry entry — including `SourceURL` — is written against a sandboxed `XDG_CONFIG_HOME` and an `httptest.Server` stub for the visibility lookup.

---

## What This Fixes

`niwa init <name> --from <org/repo> --bootstrap` produced a fully working workspace on disk (instance dir, classified repo, per-repo role, session worktree, `niwa-bootstrap/<sid>` commit, R19 success block) but never wrote an entry to the global registry at `~/.config/niwa/config.toml`. The workspace was therefore invisible to `niwa go`, shell tab completion, and `niwa apply <name>` from anywhere outside the workspace.

The non-bootstrap clone path was unaffected — it wrote the registry inline at `internal/cli/init.go:670-698`.

## Root Cause

`runInit`'s bootstrap arms at `init.go:615` and `init.go:632` do `return runBootstrap(...)`, exiting `runInit` before the registry-write block that the non-bootstrap arm reaches. `defaultRunBootstrap` then ran the visibility lookup, the scaffold write, the orchestrator (clone, channels, session create, scaffold commit), and the success block, but never touched the global registry. After a clean exit, the workspace was orphaned in the registry sense.

The workaround was `cd <workspace>/<instance> && niwa apply`, which writes the registry entry as a side effect (`apply.go:255-267`) but loses `SourceURL` (apply only preserves it from an existing entry).

## Changes

- `internal/cli/init.go`:
  - Add `registerInGlobalRegistry(workspaceRoot, configPath, registryName, source)` helper. Identical shape to the non-bootstrap registry write — resolves abs paths, loads the global config, sets the entry with `SourceURL` when provided, saves.
  - Add `runBootstrapOrchestrator` package-level seam defaulting to `workspace.RunBootstrap`. Documented as the test seam for driving `defaultRunBootstrap` end to end.
  - In `defaultRunBootstrap`, route the orchestrator call through the seam, and call `registerInGlobalRegistry` right after `runErr == nil`. Failure is non-fatal (warning to stderr) — the workspace is fully usable, only registry discovery is lost.
- `internal/cli/init_bootstrap_registry_test.go`: new regression test `TestDefaultRunBootstrap_RegistersWorkspaceInGlobalRegistry`. Sandboxes `XDG_CONFIG_HOME`, stubs the GitHub API via `httptest.Server` + `NIWA_GITHUB_API_URL`, stubs the orchestrator seam to skip the heavy machinery, runs `defaultRunBootstrap`, asserts the entry exists with the correct `Root`, `Source`, and `SourceURL`.

The non-bootstrap clone path's inline registry write is left untouched — it could call the same helper as a follow-up cleanup, but the semantics differ slightly (abs-path errors fatal there, non-fatal here), and unifying them is out of scope for the regression fix.

## Verification

- `go test ./...` — all 21 packages pass on the diff. (Two unrelated pre-existing failures in `internal/cli` — `fsnotify: too many open files` and a missing `daemon.pid` — also fail on `main` with no diff applied; both are local-environment limits.)
- `go build ./...` and `go vet ./...` clean.
- Manual: `niwa init demo --from owner/repo --bootstrap` against a sandboxed `XDG_CONFIG_HOME` (exercised by the regression test) produces a `[registry.demo]` entry with `root`, `source`, and `source_url` populated.

## Related

- #145 — the previous bootstrap-path regression (classify gap).
- v0.12.1 — the release where the prior bootstrap fix shipped.
