### PR TITLE
test(functional): use system claude auth locally, API key only in CI

### DIFF
--- a/test/functional/steps_test.go
+++ b/test/functional/steps_test.go
@@ -1185,16 +1185,29 @@ func theFileInInstanceDoesNotContain(ctx context.Context, relPath, instance, tex
 
 // --- Claude integration steps ---
 
-// claudeIsAvailable checks that the claude CLI and ANTHROPIC_API_KEY are
-// available. Returns godog.ErrPending to skip the scenario when either is absent.
+// claudeIsAvailable checks that the claude CLI can authenticate. Returns
+// godog.ErrPending to skip the scenario when it cannot.
+//
+// CI has no interactive Claude session, so it authenticates the CLI through
+// ANTHROPIC_API_KEY and skips when the key is absent. Locally, the scenario
+// relies on whatever auth the claude CLI already holds (a subscription login
+// or OAuth token), so a developer signed in to claude can run these tests
+// without setting an API key.
 func claudeIsAvailable(ctx context.Context) (context.Context, error) {
 	if _, err := exec.LookPath("claude"); err != nil {
 		return ctx, godog.ErrPending
 	}
-	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+	if runningInCI() && os.Getenv("ANTHROPIC_API_KEY") == "" {
 		return ctx, godog.ErrPending
 	}
 	return ctx, nil
+}
+
+// runningInCI reports whether the suite is executing under a CI system.
+// GitHub Actions sets GITHUB_ACTIONS; CI is the broader convention most
+// runners honor.
+func runningInCI() bool {
+	return os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("CI") != ""
 }
 
 // iRunClaudePFromInstanceRoot runs claude -p with the given prompt from the
@@ -1227,9 +1240,18 @@ func runClaudeP(s *testState, cwd, prompt string) error {
 	if err != nil {
 		return godog.ErrPending
 	}
-	env := s.buildEnv()
+	var env []string
 	if key := os.Getenv("ANTHROPIC_API_KEY"); key != "" {
-		env = append(env, "ANTHROPIC_API_KEY="+key)
+		// A key is provided (the CI path): run in the sandboxed environment
+		// and authenticate the claude CLI through the key.
+		env = append(s.buildEnv(), "ANTHROPIC_API_KEY="+key)
+	} else {
+		// No key (the local path): use the developer's real environment so
+		// claude authenticates through their existing login session, which the
+		// sandboxed HOME/XDG_CONFIG_HOME would otherwise hide. Only the claude
+		// invocation runs unsandboxed; niwa state was already materialized
+		// under the sandbox HOME in earlier steps.
+		env = os.Environ()
 	}
 	cmd := exec.Command(claudeBin, "-p", prompt)
 	cmd.Dir = cwd


### PR DESCRIPTION
## Problem

The `@claude-integration` functional scenarios were unrunnable for a contributor signed in to the `claude` CLI but without an API key:

- `claudeIsAvailable` returned `ErrPending` (skip) whenever `ANTHROPIC_API_KEY` was unset — even with a perfectly good interactive login.
- `runClaudeP` ran `claude` under the sandboxed `HOME`/`XDG_CONFIG_HOME`, which hides `~/.claude.json` and the stored credentials, so even forcing the scenario to run produced `not logged in · please run /login`.

Net effect: these tests only ran when an API key was present, which is the wrong requirement for local development.

## Change

Make the API key a **CI-only** requirement:

- **Gate:** `claudeIsAvailable` now requires only the `claude` CLI locally; the `ANTHROPIC_API_KEY` requirement applies only under CI (`GITHUB_ACTIONS`/`CI`). A developer logged into claude can run the tests with no key.
- **Auth:** when no key is present (the local path), `runClaudeP` runs the `claude` invocation with the developer's real environment so it authenticates through their existing login session. Only the `claude` call runs unsandboxed; niwa state was already materialized under the sandbox `HOME` in earlier steps. When a key is present (CI), behavior is unchanged — sandboxed env plus the key.

## Verification

- Locally, with no `ANTHROPIC_API_KEY` and not under CI, the scenario runs against the developer's login and passes:
  `1 scenarios (1 passed) / 16 steps (16 passed)`.
- Without the change it either skipped (no key) or failed `not logged in` (forced to run under sandboxed HOME).
- `go test ./...`, `go vet`, `gofmt`, and `golangci-lint` (no new findings) are clean.

## Note

CI runs these only when `ANTHROPIC_API_KEY` is set as an Actions secret (the workflow already guards the step on it). That secret is currently unset, so CI skips the claude-integration step until a valid key is restored.