### PR TITLE
docs: scope NW2 — niwa apply emits workspace-aware role table

### DIFF
--- a/docs/briefs/BRIEF-niwa-role-table.md
+++ b/docs/briefs/BRIEF-niwa-role-table.md
@@ -1,0 +1,175 @@
+---
+schema: brief/v1
+status: Accepted
+problem: |
+  niwa computes a workspace's role set at apply time to build the mesh
+  inboxes, but never writes that set down. Tools that address a role
+  from outside niwa (a bridge skill routing an @role mention, koto
+  resolving a peer-message destination) have no workspace-aware source
+  of truth and must hard-code identifiers or keep drifting bookkeeping.
+outcome: |
+  After niwa apply, a workspace carries a readable role table any Claude
+  Code session or sibling tool can consult to answer "what roles exist?"
+  and "where does a message to role X go?" without re-deriving topology
+  or maintaining a parallel list.
+---
+
+# BRIEF: niwa apply emits a workspace-aware role table
+
+## Status
+
+Accepted
+
+Framing locked via autonomous `/scope` run (recommended-default judgment
+calls; no Open Questions remain at the brief altitude). The deferred
+framing details — exact file shape, schema fields, resolution semantics,
+refresh contract — are requirements the downstream PRD owns, not brief-
+level gaps. Downstream PRD: `docs/prds/PRD-niwa-role-table.md`.
+
+## Problem Statement
+
+A niwa workspace hosts multiple repos and a coordinator-plus-delegates
+mesh. Work and messages are addressed to *roles*: a coordinator plus one
+role per cloned repo, the exact set niwa already enumerates at `niwa
+apply` time to build each role's message inbox.
+
+The gap is that this role set lives only in niwa's head. niwa derives it,
+uses it to lay down inbox directories, and then discards it. Nothing on
+disk tells an outside reader which roles exist or where a message
+addressed to a given role should land.
+
+That forces every tool that wants to address a role by name to solve the
+problem on its own terms:
+
+- A coordinator-bridge skill that turns an `@role` mention into a
+  dispatch has no list to resolve the name against, so it either asks
+  the operator to spell out explicit delivery identifiers every time or
+  keeps its own side table of roles.
+- A peer-messaging layer that routes a message to a role at the
+  multi-repo substrate has the same problem one layer down.
+
+Any side table a consumer keeps drifts the moment a repo is added or
+removed, because the consumer is re-deriving a fact niwa already computed
+authoritatively. The workspace topology has one owner — niwa — but the
+answer it produces is not published, so consumers re-invent it and the
+copies diverge.
+
+## User Outcome
+
+After `niwa apply`, the workspace carries a role table a reader can open
+to learn, without re-deriving anything, what roles the workspace has and
+where a message to each one is delivered.
+
+For the author working through a bridge skill, mentioning `@reviewer`
+resolves against that table, so addressing a teammate by role name is as
+ergonomic as the workspace topology allows — no hand-entered delivery
+identifiers, no stale side list. For a peer-messaging layer, the same
+file answers the same question at the substrate level. For an operator,
+the table is a legible picture of the workspace's roles that niwa keeps
+current: re-apply after adding a repo and the new role is simply there.
+A workspace with no bridge skill or peer-messaging layer present still
+gets the table; it is a plain readable file, useful to any session that
+opens it.
+
+## User Journeys
+
+### Bridge skill resolves an @role mention
+
+A coordinator-bridge skill (hosted in shirabe) is dispatching peer
+work. The trigger is an author mentioning `@worker` in a message the
+bridge processes. The bridge reads the workspace role table, resolves
+`worker` to its delivery destination, and dispatches without asking the
+author to supply an explicit identifier. The outcome shape: an `@role`
+mention becomes an addressed dispatch using niwa's authoritative role
+set rather than coordinator-side bookkeeping.
+
+### Peer-messaging layer routes to a role
+
+koto's peer-messaging and mention-routing layer needs to turn a role
+name into a destination at the multi-repo substrate. The trigger is a
+message addressed to a role name. koto resolves the name against the
+table niwa emitted (in koto's case, through the niwa-provided resolution
+path rather than reading the file directly). The outcome shape: the
+multi-repo substrate resolves role names from one shared source of truth,
+so koto and the bridge skill agree on what a role name means.
+
+### Operator inspects the workspace's roles
+
+An operator wants to see which roles a workspace has and where each one
+resolves — for example, to confirm a freshly added repo became an
+addressable role. The trigger is the operator inspecting the workspace
+through the role-aware niwa surface that reads the table. The outcome
+shape: the operator sees the same role set niwa used to build the mesh,
+read back from the emitted table rather than re-derived by hand.
+
+### Re-apply keeps the table current
+
+An operator adds a repo to the workspace and runs `niwa apply` again.
+The trigger is the re-apply. niwa regenerates the role table to include
+the new repo's role, idempotently — an apply that changes no roles
+rewrites no bytes. The outcome shape: the table tracks the workspace
+topology automatically, with no manual edit and no drift between the
+table and the inboxes niwa laid down in the same apply.
+
+### Standalone workspace with no consumers present
+
+A workspace is applied with neither a bridge skill nor a peer-messaging
+layer installed. The trigger is a plain `niwa apply`. The table is
+emitted anyway, as an ordinary readable file at a known location. The
+outcome shape: the emission is unconditional — its value to consumers
+depends on those consumers existing, but the file itself is always
+present and any Claude Code session can read it.
+
+## Scope Boundary
+
+### IN
+
+- Emission of a workspace-aware role-table data file during `niwa
+  apply`, at a known location, as a durable readable artifact.
+- Use of niwa's existing role enumeration as the table's source of
+  truth — the same role set niwa already computes to build the mesh
+  inboxes (coordinator plus topology-derived and explicitly-configured
+  roles).
+- Regeneration on every apply, idempotently, so the table tracks the
+  workspace topology without manual edits.
+- Treating the emitted file as a stability surface other tools read
+  against — the table is a contract, not an internal scratch file.
+
+### OUT
+
+- The bridge skill's content and mention-routing logic. The skill lives
+  in shirabe and *consumes* the table; this feature emits the data, not
+  the skill behavior.
+- The `niwa role` CLI commands (such as listing roles or resolving a
+  name to a destination) that read the table. Those are a separate niwa
+  feature; this feature emits the file they will read.
+- The peer-messaging layer's routing logic in koto. koto consumes the
+  resolution this feature makes possible; its routing code is out of
+  scope here.
+- The `.claude/agents/<role>.md` subagent-definition files generated at
+  apply time. That is a sibling feature (the agent-definition companion);
+  it produces agent *definitions*, while this feature produces the role
+  *table* (data). The two share the apply codepath and the same role set
+  but are scoped separately.
+- Changes to how roles are enumerated, named, or validated. This feature
+  reuses niwa's existing enumeration unchanged; it serializes the result
+  rather than redefining it.
+- Message delivery and transport mechanics. The per-role inboxes already
+  exist; this feature publishes where they are, it does not move messages.
+
+## Downstream Artifacts
+
+- `docs/prds/PRD-niwa-role-table.md` — requirements for the role-table
+  emission (file shape, schema, resolution semantics, refresh contract).
+- `docs/designs/DESIGN-niwa-role-table.md` — technical design of the
+  emitted table and the apply-codepath integration.
+- `docs/plans/PLAN-niwa-role-table.md` — implementation plan.
+
+## References
+
+- `internal/workspace/channels.go` — `enumerateRoles` and the existing
+  per-role inbox installation this feature's table mirrors.
+- `docs/designs/current/DESIGN-cross-session-communication.md` — the
+  peer-messaging model that motivates role-name resolution.
+- `docs/designs/current/DESIGN-mesh-session-lifecycle.md` — role-based
+  routing for delegation and peer messaging.

--- a/docs/designs/DESIGN-niwa-role-table.md
+++ b/docs/designs/DESIGN-niwa-role-table.md
@@ -260,6 +260,16 @@ dependency and negligible cost.
   `InstallChannelInfrastructure` obtains them (the role enumeration is shared or
   re-invoked there); `EmitRoleTable` receives them plus `instanceRoot` and the
   `&writtenFiles` accumulator already threaded through the pipeline.
+- **Create/apply symmetry (PRD R1).** The step is placed in the shared
+  `runPipeline`, not in an apply-only path. Both entry points route through it —
+  `Applier.Create` (`apply.go:230` → `runPipeline` at `apply.go:288`) and
+  `Applier.Apply` (`apply.go:376` → `runPipeline` at `apply.go:428`). Emitting
+  here is therefore the single change that makes `roles.json` materialize on a
+  freshly created workspace's first pipeline run *and* regenerate idempotently
+  on every subsequent apply, with no command-specific code. The role
+  enumeration the step consumes is itself shared, so `create` and `apply` can
+  never produce divergent tables. Wiring the emit into an apply-only branch
+  would be the bug this placement avoids.
 - **Managed-file registration:** appending the path to `writtenFiles` is the
   whole integration — Step 7 (`apply.go:1435-1452`) already hashes every
   `writtenFiles` entry into a `ManagedFile` and persists it in
@@ -277,7 +287,8 @@ dependency and negligible cost.
    `roles` array to the freshly built one; if equal, the step returns without
    writing (the path is still appended to `writtenFiles` so tracking stays
    consistent). If different (or the file is absent), it sets `generated` and
-   marshals with `json.MarshalIndent`, writing `0o644`.
+   marshals with `json.MarshalIndent`, writing at mode `0o600` (see Security
+   Considerations invariant 1).
 5. Step 7 hashes `.niwa/roles.json` into a `ManagedFile` and `SaveState` writes
    it into `.niwa/instance.json`.
 
@@ -324,7 +335,10 @@ Add a `@critical` Gherkin scenario in `test/functional/features/` driving real
 lists exactly the enumerated roles (coordinator + one per cloned repo), each
 `inbox` matches the created inbox directory, a second apply is byte-identical,
 adding a repo adds exactly one entry, and removing one removes exactly that
-entry.
+entry. Add one `create`-path assertion (a fresh `niwa create` produces
+`.niwa/roles.json` before any explicit `apply`) to lock the create/apply
+symmetry the shared-pipeline placement provides — matching the CLAUDE.md
+guidance to cover the init → create → apply workflow.
 Deliverables: feature file plus any step bindings.
 
 ## Security Considerations

--- a/docs/designs/DESIGN-niwa-role-table.md
+++ b/docs/designs/DESIGN-niwa-role-table.md
@@ -1,0 +1,409 @@
+# DESIGN: niwa apply emits a workspace-aware role table
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+`niwa apply` already computes a workspace's role set. `enumerateRoles`
+(`internal/workspace/channels.go:448`) walks the workspace config and group
+directories and returns `[]roleEntry{name string, repoPath string}`,
+name-sorted, with the coordinator first (its `repoPath` is empty). Apply hands
+that set to `InstallChannelInfrastructure` (`channels.go:241`), which creates a
+message inbox for each role at `.niwa/roles/<role>/inbox/`. Once the inboxes
+exist, the in-memory role set is discarded.
+
+Nothing on disk publishes that set. A tool that wants to address a role by name
+from outside niwa — a shirabe-hosted bridge skill turning an `@role` mention
+into a dispatch, koto resolving a peer-message destination at the multi-repo
+substrate, or an operator confirming a freshly cloned repo became addressable —
+has no authoritative file to read. Each one re-derives the topology or keeps a
+side table that drifts the moment a repo is added or removed.
+
+The technical problem is narrow: serialize the set niwa already enumerates into
+a durable, versioned, machine-readable file at a fixed location, register it so
+apply tracks it like every other materialized file, and regenerate it
+idempotently. The file becomes a public contract three sibling tools read
+against, so its location and shape must be stable, and it must contain no
+secrets and no absolute host paths. The work slots into one place in the apply
+pipeline — immediately after `InstallChannelInfrastructure`, where the role set
+and the accumulating `writtenFiles` list are both in scope.
+
+## Decision Drivers
+
+- **Reuse the existing enumeration unchanged (PRD R3, R11).** The table
+  serializes `enumerateRoles` output. No new role model, naming, or validation.
+- **Fixed, discoverable location (PRD R2).** Consumers hard-reference the path;
+  no globbing or discovery heuristics.
+- **Public stability surface (PRD R12).** Location and schema are a contract;
+  changes must be additive and version-gated, never silent reshaping.
+- **Idempotent regeneration (PRD R8).** An apply that does not change the role
+  set produces a byte-identical file; a change is reflected.
+- **Managed-file participation (PRD R9).** The file joins apply's managed-file
+  tracking and drift detection like other apply-materialized files.
+- **No secrets, no absolute host paths (PRD R15, R16).** Destinations are
+  expressed relative to the instance root.
+- **Negligible cost, no new dependencies (PRD R14).** Serialize in-process data
+  with machinery niwa already uses; no network calls or extra repo scans.
+- **Convention fit.** Match how niwa already emits on-disk data (JSON via
+  `encoding/json`) so the codebase stays uniform.
+
+## Considered Options
+
+### Decision 1: Serialization format
+
+The table is a public surface (R12) read by three external consumers and any
+Claude Code session, and must be plain-text, machine- and human-readable (R13)
+while adding no new dependency (R14).
+
+Key assumptions: a JSON parser is universally available to consumers (Go,
+shell, Claude Code sessions); niwa should not adopt a new serialization library
+for one emitted file.
+
+#### Chosen: JSON via `encoding/json` (`MarshalIndent`, 2-space)
+
+Every data file niwa emits to disk today is JSON marshaled with
+`json.MarshalIndent(..., "", "  ")` — `.niwa/instance.json` (`state.go:304`),
+`.niwa/sessions/sessions.json`, and the `.mcp.json` configs. Reusing JSON adds
+zero dependencies, produces deterministic output for a fixed struct plus a
+sorted slice (the basis for R8 idempotency), and is parseable by every consumer
+without adding a library. It is both machine- and human-readable (R13).
+
+#### Alternatives Considered
+
+- **TOML.** niwa's *config input* is TOML (`niwa.toml`,
+  `.niwa-snapshot.toml`), so it is familiar. Rejected: TOML appears in niwa only
+  as an authoring/input format, never as emitted machine data; consumers would
+  need a TOML parser that JSON does not require, and array-of-tables is weaker
+  than JSON for a list of uniform records. Adopting it would fork niwa's emit
+  convention.
+- **YAML.** Most human-friendly. Rejected: Go's standard library has no YAML
+  encoder, so this adds a third-party dependency for one file (against the
+  spirit of R14), and YAML's implicit typing adds parsing ambiguity to a
+  contract surface that wants an exact, predictable shape.
+- **Custom line-oriented format.** Trivial to emit. Rejected: every consumer
+  would hand-roll a parser, there is no schema-version affordance, and it
+  abandons the structured-data requirement (R13). Not viable for a versioned
+  public contract.
+
+### Decision 2: File location and filename
+
+R2 requires a known, stable location under the instance's `.niwa/` directory,
+fixed across applies. The existing layout has `.niwa/instance.json`,
+`.niwa/sessions/sessions.json`, and the per-role tree `.niwa/roles/<role>/inbox/`.
+
+Key assumptions: a fixed well-known path beats any discovery scheme for a
+hard-referenced contract; the table is instance-scoped data, peer to
+`instance.json`, not per-role data.
+
+#### Chosen: `.niwa/roles.json` at the instance `.niwa/` root
+
+The table is a single instance-level manifest of the whole role set, so it sits
+at the `.niwa/` root beside `.niwa/instance.json` rather than inside any one
+role's directory. `roles.json` reads as the manifest companion to the existing
+`.niwa/roles/` directory: the file answers "what roles exist and where do their
+messages go?"; the directory holds each role's inbox. The file and the
+directory coexist without collision (distinct names). The path is a compile-time
+constant, mirroring `StateDir`/`StateFile` in `state.go`, so consumers reference
+`<instance-root>/.niwa/roles.json` with no discovery step.
+
+#### Alternatives Considered
+
+- **`.niwa/roles/roles.json`** (inside the roles directory). Rejected: nests an
+  instance-level manifest inside a directory whose entries are per-role subtrees,
+  blurring "the set of roles" with "one role's data"; a consumer listing roles
+  by walking `.niwa/roles/*` would have to special-case a `roles.json`
+  pseudo-entry. Keeping the manifest one level up avoids that.
+- **`.niwa/role-table.json`** (matches the feature name). Rejected: "role table"
+  is the design's internal name; `roles.json` is shorter, matches the sibling
+  `roles/` directory, and follows niwa's `<noun>.json` data-file naming
+  (`instance.json`, `sessions.json`). No functional difference; convention fit
+  decides it.
+- **Embed the role set inside `instance.json`.** Rejected: `instance.json` is
+  niwa's private state schema (versioned independently at SchemaVersion 4); the
+  table is a *public* contract with its own version cadence (R6, R12). Coupling
+  them would force consumers to parse niwa-internal state and tie the public
+  contract's evolution to internal-state migrations. A dedicated file keeps the
+  public surface separable.
+
+### Decision 3: Record schema, delivery-destination semantics, version and ordering
+
+R4 requires each entry to record the role's delivery destination (its inbox)
+and the repo it is bound to (or a coordinator marker). R5 keeps the coordinator
+always present, R6 requires a schema version, R7 requires deterministic stable
+ordering, and R16 requires destinations relative to the instance root. The
+source is `enumerateRoles` -> `[]roleEntry{name, repoPath}`, name-sorted, with
+the coordinator carrying an empty `repoPath`.
+
+Key assumptions: the destination a consumer needs is the inbox directory
+`.niwa/roles/<name>/inbox` (the same path apply creates); repo binding is for
+identification, not routing, and is null for the coordinator.
+
+#### Chosen: top-level `{schema_version, generated, roles[]}` with relative-path records
+
+```json
+{
+  "schema_version": 1,
+  "generated": "2026-05-31T00:00:00Z",
+  "roles": [
+    {"name": "coordinator", "coordinator": true, "repo": null, "inbox": ".niwa/roles/coordinator/inbox"},
+    {"name": "api", "coordinator": false, "repo": "groups/backend/api", "inbox": ".niwa/roles/api/inbox"}
+  ]
+}
+```
+
+- **`schema_version`** (int, top-level) mirrors niwa's integer `SchemaVersion`
+  convention (`state.go:50`), starting at 1; a consumer reads it first and falls
+  back or refuses on an unrecognized value (R6, R12).
+- **`generated`** (RFC3339 UTC string) records provenance, matching the
+  `Generated time.Time` already on `ManagedFile`.
+- **`roles`** (array) carries one entry per enumerated role in
+  `enumerateRoles`' existing name-sorted order, coordinator first (R7) — no
+  re-sorting.
+- Per-role fields: **`name`** verbatim from the enumeration (R11);
+  **`coordinator`** (bool) true only for the coordinator (R5), so a consumer
+  special-cases it without string-matching; **`repo`**, the instance-root-
+  relative path of the bound repo or `null` for the coordinator (R4b, R16);
+  **`inbox`**, the instance-root-relative inbox path, which *is* the delivery
+  destination (R4a).
+
+A consumer resolves a role name by finding its entry and joining `inbox` onto
+the instance root it already knows. Because that inbox is the same directory
+apply created in the same run, the table and the inboxes cannot disagree.
+
+#### Alternatives Considered
+
+- **Map keyed by role name** (`"roles": {"coordinator": {...}}`). Rejected: JSON
+  object key order is not guaranteed across all consumer parsers, undermining
+  R7's deterministic-order contract, and it makes the sorted/coordinator-first
+  ordering implicit. An array preserves the explicit sort.
+- **Destination as the repo path rather than the inbox.** Rejected: the PRD's
+  "delivery destination" is the message inbox (R4a); the repo path answers
+  identification (R4b). Recording both, distinctly, avoids forcing consumers to
+  re-derive the inbox from the repo path.
+- **Drop the `coordinator` boolean, infer from `name == "coordinator"` or
+  `repo == null`.** Rejected: forces consumers to hard-code the reserved name or
+  overload `repo`'s null meaning; an explicit flag is a cleaner contract for one
+  bool.
+- **Richer per-entry metadata (role kind, created-by, per-entry version).**
+  Rejected as scope creep: the PRD fixes contract obligations, not extra
+  metadata; R12's additive, version-gated discipline lets later features add
+  fields without a v1 commitment. Start minimal.
+
+## Decision Outcome
+
+niwa apply emits `.niwa/roles.json`, a JSON document carrying a top-level
+`schema_version`, a `generated` timestamp, and a name-sorted `roles` array whose
+entries each record the role name, a coordinator flag, the instance-root-
+relative repo binding (or null), and the instance-root-relative inbox path that
+serves as the role's delivery destination. The three decisions reinforce one
+another: JSON is the format every consumer already parses and niwa already
+emits; a dedicated root-level `roles.json` keeps the public contract separable
+from niwa's private `instance.json` while reading as the manifest companion to
+the `.niwa/roles/` tree; and an explicit array of relative-path records gives a
+deterministic, host-path-free contract that maps one-to-one onto the inboxes
+apply lays down in the same run. The emitter compares the freshly enumerated
+role set against the existing file's contents and rewrites only on a real
+change, so unchanged applies leave the file byte-identical (R8) while a changed
+topology refreshes both the records and the `generated` timestamp.
+
+## Solution Architecture
+
+### Overview
+
+A new emit step in the apply pipeline serializes the enumerated role set to
+`.niwa/roles.json` and registers the file with apply's managed-file tracking.
+The step reuses the role set already computed for inbox installation and writes
+through the same JSON machinery niwa uses for `instance.json`, so it adds no new
+dependency and negligible cost.
+
+### Components
+
+- **Role-table builder** (new, in `internal/workspace`, e.g. `roletable.go`).
+  A pure function `buildRoleTable(roles []roleEntry, instanceRoot string)
+  roleTable` maps the enumeration into the serializable shape, computing each
+  role's instance-root-relative `repo` and `inbox` paths. Pure and
+  table-testable; no I/O.
+- **Serializable types** (new):
+  ```go
+  type roleTable struct {
+      SchemaVersion int             `json:"schema_version"`
+      Generated     time.Time       `json:"generated"`
+      Roles         []roleTableEntry `json:"roles"`
+  }
+  type roleTableEntry struct {
+      Name        string  `json:"name"`
+      Coordinator bool    `json:"coordinator"`
+      Repo        *string `json:"repo"`   // nil -> JSON null (coordinator)
+      Inbox       string  `json:"inbox"`
+  }
+  const roleTableSchemaVersion = 1
+  ```
+- **Emit step** (new, e.g. `EmitRoleTable(roles []roleEntry, instanceRoot
+  string, writtenFiles *[]string) error`). Builds the table, applies the
+  idempotency check, writes the file when needed, and appends the path to
+  `writtenFiles` so Step 7 hashes it into `ManagedFiles`.
+- **Path constant** (new). `RoleTableFile = "roles.json"` beside the existing
+  `StateDir`/`StateFile` constants, plus a helper
+  `RoleTablePath(instanceRoot) = filepath.Join(instanceRoot, StateDir,
+  RoleTableFile)`.
+
+### Key Interfaces
+
+- **Public contract:** `<instance-root>/.niwa/roles.json` with the schema in
+  Decision 3. `schema_version` is the compatibility gate; `inbox` is the
+  resolution target; `repo`/`coordinator` identify the binding.
+- **Internal call site:** `runPipeline` in `internal/workspace/apply.go`, right
+  after `InstallChannelInfrastructure` returns (around `apply.go:1276`, before
+  Step 5). The enumerated roles are obtained the same way
+  `InstallChannelInfrastructure` obtains them (the role enumeration is shared or
+  re-invoked there); `EmitRoleTable` receives them plus `instanceRoot` and the
+  `&writtenFiles` accumulator already threaded through the pipeline.
+- **Managed-file registration:** appending the path to `writtenFiles` is the
+  whole integration — Step 7 (`apply.go:1435-1452`) already hashes every
+  `writtenFiles` entry into a `ManagedFile` and persists it in
+  `InstanceState.ManagedFiles`, so the table participates in drift detection
+  (`CheckDrift`, `apply.go:411`) with no table-specific code.
+
+### Data Flow
+
+1. Apply runs the pipeline; Step 4.75 calls `InstallChannelInfrastructure`,
+   creating `.niwa/roles/<role>/inbox/` for each enumerated role.
+2. The new emit step receives the same `[]roleEntry` and `instanceRoot`.
+3. `buildRoleTable` produces a `roleTable` with relative `repo`/`inbox` paths,
+   coordinator-first name-sorted order preserved from the enumeration.
+4. The idempotency check reads any existing `.niwa/roles.json`, compares its
+   `roles` array to the freshly built one; if equal, the step returns without
+   writing (the path is still appended to `writtenFiles` so tracking stays
+   consistent). If different (or the file is absent), it sets `generated` and
+   marshals with `json.MarshalIndent`, writing `0o644`.
+5. Step 7 hashes `.niwa/roles.json` into a `ManagedFile` and `SaveState` writes
+   it into `.niwa/instance.json`.
+
+### Idempotency detail
+
+The comparison is on the `roles` array only, not on `generated`. A naive
+`time.Now()` on every apply would rewrite the file each run and break R8.
+Comparing the role records (which are what actually reflect topology) and
+preserving the prior `generated` on a no-op keeps the timestamp meaningful while
+guaranteeing byte-identical output when nothing changed. When the role set does
+change, both the records and `generated` refresh.
+
+## Implementation Approach
+
+### Phase 1: Types and pure builder
+
+Add `internal/workspace/roletable.go` with `roleTable`, `roleTableEntry`, the
+`roleTableSchemaVersion` constant, the `RoleTableFile` path constant and
+`RoleTablePath` helper, and the pure `buildRoleTable(roles, instanceRoot)`. Add
+table-driven unit tests covering coordinator-null `repo`, a topology role, an
+explicit-override role, ordering, and relative-path computation.
+Deliverables: `roletable.go`, `roletable_test.go`.
+
+### Phase 2: Emit step with idempotency
+
+Add `EmitRoleTable(roles, instanceRoot, &writtenFiles)`: build, read-compare
+existing file, write-or-skip, append path to `writtenFiles`. Unit-test the
+write path, the no-op-on-unchanged path (byte-identical), the rewrite-on-change
+path, and the absent-file path.
+Deliverables: emit function in `roletable.go`, tests.
+
+### Phase 3: Pipeline wiring
+
+Call `EmitRoleTable` in `runPipeline` immediately after
+`InstallChannelInfrastructure`, passing the enumerated roles, `instanceRoot`,
+and `&writtenFiles`. Confirm Step 7 picks up the path into `ManagedFiles`.
+Deliverables: edit to `apply.go`; assertion in an apply-level test that
+`.niwa/roles.json` is present in `InstanceState.ManagedFiles`.
+
+### Phase 4: Functional coverage
+
+Add a `@critical` Gherkin scenario in `test/functional/features/` driving real
+`niwa apply` against `localGitServer` repos: assert `.niwa/roles.json` exists,
+lists exactly the enumerated roles (coordinator + one per cloned repo), each
+`inbox` matches the created inbox directory, a second apply is byte-identical,
+adding a repo adds exactly one entry, and removing one removes exactly that
+entry.
+Deliverables: feature file plus any step bindings.
+
+## Security Considerations
+
+`.niwa/roles.json` is a non-secret, local-only data file. It carries no
+credentials, tokens, or vault material — only role names, a coordinator flag,
+and workspace-relative repo/inbox paths, all of which niwa already computes and
+partly exposes (for example in the `## Channels` section). The emit step makes
+no network access, spawns no process, executes no external input, and adds no
+dependency beyond `encoding/json`, which niwa already uses for `instance.json`
+and `sessions.json`. niwa never unmarshals its own output, so there is no
+deserialization attack surface.
+
+Two invariants must hold in the implementation and be covered by tests:
+
+1. **File mode 0600.** Write the file through the channels installer's
+   `writeIdempotent` helper (or `os.WriteFile` followed by an explicit
+   `Chmod(0o600)`), matching every sibling managed file. Never rely on a bare
+   write that inherits the process umask. This keeps the file consistent with
+   `instance.json`/`sessions.json` and avoids needlessly exposing workspace
+   topology to other local users on shared hosts.
+
+2. **Relative paths only — enforced, not assumed.** `enumerateRoles` holds
+   absolute on-disk repo paths in `roleEntry.repoPath` (topology entries are
+   `filepath.Join(groupDir, repoName)`; explicit entries resolve against the
+   instance root or are kept verbatim when already absolute). Before
+   serialization, convert each to a path relative to the instance root
+   (`filepath.Rel`), emit `null` for the coordinator (empty `repoPath`), and
+   reject — or null out — any role whose resolved path falls outside the
+   instance root. The file is intended to be committed and read by other tools,
+   so a leaked absolute path would expose the user's home directory and
+   workspace layout in git history and to every downstream consumer. Add a test
+   asserting no emitted path is absolute, contains the instance-root prefix, or
+   contains a `..` segment.
+
+Role names and path components are constrained by niwa's existing
+`^[a-z0-9][a-z0-9-]{0,31}$` validation, which apply hard-fails on violation.
+That regex excludes JSON control bytes, quotes, path separators, `..`, and
+shell metacharacters, so emitted values cannot smuggle injection payloads into a
+consumer. Combined with `encoding/json` escaping on the producer side, the emit
+path is injection-safe; consumers (shirabe, koto) should still treat the values
+as data and never pass them to a shell or `eval`.
+
+Publishing the role set inherently reveals which repos a workspace coordinates
+and how roles map to them. Given the file's stated purpose (cross-tool role
+resolution) this disclosure is intended, and the repo names are already visible
+in the committed workspace tree and the `## Channels` section; no sensitive data
+beyond what is already on disk in the same instance is exposed.
+
+## Consequences
+
+### Positive
+
+- One authoritative, versioned file replaces every consumer's drifting side
+  table; the bridge skill, koto, the `niwa role` CLI, and any session resolve
+  role names against the same source of truth niwa used to build the mesh.
+- The integration is minimal and low-risk: a pure builder plus a single
+  pipeline call, reusing the existing JSON, path, and managed-file machinery.
+  No new dependency, no new network or scan cost (R14).
+- Drift detection and idempotency come almost for free by appending to
+  `writtenFiles`; the file behaves like every other apply-materialized artifact.
+
+### Negative
+
+- The table is an apply-time snapshot; filesystem changes between applies are
+  not reflected until the next `niwa apply` (inherent to niwa's
+  materialize-on-apply model, called out in the PRD's Known Limitations).
+- A new public contract is now committed to: `schema_version` must be honored,
+  and future shape changes are constrained to additive, version-gated evolution.
+- The idempotency comparison adds a read of the existing file on every apply (a
+  small, bounded cost on a local file).
+
+### Mitigations
+
+- The snapshot limitation is documented in the schema's intent and matches how
+  every other managed file behaves, so consumers already expect apply-time
+  semantics.
+- `schema_version` is the explicit lever for evolving the contract safely; new
+  fields are additive and old consumers ignore unknown keys, while a major bump
+  signals an incompatible change a consumer can detect and refuse.
+- The extra read is one local `os.ReadFile` of a small file, dwarfed by the
+  surrounding apply work; no network or repo scan is involved.

--- a/docs/designs/DESIGN-niwa-role-table.md
+++ b/docs/designs/DESIGN-niwa-role-table.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Planned
 
 ## Context and Problem Statement
 

--- a/docs/plans/PLAN-niwa-role-table.md
+++ b/docs/plans/PLAN-niwa-role-table.md
@@ -1,0 +1,248 @@
+---
+schema: plan/v1
+status: Draft
+execution_mode: single-pr
+milestone: null
+issue_count: 4
+upstream: docs/designs/DESIGN-niwa-role-table.md
+---
+
+# PLAN: niwa apply emits a workspace-aware role table
+
+## Status
+
+Draft
+
+Single-PR plan decomposed from `docs/designs/DESIGN-niwa-role-table.md`
+(Accepted) via an autonomous `/scope` run. All four work items land in one
+pull request; outlines below are the in-PR work breakdown, not separate
+GitHub issues.
+
+## Scope Summary
+
+Add an apply-pipeline emit step that serializes niwa's already-computed role
+set to a versioned, drift-tracked `.niwa/roles.json`, so sibling tools (the
+shirabe bridge skill, koto mention-routing, the future `niwa role` CLI) and
+any session can resolve a role name to its inbox from one authoritative file.
+
+## Decomposition Strategy
+
+**Horizontal.** The design describes a layered pipeline with stable interfaces
+between each layer: a pure, I/O-free builder (`buildRoleTable`) feeds an emit
+step (`EmitRoleTable`) that owns file I/O and idempotency, which a single
+pipeline call site wires in, validated end-to-end by a functional scenario.
+Each layer has a well-defined boundary and is a prerequisite for the next, and
+the lower layers are unit-testable in isolation before the integration exists.
+Integration risk is low — one new file write inside a directory apply already
+owns, reusing existing JSON, path-constant, and managed-file machinery — so the
+early-feedback benefit of a walking skeleton is not needed; building each layer
+fully before the next is the lower-friction shape.
+
+The four work items follow the design's own Implementation Approach phases
+1-to-4 directly.
+
+## Issue Outlines
+
+### <<ISSUE:1>> — Serializable types and pure role-table builder
+
+**Complexity:** testable
+
+**Goal.** Add `internal/workspace/roletable.go` with the serializable types,
+the schema-version and path constants, and the pure `buildRoleTable` function
+that maps the enumeration into the wire shape. No I/O — this is the
+table-testable core that the emit step and pipeline build on.
+
+**Scope.**
+- `roleTable` struct: `SchemaVersion int` (`json:"schema_version"`),
+  `Generated time.Time` (`json:"generated"`), `Roles []roleTableEntry`
+  (`json:"roles"`).
+- `roleTableEntry` struct: `Name string`, `Coordinator bool`,
+  `Repo *string` (`json:"repo"`, nil → JSON `null`), `Inbox string`.
+- `const roleTableSchemaVersion = 1`.
+- `RoleTableFile = "roles.json"` constant beside `StateDir`/`StateFile`, plus
+  `RoleTablePath(instanceRoot) = filepath.Join(instanceRoot, StateDir,
+  RoleTableFile)`.
+- `buildRoleTable(roles []roleEntry, instanceRoot string) (roleTable, error)`:
+  preserves `enumerateRoles`' coordinator-first, name-sorted order (no
+  re-sort); sets `Coordinator` true only for the coordinator; converts each
+  `roleEntry.repoPath` to an instance-root-relative path via `filepath.Rel`,
+  emitting `null` (nil `*string`) for the coordinator's empty `repoPath`;
+  computes `Inbox` as the instance-root-relative `.niwa/roles/<name>/inbox`.
+- Reject (return an error) any role whose `repoPath` resolves outside the
+  instance root (no `..` escape, no absolute leak) — the relative-path
+  invariant from the design's Security Considerations, enforced in code.
+
+**Acceptance criteria.**
+- [ ] Table-driven unit tests cover: coordinator entry (`Repo` nil, `Inbox`
+      = `.niwa/roles/coordinator/inbox`), a topology-derived role, an explicit
+      `[channels.mesh.roles]` override role, ordering preservation
+      (coordinator first, then name-sorted), and relative-path computation.
+- [ ] A test asserts no built `Repo`/`Inbox` value is absolute, contains the
+      instance-root prefix, or contains a `..` segment.
+- [ ] A test asserts a role resolving outside the instance root produces an
+      error rather than a leaked path.
+- [ ] `go test ./internal/workspace/...`, `gofmt`, and `go vet` pass.
+
+**Dependencies.** None.
+
+**Design refs.** Decision 3 (schema), Components, Implementation Approach
+Phase 1, Security Considerations invariant 2.
+
+---
+
+### <<ISSUE:2>> — Idempotent emit step writing `.niwa/roles.json` at mode 0600
+
+**Complexity:** critical
+
+Classified critical because this item owns the feature's two security
+invariants — no host-path leakage (relative paths only) and restrictive file
+mode (0600) — on a file explicitly intended to be committed and read by
+external tools.
+
+**Goal.** Add `EmitRoleTable(roles []roleEntry, instanceRoot string,
+writtenFiles *[]string) error`: build the table, apply the idempotency check,
+write the file only on a real change at mode 0600, and append the path to
+`writtenFiles` so apply's Step 7 hashes it into `ManagedFiles`.
+
+**Scope.**
+- Call `buildRoleTable`; on a build error, fail the emit (propagate).
+- Idempotency: read any existing `.niwa/roles.json`; compare the `roles`
+  payload only (NOT `generated`). If unchanged, leave the file byte-identical
+  (preserve the prior `generated`) and skip the write. If changed or absent,
+  set `generated` and write.
+- Write through the channels installer's existing `writeIdempotent` helper (or
+  `os.WriteFile` + explicit `Chmod(0o600)`) — never a bare write that inherits
+  the umask — using `json.MarshalIndent(..., "", "  ")` to match
+  `instance.json`/`sessions.json`.
+- Always append `RoleTablePath(instanceRoot)` to `*writtenFiles` (even on the
+  no-op path) so managed-file tracking stays consistent.
+
+**Acceptance criteria.**
+- [ ] Unit tests cover: absent-file (writes fresh), unchanged-set (second emit
+      produces a byte-identical file and preserves `generated`),
+      changed-set (rewrite reflects new roles and refreshes `generated`).
+- [ ] A test asserts the emitted file's mode is `0600`.
+- [ ] A test asserts the emitted JSON contains no absolute path, no
+      instance-root prefix, and no `..` segment (read-back of the serialized
+      bytes).
+- [ ] A test asserts the path is appended to `writtenFiles` on both the write
+      and the no-op paths.
+- [ ] `go test ./internal/workspace/...`, `gofmt`, and `go vet` pass.
+
+**Dependencies.** `<<ISSUE:1>>`.
+
+**Design refs.** Decision Outcome (idempotency), Data Flow steps 2-4,
+Idempotency detail, Security Considerations invariants 1 and 2.
+
+---
+
+### <<ISSUE:3>> — Wire the emit step into the apply pipeline
+
+**Complexity:** testable
+
+**Goal.** Invoke `EmitRoleTable` in `runPipeline`
+(`internal/workspace/apply.go`) immediately after
+`InstallChannelInfrastructure` returns (around `apply.go:1276`, before Step 5),
+passing the enumerated roles, `instanceRoot`, and the existing `&writtenFiles`
+accumulator, so the table is emitted on every apply that installs mesh
+infrastructure and is picked up by Step 7 into `InstanceState.ManagedFiles`.
+
+**Scope.**
+- Obtain the enumerated role set at the call site the same way
+  `InstallChannelInfrastructure` obtains it (share the slice or re-invoke
+  `enumerateRoles`); pass it to `EmitRoleTable`.
+- Emit unconditionally whenever mesh channel infrastructure is installed (R1,
+  R10) — no consumer-presence gating.
+- No table-specific managed-file code: appending to `writtenFiles` is the whole
+  integration; Step 7 (`apply.go:1435-1452`) and `CheckDrift` (`apply.go:411`)
+  handle the rest.
+
+**Acceptance criteria.**
+- [ ] An apply-level test asserts `.niwa/roles.json` exists after apply and
+      appears in `InstanceState.ManagedFiles` (drift-tracked).
+- [ ] The emitted table lists exactly the enumerated roles (coordinator + one
+      per cloned repo + explicit overrides), with each `inbox` matching the
+      inbox directory created in the same apply.
+- [ ] `go test ./...`, `gofmt`, and `go vet` pass.
+
+**Dependencies.** `<<ISSUE:2>>`.
+
+**Design refs.** Key Interfaces (internal call site, managed-file
+registration), Implementation Approach Phase 3; PRD R1, R9, R10.
+
+---
+
+### <<ISSUE:4>> — `@critical` functional scenario for role-table emission
+
+**Complexity:** testable
+
+**Goal.** Add a `@critical` Gherkin scenario under `test/functional/features/`
+driving real `niwa apply` against `localGitServer` bare-repo fakes, validating
+the end-to-end emission, idempotency, and add/remove-repo behavior the PRD
+acceptance criteria require.
+
+**Scope.**
+- Assert `.niwa/roles.json` exists after apply.
+- Assert it lists exactly the enumerated roles (coordinator + one per cloned
+  repo); each `inbox` matches the created inbox directory.
+- Assert a second apply on the unchanged workspace yields a byte-identical file
+  (R8).
+- Assert adding a repo and re-applying adds exactly one role entry; removing a
+  repo removes exactly that entry.
+- Assert the file contains no absolute host path (relative-path contract, R16).
+
+**Acceptance criteria.**
+- [ ] The scenario is tagged `@critical` and runs under `make
+      test-functional-critical`.
+- [ ] All assertions above pass against the compiled binary via the
+      `localGitServer` helper (offline).
+- [ ] `make test-functional-critical` passes.
+
+**Dependencies.** `<<ISSUE:3>>`.
+
+**Design refs.** Implementation Approach Phase 4; PRD Acceptance Criteria;
+CLAUDE.md functional-testing convention.
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    I1["#1 Types + pure builder"]
+    I2["#2 Idempotent emit step (0600)"]
+    I3["#3 Pipeline wiring"]
+    I4["#4 @critical functional scenario"]
+
+    I1 --> I2
+    I2 --> I3
+    I3 --> I4
+```
+
+## Implementation Sequence
+
+The four items form a single linear critical path —
+`<<ISSUE:1>>` → `<<ISSUE:2>>` → `<<ISSUE:3>>` → `<<ISSUE:4>>` — with no
+parallelization opportunity, which is expected for a horizontal decomposition
+of one tightly-layered emit step. Land them in order within one PR:
+
+1. **`<<ISSUE:1>>`** establishes the types and the pure, fully-tested builder
+   (including the relative-path invariant) with zero I/O.
+2. **`<<ISSUE:2>>`** adds the file-writing emit step with idempotency and the
+   0600 mode invariant on top of the builder.
+3. **`<<ISSUE:3>>`** wires the emit step into `runPipeline` and confirms
+   managed-file/drift participation.
+4. **`<<ISSUE:4>>`** validates the whole path end-to-end against real applies.
+
+Each step is independently reviewable, but the PR is the unit of delivery: the
+observable value — `niwa apply` emitting a working, drift-tracked role table —
+is realized when all four land together.
+
+## Value Confirmation
+
+Single-PR unit check (Phase 3.5a): the one PR-shaped unit delivers observable
+incremental value on its own — after it merges, `niwa apply` emits a versioned,
+drift-tracked `.niwa/roles.json` that any reader can resolve role names
+against, with no consumer required to be present (PRD R10). The split into four
+in-PR items is a work breakdown, not four independently-shippable increments;
+none is intended to land alone. Execution mode **single-pr** confirmed — no
+hard constraint forces multiple PRs, and the feature is one cohesive
+deliverable. (Autonomous `/scope` run; recommended-default judgment.)

--- a/docs/plans/PLAN-niwa-role-table.md
+++ b/docs/plans/PLAN-niwa-role-table.md
@@ -144,8 +144,12 @@ Idempotency detail, Security Considerations invariants 1 and 2.
 (`internal/workspace/apply.go`) immediately after
 `InstallChannelInfrastructure` returns (around `apply.go:1276`, before Step 5),
 passing the enumerated roles, `instanceRoot`, and the existing `&writtenFiles`
-accumulator, so the table is emitted on every apply that installs mesh
+accumulator, so the table is emitted on every run that installs mesh
 infrastructure and is picked up by Step 7 into `InstanceState.ManagedFiles`.
+`runPipeline` is the pipeline shared by both `Applier.Create` (`apply.go:288`)
+and `Applier.Apply` (`apply.go:428`), so wiring here — and only here — gives
+create/apply symmetry (PRD R1) for free; do NOT add the call in an apply-only
+branch.
 
 **Scope.**
 - Obtain the enumerated role set at the call site the same way
@@ -163,12 +167,15 @@ infrastructure and is picked up by Step 7 into `InstanceState.ManagedFiles`.
 - [ ] The emitted table lists exactly the enumerated roles (coordinator + one
       per cloned repo + explicit overrides), with each `inbox` matching the
       inbox directory created in the same apply.
+- [ ] A test exercising the `Applier.Create` path asserts `.niwa/roles.json` is
+      emitted there too (the call is in shared `runPipeline`, not apply-only) —
+      locking PRD R1 create/apply symmetry.
 - [ ] `go test ./...`, `gofmt`, and `go vet` pass.
 
 **Dependencies.** `<<ISSUE:2>>`.
 
-**Design refs.** Key Interfaces (internal call site, managed-file
-registration), Implementation Approach Phase 3; PRD R1, R9, R10.
+**Design refs.** Key Interfaces (internal call site, create/apply symmetry,
+managed-file registration), Implementation Approach Phase 3; PRD R1, R9, R10.
 
 ---
 
@@ -189,6 +196,9 @@ acceptance criteria require.
   (R8).
 - Assert adding a repo and re-applying adds exactly one role entry; removing a
   repo removes exactly that entry.
+- Assert a fresh `niwa create` produces `.niwa/roles.json` before any explicit
+  `apply` (create/apply symmetry, R1; covers the init → create → apply workflow
+  per CLAUDE.md).
 - Assert the file contains no absolute host path (relative-path contract, R16).
 
 **Acceptance criteria.**

--- a/docs/prds/PRD-niwa-role-table.md
+++ b/docs/prds/PRD-niwa-role-table.md
@@ -1,5 +1,5 @@
 ---
-status: Accepted
+status: In Progress
 problem: |
   niwa enumerates a workspace's role set at apply time to build the mesh
   inboxes but never persists it. Tools that address a role by name from
@@ -19,10 +19,11 @@ upstream: docs/briefs/BRIEF-niwa-role-table.md
 
 ## Status
 
-Accepted
+In Progress
 
 Requirements locked via autonomous `/scope` run (recommended-default
-judgment calls; no Open Questions remain). The feature carries
+judgment calls; no Open Questions remain). Design underway at
+`docs/designs/DESIGN-niwa-role-table.md`. The feature carries
 architectural choices left open for the design — the concrete file
 format, the exact location and filename under `.niwa/`, the schema field
 layout, and what a "delivery destination" resolves to — so a design doc

--- a/docs/prds/PRD-niwa-role-table.md
+++ b/docs/prds/PRD-niwa-role-table.md
@@ -1,0 +1,227 @@
+---
+status: Accepted
+problem: |
+  niwa enumerates a workspace's role set at apply time to build the mesh
+  inboxes but never persists it. Tools that address a role by name from
+  outside niwa (a coordinator-bridge skill, a peer-messaging layer, an
+  operator) have no workspace-aware source of truth and must hard-code
+  identifiers or keep drifting side tables that diverge from the topology
+  niwa already computed.
+goals: |
+  Make niwa apply emit a durable, readable role table that publishes the
+  role set niwa already derives, so any session or sibling tool can
+  resolve a role name to its delivery destination from one authoritative
+  file that niwa keeps current on every apply.
+upstream: docs/briefs/BRIEF-niwa-role-table.md
+---
+
+# PRD: niwa apply emits a workspace-aware role table
+
+## Status
+
+Accepted
+
+Requirements locked via autonomous `/scope` run (recommended-default
+judgment calls; no Open Questions remain). The feature carries
+architectural choices left open for the design — the concrete file
+format, the exact location and filename under `.niwa/`, the schema field
+layout, and what a "delivery destination" resolves to — so a design doc
+is warranted before implementation. Downstream design:
+`docs/designs/DESIGN-niwa-role-table.md`.
+
+## Problem Statement
+
+A niwa workspace hosts multiple repos and a coordinator-plus-delegates
+mesh. Messages and delegated work are addressed to *roles*: a coordinator
+plus one role per cloned repo, the exact set niwa already enumerates at
+`niwa apply` time (see `enumerateRoles` in
+`internal/workspace/channels.go`) to lay down each role's message inbox
+under `.niwa/roles/<role>/inbox/`.
+
+That role set lives only in niwa's process memory. niwa derives it, uses
+it to create the inbox directories, and discards it. Nothing on disk
+tells an outside reader which roles a workspace has or where a message
+addressed to a given role should be delivered.
+
+The people and tools affected are those that address a role by name from
+outside niwa:
+
+- A coordinator-bridge skill (hosted in shirabe) that turns an `@role`
+  mention into a dispatch has no list to resolve the name against. It
+  falls back to explicit operator-supplied identifiers or its own side
+  table of roles.
+- A peer-messaging and mention-routing layer (koto) at the multi-repo
+  substrate has the same problem one layer down.
+- An operator who wants to see which roles a workspace has must read the
+  config and re-derive the topology by hand.
+
+Any side table a consumer keeps drifts the moment a repo is added or
+removed, because the consumer is re-deriving a fact niwa already owns
+authoritatively. This matters now because the workspace mesh — the
+coordinator-and-delegates pattern these consumers are being built around
+— depends on role addressing being ergonomic and consistent across
+tools, and today every tool re-invents the same answer.
+
+## Goals
+
+- niwa publishes the role set it already computes, so it stops being a
+  fact that lives only in niwa's head.
+- A reader — a bridge skill, a peer-messaging layer, an operator, or any
+  Claude Code session — can resolve a role name to its delivery
+  destination from a single authoritative file without re-deriving the
+  workspace topology.
+- The published table tracks the workspace automatically: every apply
+  regenerates it, and an apply that changes nothing changes nothing.
+- The file is a stable contract sibling tools can build against, not an
+  internal scratch artifact whose shape changes without notice.
+
+## User Stories
+
+- As a coordinator-bridge skill resolving an `@role` mention, I want to
+  look up the role name in a workspace-provided table so that I can
+  dispatch to the right destination without asking the operator to spell
+  out an explicit identifier.
+- As a peer-messaging layer routing to a role at the multi-repo
+  substrate, I want one authoritative role-to-destination mapping so that
+  my routing agrees with what every other tool resolves the same name to.
+- As an operator inspecting a workspace, I want to read the role set niwa
+  actually built so that I can confirm a newly added repo became an
+  addressable role without re-deriving the topology myself.
+- As an operator who re-applies after changing the repo set, I want the
+  table regenerated automatically so that it never drifts from the
+  inboxes niwa created in the same apply.
+- As the maintainer of a tool that reads the table, I want its location
+  and shape to be a versioned, stable interface so that a niwa upgrade
+  does not silently break my consumer.
+
+## Requirements
+
+### Functional
+
+- **R1.** `niwa apply` SHALL emit a role-table data file as part of every
+  apply run that installs the mesh channel infrastructure.
+- **R2.** The table SHALL be written to a known, stable location under
+  the workspace instance's `.niwa/` directory, fixed across applies so
+  consumers can locate it without discovery heuristics.
+- **R3.** The table's source of truth SHALL be niwa's existing role
+  enumeration — coordinator, topology-derived roles (one per cloned
+  repo), and explicitly-configured `[channels.mesh.roles]` overrides. The
+  table SHALL contain exactly that role set: every enumerated role and no
+  others.
+- **R4.** For each role, the table SHALL record the information a consumer
+  needs to (a) resolve the role name to its delivery destination (the
+  role's message inbox) and (b) identify the repo the role is bound to
+  (or mark it as the coordinator, which is bound to the instance root).
+- **R5.** The coordinator role SHALL always be present in the table.
+- **R6.** The table SHALL carry a schema version so a consumer can detect
+  an incompatible change rather than misread a newer table.
+- **R7.** Role entries SHALL appear in a deterministic order that is
+  stable across applies which do not change the role set.
+- **R8.** Re-running `niwa apply` SHALL regenerate the table. An apply
+  that does not change the enumerated role set SHALL produce byte-
+  identical output; a change to the role set SHALL be reflected in the
+  regenerated table.
+- **R9.** The emitted table SHALL be registered as a niwa-managed file for
+  the instance, so it participates in apply's managed-file tracking and
+  drift detection like other apply-materialized files.
+- **R10.** The table SHALL be emitted unconditionally whenever mesh
+  channel infrastructure is installed — independent of whether any
+  consumer (bridge skill, peer-messaging layer, role CLI) is present in
+  the workspace.
+- **R11.** Role names in the table SHALL conform to niwa's existing
+  role-name rules. This feature introduces no new naming, enumeration, or
+  validation behavior; it serializes the result of the existing
+  enumeration unchanged.
+
+### Non-functional
+
+- **R12.** The table SHALL be a stability surface: its location and schema
+  constitute a public interface sibling tools read against, and changes to
+  that interface SHALL follow an additive, version-gated discipline rather
+  than silent reshaping.
+- **R13.** The table SHALL be plain-text, machine-readable structured data
+  a human can also read directly.
+- **R14.** Emission SHALL add negligible cost to apply, since it serializes
+  data the apply run has already computed; it SHALL NOT introduce new
+  network calls or repo scans beyond the existing enumeration.
+- **R15.** The table SHALL contain no secrets, tokens, or credentials.
+- **R16.** Destination references in the table SHALL be expressed relative
+  to the workspace instance root, so the file is position-independent and
+  does not leak absolute host paths.
+
+## Acceptance Criteria
+
+- [ ] After `niwa apply` on a workspace whose mesh infrastructure is
+  installed, the role-table file exists at its fixed `.niwa/` location.
+- [ ] The table lists exactly the roles niwa enumerated for the workspace
+  (coordinator + one per cloned repo + explicit overrides) — no missing
+  roles and no extra entries.
+- [ ] Each role entry's recorded delivery destination matches the role's
+  actual inbox directory created during the same apply.
+- [ ] The coordinator role is present in the table.
+- [ ] The table includes a schema-version field.
+- [ ] Running `niwa apply` twice on an unchanged workspace yields a
+  byte-identical table on the second run (no spurious rewrite).
+- [ ] Adding one repo and re-applying produces exactly one additional
+  role entry corresponding to that repo.
+- [ ] Removing a repo and re-applying removes exactly that repo's role
+  entry.
+- [ ] The table is recorded among the instance's niwa-managed files
+  (observable in the instance state niwa persists for the workspace).
+- [ ] Emission occurs even when no bridge skill, peer-messaging layer, or
+  role CLI is installed in the workspace.
+- [ ] A reader can resolve a role name to its delivery destination using
+  only the file's documented schema, without niwa-internal knowledge.
+- [ ] The table contains no secrets, tokens, or credentials, and no
+  absolute host paths.
+
+## Decisions and Trade-offs
+
+- **Source of truth is the existing enumeration, not a new role model.**
+  The table serializes `enumerateRoles` output. The alternative — a
+  dedicated role-definition config the table reads from — was rejected
+  because it would duplicate the topology niwa already derives and create
+  a second place for the role set to drift. Trade-off accepted: the table
+  is exactly as expressive as the existing enumeration, no more.
+- **Emission is unconditional whenever mesh infra installs.** Gating
+  emission on a consumer being present was rejected: the role CLI and any
+  standalone reader need the file regardless, and a conditional emission
+  would make "does the table exist?" depend on unrelated workspace state.
+- **Architectural choices are deferred to the design.** The concrete file
+  format, the exact filename and location under `.niwa/`, the schema field
+  layout, and the precise meaning of "delivery destination" (inbox path,
+  repo path, or both) are genuine architectural alternatives with viable
+  options. They are left open for `DESIGN-niwa-role-table.md` so the
+  design can weigh them against the consumer contract; this PRD fixes the
+  behavior and the contract obligations, not the wire shape.
+
+## Known Limitations
+
+- The table's value to addressing ergonomics depends on consumers (bridge
+  skill, peer-messaging layer, role CLI) existing. Without them the file
+  is still emitted and readable, but the end-to-end `@role` resolution
+  experience is only realized once a consumer reads it. This PRD
+  deliberately scopes only the emission side.
+- The table reflects the role set as of the last apply. Between applies,
+  manual filesystem changes to the repo set are not reflected until the
+  next `niwa apply`; the table is an apply-time snapshot, consistent with
+  how niwa materializes every other managed file.
+
+## Out of Scope
+
+- The coordinator-bridge skill's content and mention-routing logic. It
+  lives in shirabe and consumes the table; this PRD covers emitting the
+  data, not the skill.
+- The `niwa role` CLI commands (e.g. listing roles, resolving a name to a
+  destination) that read the table. Separate niwa feature; this PRD emits
+  the file those commands will read.
+- koto's peer-messaging and mention-routing logic that consumes the
+  resolution this feature enables.
+- The `.claude/agents/<role>.md` subagent-definition files generated at
+  apply time. That is the sibling agent-definition feature; it produces
+  agent *definitions*, while this PRD covers the role *table* (data). Both
+  share the apply codepath and the same role set but are scoped separately.
+- Any change to how roles are enumerated, named, or validated. The feature
+  reuses the existing enumeration unchanged.
+- Message delivery and transport. The per-role inboxes already exist; this
+  feature publishes where they are, it does not move messages.

--- a/docs/prds/PRD-niwa-role-table.md
+++ b/docs/prds/PRD-niwa-role-table.md
@@ -99,8 +99,14 @@ tools, and today every tool re-invents the same answer.
 
 ### Functional
 
-- **R1.** `niwa apply` SHALL emit a role-table data file as part of every
-  apply run that installs the mesh channel infrastructure.
+- **R1.** Emitting the role-table data file SHALL be symmetric across the
+  commands that materialize a workspace: both `niwa create` and `niwa apply`
+  SHALL emit the table as part of every run that installs the mesh channel
+  infrastructure. Because the two commands share one materialization pipeline,
+  emission is wired once into that shared pipeline and covers both entry points
+  with no command-specific behavior. A freshly created workspace SHALL therefore
+  carry the table after its initial materialization, before any explicit
+  `apply`.
 - **R2.** The table SHALL be written to a known, stable location under
   the workspace instance's `.niwa/` directory, fixed across applies so
   consumers can locate it without discovery heuristics.
@@ -154,6 +160,9 @@ tools, and today every tool re-invents the same answer.
 
 - [ ] After `niwa apply` on a workspace whose mesh infrastructure is
   installed, the role-table file exists at its fixed `.niwa/` location.
+- [ ] After a fresh `niwa create` (before any explicit `apply`), the
+  role-table file already exists at the same fixed `.niwa/` location, with
+  the same contents `apply` would produce for the same role set.
 - [ ] The table lists exactly the roles niwa enumerated for the workspace
   (coordinator + one per cloned repo + explicit overrides) — no missing
   roles and no extra entries.


### PR DESCRIPTION
> **Status: closed — superseded.** A later decision reframed this work: start with Claude Code native agent teams for in-session coordination and defer this static role-table feature until cross-repo coordination demonstrably needs it. See the closing comment.

## What

Scopes a **workspace-aware role table** for `niwa apply` by running the full tactical chain. This PR is **docs only**: BRIEF, PRD, DESIGN, and a single-PR PLAN. No code — it was opened for review before implementation.

## Artifacts

| Doc | Status | Path |
|---|---|---|
| BRIEF | Accepted | `docs/briefs/BRIEF-niwa-role-table.md` |
| PRD | In Progress (design pointer) | `docs/prds/PRD-niwa-role-table.md` |
| DESIGN | Planned | `docs/designs/DESIGN-niwa-role-table.md` |
| PLAN | Draft (single-pr) | `docs/plans/PLAN-niwa-role-table.md` |

## Design decisions (resolving the design's open questions)

1. **Format** — JSON via `encoding/json` (`MarshalIndent`, 2-space). Reuses niwa's existing emit convention (`instance.json`, `sessions.json`); zero new deps.
2. **Location** — `.niwa/roles.json` at the instance root. Manifest companion to the `.niwa/roles/` tree, kept separable from the private `instance.json`.
3. **Schema** — `{schema_version, generated, roles[]}` with per-role `{name, coordinator, repo, inbox}`. Delivery destination is the inbox relative path; coordinator-first, name-sorted ordering.
4. **Security invariants** — file mode `0600` and an enforced relative-path contract (no host-path leak).

## Implementation shape (PLAN)

4 in-PR work items, linear path 1 → 2 → 3 → 4:

1. Serializable types + pure `buildRoleTable`
2. Idempotent emit step writing `.niwa/roles.json` at mode `0600` (owns the no-host-path-leak and file-mode invariants)
3. Wire the emit step into the apply pipeline after `InstallChannelInfrastructure`
4. `@critical` functional Gherkin scenario

## Consumers (downstream)

- The shirabe `koto-mesh` bridge skill — would consult the table at peer-ask dispatch and mention-routing time
- A `niwa role` CLI — would read the table this feature emits
- koto's mention-routing — would shell out to `niwa role resolve`

Sibling per-role `.claude/agents/<role>.md` generation is kept out of scope; the relationship is noted in the PRD.

## Notes for reviewers

- Generated via the `/scope` tactical chain (BRIEF → PRD → DESIGN → PLAN); design classified Complex (public stability surface, external consumers, open format/location alternatives).
- `shirabe validate` was not run in the autonomous worktree (needs interactive approval); equivalent manual structural checks passed per child.
