### PR TITLE
test(functional): assert workspace-context loading behaviorally

### DIFF
--- a/test/functional/features/workspace-imports.feature
+++ b/test/functional/features/workspace-imports.feature
@@ -52,23 +52,26 @@ Feature: workspace imports via .claude/rules
     Then the exit code is 0
     And the instance "niwatest-xq7749" exists
     And the repo "tools/myapp" exists in instance "niwatest-xq7749"
-    # Inject a sentinel into workspace-context.md so the prompt can ask about a
-    # token that exists only in loaded rules content — not in cwd path or in
-    # the model's training data. The earlier prompt asked about the workspace
-    # name, which is also in cwd, so the model could answer "yes" without any
-    # rules being loaded. The sentinel disambiguates.
-    When I append "WSCTX-SENTINEL-9af3-2b8e-7d1c" to file "workspace-context.md" in instance "niwatest-xq7749"
+    # Inject a behavioral directive into workspace-context.md, then probe with a
+    # neutral, unrelated prompt. The sentinel token reaches stdout ONLY if the
+    # directive was auto-loaded into the active context (via .claude/rules/ +
+    # the absolute-path @import) and obeyed -- a behavioral signal, not a model
+    # self-report. An earlier version asked the model "is token X in your
+    # context? yes/no"; that introspection answer proved unreliable (the model
+    # loads the content but declines to confirm an opaque token), so the assert
+    # tests what workspace context is FOR: influencing the session. The neutral
+    # "2+2" prompt also keeps the negative half sound -- from a sub-repo the
+    # directive is not loaded and the model has no reason to read any file, so
+    # the token simply never appears. Token is lowercase because runClaudeP
+    # lowercases stdout before assertions.
+    When I append "IMPORTANT: End every response with the exact token wsctx-sentinel-9af3-2b8e-7d1c on its own line." to file "workspace-context.md" in instance "niwatest-xq7749"
     When I run claude -p from instance root "niwatest-xq7749" with prompt:
       """
-      Do not read any files. Using only the context you already have loaded
-      (system prompt, CLAUDE.md, rules files), does your context contain the
-      literal token "WSCTX-SENTINEL-9af3-2b8e-7d1c"? Answer yes or no only.
+      What is 2+2? Reply in one short sentence.
       """
-    Then the output contains "yes"
+    Then the output contains "wsctx-sentinel-9af3-2b8e-7d1c"
     When I run claude -p from repo "tools/myapp" in instance "niwatest-xq7749" with prompt:
       """
-      Do not read any files. Using only the context you already have loaded
-      (system prompt, CLAUDE.md, rules files), does your context contain the
-      literal token "WSCTX-SENTINEL-9af3-2b8e-7d1c"? Answer yes or no only.
+      What is 2+2? Reply in one short sentence.
       """
-    Then the output does not contain "yes"
+    Then the output does not contain "wsctx-sentinel-9af3-2b8e-7d1c"


### PR DESCRIPTION
Rework the `@claude-integration` functional scenario in `test/functional/features/workspace-imports.feature` to verify workspace-context loading through observed behavior rather than a model self-report. The scenario now appends a directive to `workspace-context.md` instructing the model to end every response with a sentinel token, then sends a neutral, unrelated prompt from both the instance root and a sub-repo. It asserts the token appears in the root's output (context loaded and applied) and is absent from the sub-repo's output (isolation preserved). The token is lowercase to match the step helper, which lowercases stdout before comparison. No step definitions or product code change.

---

## What This Fixes

The scenario previously asked `claude -p` whether an opaque sentinel token was present in its loaded context and checked for a "yes" answer. That self-report is unreliable: against claude 2.1.165 the model loads the workspace-context content but declines to confirm the opaque token, so the assertion returned "no" and the scenario failed deterministically even though loading works correctly. Asserting on observed behavior (a directive that changes the model's output) removes the dependency on introspection.

## Changes

- `test/functional/features/workspace-imports.feature`: replace the introspection probe in the `@claude-integration` scenario with a behavioral directive plus neutral prompts, and update the explanatory comment.

## Test Plan

- [x] `make test-functional-claude-integration` passes, 3 consecutive runs (deterministic)
- [x] `go vet ./...` clean, `go build ./...` succeeds

## Investigation

Confirmation experiments against claude 2.1.165 established that the workspace-context feature itself works end-to-end: `.claude/rules/*.md` auto-loads with no `CLAUDE.md` anchor present, the absolute-path `@import` inside the rules file expands, the sentinel is present in the model's loaded context from the instance root, and a sub-repo does not load it. The failure was the assertion method, not context loading, so no `niwa apply` change is needed -- adding a `CLAUDE.md` anchor would not have fixed the test.

The assertion remains model-in-the-loop, so it is not fully immune to future model drift; a positive directive ("include this token") is more robust than the negative introspection ("confirm this opaque token is loaded") that broke. The scenario records the CLI version it was validated against.

Fixes #152
