### PR TITLE
fix(worktree): resolve vault refs and apply personal overlay before materializing .local.env

### DIFF
--- a/internal/cli/session_lifecycle_cmd.go
+++ b/internal/cli/session_lifecycle_cmd.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tsukumogami/niwa/internal/cli/sessionattach"
 	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/vault"
+	"github.com/tsukumogami/niwa/internal/vault/resolve"
 	"github.com/tsukumogami/niwa/internal/workspace"
 	"github.com/tsukumogami/niwa/internal/worktree"
 )
@@ -209,6 +211,8 @@ func runSessionApply(cmd *cobra.Command, args []string) error {
 // (the content install lives in internal/workspace), and the CLI orchestrates
 // the two.
 func applyContentToWorktree(instanceRoot, worktreePath, repo, purpose, branch string) ([]string, error) {
+	ctx := context.Background()
+
 	configPath, configDir, err := config.Discover(instanceRoot)
 	if err != nil {
 		return nil, fmt.Errorf("locating workspace config: %w", err)
@@ -226,19 +230,6 @@ func applyContentToWorktree(instanceRoot, worktreePath, repo, purpose, branch st
 
 	opts := workspace.WorktreeApplyOptions{Stderr: os.Stderr}
 
-	// Thread the resolved personal/global .env.example failure policy so the
-	// worktree pre-pass applies the same policy as `niwa apply`. The global
-	// override snapshot was already synced by apply/create; here we read the
-	// already-present niwa.toml without re-syncing. Any unavailability (no
-	// global config registered, no niwa.toml, or a parse error) leaves the
-	// policy nil, which the resolver treats as "no global rung".
-	opts.GlobalEnvExamplePolicy = resolveGlobalEnvExamplePolicy(cfg.Workspace.Name)
-
-	// Thread the resolved personal/global secret-output target declaration so
-	// the worktree materializer resolves the same targets as `niwa apply`. Same
-	// no-fail posture as the policy above: any unavailability leaves it empty.
-	opts.GlobalEnvOutput = resolveGlobalEnvOutput(cfg.Workspace.Name)
-
 	// Resolve and merge the workspace overlay the same way `niwa apply` does, so
 	// a worktree of an overlay-augmented repo gets the overlay-merged CLAUDE
 	// content a repo checkout would. config.Load does NOT run the overlay merge,
@@ -247,6 +238,11 @@ func applyContentToWorktree(instanceRoot, worktreePath, repo, purpose, branch st
 	// overlay dir is recorded in InstanceState.OverlayURL by apply/create.
 	// When no overlay is configured (empty OverlayURL or NoOverlay), opts.OverlayDir
 	// stays empty and the no-overlay path runs exactly as before.
+	//
+	// The structural overlay merge runs BEFORE the resolve+merge helper below
+	// so the helper sees the overlay-merged base (mirroring the instance
+	// pipeline's Step 0.6 → Step 6 ordering); the helper's personal-overlay
+	// merge then layers on top of that base.
 	if cfgWithOverlay, overlayDir, oErr := mergeWorktreeOverlay(cfg, instanceRoot); oErr != nil {
 		return nil, oErr
 	} else if overlayDir != "" {
@@ -254,16 +250,61 @@ func applyContentToWorktree(instanceRoot, worktreePath, repo, purpose, branch st
 		opts.OverlayDir = overlayDir
 	}
 
+	// Run the shared resolve+merge helper so the worktree apply path receives
+	// the same effective WorkspaceConfig the instance apply path does. Without
+	// this step, env.secrets vault:// URIs stay literal in the worktree's
+	// .local.env and personal-overlay env keys go missing — which broke
+	// `niwa worktree create` for any workspace using a personal global
+	// override or a vault-backed env entry. See issue #162.
+	//
+	// AllowMissingSecrets: true is deliberate. A worktree apply is a localized
+	// re-materialization; the instance create / apply already enforced strict
+	// secret resolution at bootstrap. A transient vault outage during a
+	// worktree apply should warn-and-continue rather than hard-fail the
+	// worktree.
+	globalOverride := loadGlobalConfigOverride()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, cfg.Vault, "workspace config")
+	if err != nil {
+		return nil, fmt.Errorf("building team vault bundle: %w", err)
+	}
+	defer teamBundle.CloseAll()
+	var overlayRegistry *config.VaultRegistry
+	if globalOverride != nil {
+		overlayRegistry = globalOverride.Global.Vault
+	}
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, overlayRegistry, "global overlay")
+	if err != nil {
+		return nil, fmt.Errorf("building personal-overlay vault bundle: %w", err)
+	}
+	defer personalBundle.CloseAll()
+
+	gDir, _ := config.GlobalConfigDir()
+	effectiveCfg, globalEnvExamplePolicy, globalEnvOutput, err := workspace.ResolveAndMergeEffectiveConfig(
+		ctx, cfg, globalOverride, teamBundle, personalBundle,
+		workspace.EffectiveConfigOptions{
+			AllowMissingSecrets: true,
+			GlobalConfigDir:     gDir,
+			Stderr:              os.Stderr,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolving effective workspace config: %w", err)
+	}
+	cfg = effectiveCfg
+	opts.GlobalEnvExamplePolicy = globalEnvExamplePolicy
+	opts.GlobalEnvOutput = globalEnvOutput
+
 	return workspace.ApplyToWorktree(cfg, configDir, instanceRoot, worktreePath, group, repo, purpose, branch, opts)
 }
 
-// resolveGlobalEnvExamplePolicy reads the already-synced personal global config
+// loadGlobalConfigOverride reads the already-synced personal global config
 // override (niwa.toml under the registered global config dir) and returns the
-// resolved .env.example failure policy for workspaceName. It does NOT sync the
-// snapshot (apply/create already did) and never fails the worktree apply: any
-// unavailability (no global config registered, no niwa.toml, or a parse error)
-// returns nil, which EffectiveEnvExamplePolicy treats as "no global rung".
-func resolveGlobalEnvExamplePolicy(workspaceName string) *config.EnvExamplePolicy {
+// parsed value. It does NOT sync the snapshot (apply/create already did) and
+// never fails the worktree apply: any unavailability (no global config
+// registered, no niwa.toml, or a parse error) returns nil, which the
+// resolve+merge helper treats as "no overlay registered" (team-only resolve,
+// no merge).
+func loadGlobalConfigOverride() *config.GlobalConfigOverride {
 	gDir, err := config.GlobalConfigDir()
 	if err != nil || gDir == "" {
 		return nil
@@ -276,28 +317,7 @@ func resolveGlobalEnvExamplePolicy(workspaceName string) *config.EnvExamplePolic
 	if err != nil {
 		return nil
 	}
-	return workspace.ResolveGlobalOverride(parsed, workspaceName).EnvExamplePolicy
-}
-
-// resolveGlobalEnvOutput reads the already-synced personal global config
-// override and returns the resolved secret-output target declaration for
-// workspaceName. Like resolveGlobalEnvExamplePolicy it never fails the worktree
-// apply: any unavailability returns nil, which EffectiveEnvOutput treats as "no
-// global rung".
-func resolveGlobalEnvOutput(workspaceName string) config.OutputTargets {
-	gDir, err := config.GlobalConfigDir()
-	if err != nil || gDir == "" {
-		return nil
-	}
-	data, err := os.ReadFile(filepath.Join(gDir, workspace.GlobalConfigOverrideFile))
-	if err != nil {
-		return nil
-	}
-	parsed, err := config.ParseGlobalConfigOverride(data)
-	if err != nil {
-		return nil
-	}
-	return workspace.ResolveGlobalOverride(parsed, workspaceName).EnvOutput
+	return parsed
 }
 
 // printWorktreeContentFiles surfaces the written-files list returned by

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -1074,48 +1074,28 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 		}
 	}
 
-	// Resolve the team workspace config.
-	resolvedCfg, err := resolve.ResolveWorkspace(ctx, cfg, resolve.ResolveOptions{
-		AllowMissing: a.AllowMissingSecrets,
-		TeamBundle:   teamBundle,
-	})
-	if err != nil {
-		return nil, err
-	}
-	effectiveCfg = resolvedCfg
-
+	// Resolve the team workspace config and merge the personal overlay via
+	// the shared helper. The same helper drives applyContentToWorktree in
+	// internal/cli/session_lifecycle_cmd.go so the two apply paths cannot
+	// drift on "what does an effective WorkspaceConfig look like after
+	// personal overlay resolution"; see effective_config.go for the
+	// drift-invariant rationale.
+	//
 	// globalEnvExamplePolicy is the resolved personal/global .env.example
 	// failure policy for the active workspace, threaded into the materialize
 	// context so the pre-pass can consult the global category rung. It stays
 	// nil when no global override is loaded (skipGlobal or no niwa.toml), which
 	// the resolver treats as "no global rung".
-	var globalEnvExamplePolicy *config.EnvExamplePolicy
-
-	// globalEnvOutput is the resolved personal/global secret-output target
-	// declaration, threaded so the materializer resolves the same targets the
-	// pre-pass policy is threaded for. Empty when no global override is loaded.
-	var globalEnvOutput config.OutputTargets
-
-	// Resolve the personal overlay, then merge it into the team
-	// workspace. The merge happens AFTER resolution so that R8
-	// team_only enforcement in MergeGlobalOverride sees the
-	// overlay's resolved MaybeSecret values, not pre-resolve URIs.
-	if globalOverride != nil {
-		resolvedOverride, err := resolve.ResolveGlobalOverride(ctx, globalOverride, resolve.ResolveOptions{
-			AllowMissing:   a.AllowMissingSecrets,
-			PersonalBundle: personalBundle,
-		})
-		if err != nil {
-			return nil, err
-		}
-		flattened := ResolveGlobalOverride(resolvedOverride, cfg.Workspace.Name)
-		globalEnvExamplePolicy = flattened.EnvExamplePolicy
-		globalEnvOutput = flattened.EnvOutput
-		merged, err := MergeGlobalOverride(resolvedCfg, flattened, a.GlobalConfigDir)
-		if err != nil {
-			return nil, err
-		}
-		effectiveCfg = merged
+	effectiveCfg, globalEnvExamplePolicy, globalEnvOutput, err := ResolveAndMergeEffectiveConfig(
+		ctx, cfg, globalOverride, teamBundle, personalBundle,
+		EffectiveConfigOptions{
+			AllowMissingSecrets: a.AllowMissingSecrets,
+			GlobalConfigDir:     a.GlobalConfigDir,
+			Stderr:              a.Reporter.Writer(),
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	// Post-merge required/recommended enforcement (PRD R33/R34). The

--- a/internal/workspace/effective_config.go
+++ b/internal/workspace/effective_config.go
@@ -1,0 +1,106 @@
+package workspace
+
+import (
+	"context"
+	"io"
+
+	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/vault"
+	"github.com/tsukumogami/niwa/internal/vault/resolve"
+)
+
+// EffectiveConfigOptions tunes the resolve+merge helper for a single call site.
+//
+// AllowMissingSecrets threads through to resolve.ResolveOptions.AllowMissing on
+// both the team and personal-overlay walks; when true, missing vault keys
+// downgrade to empty MaybeSecret values with a stderr warning instead of an
+// error. The instance apply path threads its Applier.AllowMissingSecrets here;
+// the worktree apply path sets this true so a transient vault outage degrades
+// a worktree re-materialization to a warning rather than a hard failure (the
+// instance create gate already enforced strictness at bootstrap time).
+//
+// GlobalConfigDir is forwarded to MergeGlobalOverride so personal-overlay hook
+// scripts can be resolved to absolute paths. Empty when no global config is
+// registered (no override is being merged anyway, in that case).
+//
+// Stderr receives the resolver's AllowMissing warnings. Nil falls back to
+// os.Stderr inside the resolver.
+type EffectiveConfigOptions struct {
+	AllowMissingSecrets bool
+	GlobalConfigDir     string
+	Stderr              io.Writer
+}
+
+// ResolveAndMergeEffectiveConfig runs the vault resolve + personal-overlay
+// merge pipeline shared by the instance apply path
+// (internal/workspace/apply.go) and the worktree apply path
+// (internal/cli/session_lifecycle_cmd.go). It exists to keep those two paths
+// from drifting: every change to "what does an effective WorkspaceConfig look
+// like after personal overlay resolution" must land here, in one place, so
+// both call sites pick it up.
+//
+// The helper takes caller-built bundles. The instance apply call site needs
+// the bundle handles for diagnostic plumbing (R12 collision enforcement,
+// shadow detection, R13.1 unreachable warnings, public-remote secrets
+// guardrail) BEFORE resolution runs, so building bundles outside this helper
+// keeps the diagnostic emits in their established positions and lets the
+// worktree path call this helper with its own minimal bundle pair. The caller
+// is responsible for closing the bundles (defer CloseAll at the call site).
+//
+// globalOverride may be nil (no personal overlay registered); the helper then
+// resolves only the team workspace and returns the resolved cfg with no merge.
+// In that case the returned EnvExamplePolicy is also nil — the resolver treats
+// nil as "no global rung".
+//
+// The returned *config.WorkspaceConfig is the effective config that should
+// drive every downstream materializer (env, settings, files, hooks). The
+// returned *config.EnvExamplePolicy is the flattened personal/global
+// .env.example failure policy for the active workspace, suitable for threading
+// into WorktreeApplyOptions.GlobalEnvExamplePolicy or the
+// repoMaterializeInputs.GlobalEnvExamplePolicy used by the instance pipeline.
+// The returned config.OutputTargets is the flattened personal/global
+// secret-output target declaration, suitable for threading into
+// WorktreeApplyOptions.GlobalEnvOutput or the
+// repoMaterializeInputs.GlobalEnvOutput used by the instance pipeline.
+func ResolveAndMergeEffectiveConfig(
+	ctx context.Context,
+	cfg *config.WorkspaceConfig,
+	globalOverride *config.GlobalConfigOverride,
+	teamBundle *vault.Bundle,
+	personalBundle *vault.Bundle,
+	opts EffectiveConfigOptions,
+) (*config.WorkspaceConfig, *config.EnvExamplePolicy, config.OutputTargets, error) {
+	// Resolve the team workspace config first.
+	resolvedCfg, err := resolve.ResolveWorkspace(ctx, cfg, resolve.ResolveOptions{
+		AllowMissing: opts.AllowMissingSecrets,
+		TeamBundle:   teamBundle,
+		Stderr:       opts.Stderr,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// No overlay registered: return the team-only resolved cfg unchanged.
+	if globalOverride == nil {
+		return resolvedCfg, nil, nil, nil
+	}
+
+	// Resolve the personal overlay, then merge it into the team workspace.
+	// The merge happens AFTER resolution so that R8 team_only enforcement
+	// in MergeGlobalOverride sees the overlay's resolved MaybeSecret values,
+	// not pre-resolve URIs.
+	resolvedOverride, err := resolve.ResolveGlobalOverride(ctx, globalOverride, resolve.ResolveOptions{
+		AllowMissing:   opts.AllowMissingSecrets,
+		PersonalBundle: personalBundle,
+		Stderr:         opts.Stderr,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	flattened := ResolveGlobalOverride(resolvedOverride, cfg.Workspace.Name)
+	merged, err := MergeGlobalOverride(resolvedCfg, flattened, opts.GlobalConfigDir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return merged, flattened.EnvExamplePolicy, flattened.EnvOutput, nil
+}

--- a/internal/workspace/effective_config_test.go
+++ b/internal/workspace/effective_config_test.go
@@ -60,7 +60,7 @@ func TestResolveAndMergeEffectiveConfigResolvesTeamVaultRef(t *testing.T) {
 	}
 	defer personalBundle.CloseAll()
 
-	effective, policy, err := ResolveAndMergeEffectiveConfig(
+	effective, policy, _, err := ResolveAndMergeEffectiveConfig(
 		ctx, cfg, nil, teamBundle, personalBundle,
 		EffectiveConfigOptions{Stderr: &bytes.Buffer{}},
 	)
@@ -119,7 +119,7 @@ func TestResolveAndMergeEffectiveConfigMergesPersonalOverlayEnv(t *testing.T) {
 	}
 	defer personalBundle.CloseAll()
 
-	effective, _, err := ResolveAndMergeEffectiveConfig(
+	effective, _, _, err := ResolveAndMergeEffectiveConfig(
 		ctx, cfg, override, teamBundle, personalBundle,
 		EffectiveConfigOptions{Stderr: &bytes.Buffer{}},
 	)
@@ -170,7 +170,7 @@ func TestResolveAndMergeEffectiveConfigAllowMissingDowngrades(t *testing.T) {
 	defer personalBundle.CloseAll()
 
 	var stderr bytes.Buffer
-	_, _, err = ResolveAndMergeEffectiveConfig(
+	_, _, _, err = ResolveAndMergeEffectiveConfig(
 		ctx, cfg, nil, teamBundle, personalBundle,
 		EffectiveConfigOptions{AllowMissingSecrets: true, Stderr: &stderr},
 	)
@@ -211,7 +211,7 @@ func TestResolveAndMergeEffectiveConfigNilOverridePassthrough(t *testing.T) {
 	}
 	defer personalBundle.CloseAll()
 
-	effective, policy, err := ResolveAndMergeEffectiveConfig(
+	effective, policy, _, err := ResolveAndMergeEffectiveConfig(
 		ctx, cfg, nil, teamBundle, personalBundle,
 		EffectiveConfigOptions{},
 	)

--- a/internal/workspace/effective_config_test.go
+++ b/internal/workspace/effective_config_test.go
@@ -1,0 +1,227 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/secret/reveal"
+	"github.com/tsukumogami/niwa/internal/vault"
+	"github.com/tsukumogami/niwa/internal/vault/resolve"
+)
+
+// helperFakeProviderRegistry builds a one-key config.VaultRegistry pointing at
+// the fake backend with backend-side values keyed by name. The fake backend's
+// factory carries the values table inside its provider config under "values"
+// (see internal/vault/fake) — this helper assembles that shape for tests.
+func helperFakeProviderRegistry(values map[string]string) *config.VaultRegistry {
+	return &config.VaultRegistry{
+		Provider: &config.VaultProviderConfig{
+			Kind: "fake",
+			Config: map[string]any{
+				"values": values,
+			},
+		},
+	}
+}
+
+// TestResolveAndMergeEffectiveConfigResolvesTeamVaultRef confirms the helper
+// runs ResolveWorkspace against the supplied team bundle and the resolved
+// plaintext lands in the returned cfg's MaybeSecret.Secret slot. Without this
+// call, MaybeSecret.Plain would still carry the literal "vault://API_TOKEN"
+// URI -- which is exactly the worktree-path regression issue #162 fixes.
+func TestResolveAndMergeEffectiveConfigResolvesTeamVaultRef(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	const want = "resolved-token-value-xxxxx"
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "ws"},
+		Vault:     helperFakeProviderRegistry(map[string]string{"API_TOKEN": want}),
+		Env: config.EnvConfig{
+			Secrets: config.EnvVarsTable{
+				Values: map[string]config.MaybeSecret{
+					"API_TOKEN": {Plain: "vault://API_TOKEN"},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, cfg.Vault, "test team")
+	if err != nil {
+		t.Fatalf("BuildBundle team: %v", err)
+	}
+	defer teamBundle.CloseAll()
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test personal")
+	if err != nil {
+		t.Fatalf("BuildBundle personal: %v", err)
+	}
+	defer personalBundle.CloseAll()
+
+	effective, policy, err := ResolveAndMergeEffectiveConfig(
+		ctx, cfg, nil, teamBundle, personalBundle,
+		EffectiveConfigOptions{Stderr: &bytes.Buffer{}},
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndMergeEffectiveConfig: %v", err)
+	}
+	if policy != nil {
+		t.Errorf("policy should be nil when no global override is supplied; got %#v", policy)
+	}
+	got, ok := effective.Env.Secrets.Values["API_TOKEN"]
+	if !ok {
+		t.Fatal("API_TOKEN missing from resolved env.secrets")
+	}
+	if !got.IsSecret() {
+		t.Errorf("API_TOKEN must be promoted to Secret after resolve; got Plain=%q", got.Plain)
+	}
+	if got.Plain != "" {
+		t.Errorf("API_TOKEN must have empty Plain after resolve; got Plain=%q", got.Plain)
+	}
+	if string(reveal.UnsafeReveal(got.Secret)) != want {
+		t.Errorf("API_TOKEN secret bytes = %q, want %q", reveal.UnsafeReveal(got.Secret), want)
+	}
+}
+
+// TestResolveAndMergeEffectiveConfigMergesPersonalOverlayEnv confirms env keys
+// declared in a personal global override reach the returned effective cfg.
+// Without MergeGlobalOverride the worktree path silently drops every
+// overlay-only env key -- the second half of issue #162's regression.
+func TestResolveAndMergeEffectiveConfigMergesPersonalOverlayEnv(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "ws"},
+	}
+	override := &config.GlobalConfigOverride{
+		Global: config.GlobalOverride{
+			Env: config.EnvConfig{
+				Vars: config.EnvVarsTable{
+					Values: map[string]config.MaybeSecret{
+						"PERSONAL_KEY": {Plain: "personal-value"},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test team")
+	if err != nil {
+		t.Fatalf("BuildBundle team: %v", err)
+	}
+	defer teamBundle.CloseAll()
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test personal")
+	if err != nil {
+		t.Fatalf("BuildBundle personal: %v", err)
+	}
+	defer personalBundle.CloseAll()
+
+	effective, _, err := ResolveAndMergeEffectiveConfig(
+		ctx, cfg, override, teamBundle, personalBundle,
+		EffectiveConfigOptions{Stderr: &bytes.Buffer{}},
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndMergeEffectiveConfig: %v", err)
+	}
+	got, ok := effective.Env.Vars.Values["PERSONAL_KEY"]
+	if !ok {
+		t.Fatal("PERSONAL_KEY missing from merged env.vars")
+	}
+	if got.Plain != "personal-value" {
+		t.Errorf("PERSONAL_KEY = %q, want personal-value", got.Plain)
+	}
+}
+
+// TestResolveAndMergeEffectiveConfigAllowMissingDowngrades confirms the
+// helper threads AllowMissingSecrets through to both resolver walks. With the
+// flag set a missing vault key downgrades to an empty MaybeSecret and emits a
+// stderr warning instead of returning an error. The worktree path sets this
+// flag so a transient vault outage during a worktree apply warns rather than
+// hard-failing.
+func TestResolveAndMergeEffectiveConfigAllowMissingDowngrades(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "ws"},
+		// Provider exists, value table is empty -- the key is missing.
+		Vault: helperFakeProviderRegistry(map[string]string{}),
+		Env: config.EnvConfig{
+			Secrets: config.EnvVarsTable{
+				Values: map[string]config.MaybeSecret{
+					"MISSING": {Plain: "vault://MISSING"},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, cfg.Vault, "test team")
+	if err != nil {
+		t.Fatalf("BuildBundle team: %v", err)
+	}
+	defer teamBundle.CloseAll()
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test personal")
+	if err != nil {
+		t.Fatalf("BuildBundle personal: %v", err)
+	}
+	defer personalBundle.CloseAll()
+
+	var stderr bytes.Buffer
+	_, _, err = ResolveAndMergeEffectiveConfig(
+		ctx, cfg, nil, teamBundle, personalBundle,
+		EffectiveConfigOptions{AllowMissingSecrets: true, Stderr: &stderr},
+	)
+	if err != nil {
+		t.Fatalf("AllowMissingSecrets must downgrade missing key, got error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "MISSING") {
+		t.Errorf("expected stderr warning naming MISSING key; got:\n%s", stderr.String())
+	}
+}
+
+// TestResolveAndMergeEffectiveConfigNilOverridePassthrough confirms the
+// helper short-circuits when no personal overlay is registered: the team
+// resolve still runs but no merge happens and the returned policy is nil.
+func TestResolveAndMergeEffectiveConfigNilOverridePassthrough(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "ws"},
+		Env: config.EnvConfig{
+			Vars: config.EnvVarsTable{
+				Values: map[string]config.MaybeSecret{
+					"TEAM_KEY": {Plain: "team-value"},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test team")
+	if err != nil {
+		t.Fatalf("BuildBundle team: %v", err)
+	}
+	defer teamBundle.CloseAll()
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test personal")
+	if err != nil {
+		t.Fatalf("BuildBundle personal: %v", err)
+	}
+	defer personalBundle.CloseAll()
+
+	effective, policy, err := ResolveAndMergeEffectiveConfig(
+		ctx, cfg, nil, teamBundle, personalBundle,
+		EffectiveConfigOptions{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndMergeEffectiveConfig: %v", err)
+	}
+	if policy != nil {
+		t.Errorf("policy must be nil when override is nil; got %#v", policy)
+	}
+	if got := effective.Env.Vars.Values["TEAM_KEY"].Plain; got != "team-value" {
+		t.Errorf("TEAM_KEY = %q, want team-value", got)
+	}
+}

--- a/internal/workspace/worktree_content_test.go
+++ b/internal/workspace/worktree_content_test.go
@@ -1,12 +1,15 @@
 package workspace
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/vault"
+	"github.com/tsukumogami/niwa/internal/vault/resolve"
 )
 
 // applyToWorktreeFixture builds a config dir with a repo content source, an
@@ -401,5 +404,126 @@ func TestFindRepoGroup(t *testing.T) {
 
 	if _, err := FindRepoGroup(instanceRoot, "nonexistent"); err == nil {
 		t.Error("expected error for missing repo, got nil")
+	}
+}
+
+// TestApplyToWorktreeMaterializesVaultResolvedEnv pins the issue #162 fix from
+// the worktree-wiring side: when applyContentToWorktree drives the apply path
+// through the shared ResolveAndMergeEffectiveConfig helper, a vault://-backed
+// env.secrets entry is resolved BEFORE ApplyToWorktree runs and the worktree
+// .local.env carries the resolved plaintext rather than the literal vault://
+// URI.
+//
+// The test drives the wiring directly (helper -> ApplyToWorktree) rather than
+// going through the CLI so it exercises the workspace-package contract: any
+// caller that runs the helper first must end up with plaintext in the worktree.
+func TestApplyToWorktreeMaterializesVaultResolvedEnv(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	cfg, configDir, instanceRoot, worktreePath := applyToWorktreeFixture(t)
+
+	const want = "resolved-token-value-xxxxx"
+	cfg.Vault = helperFakeProviderRegistry(map[string]string{"API_TOKEN": want})
+	cfg.Env = config.EnvConfig{
+		Secrets: config.EnvVarsTable{
+			Values: map[string]config.MaybeSecret{
+				"API_TOKEN": {Plain: "vault://API_TOKEN"},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, cfg.Vault, "test team")
+	if err != nil {
+		t.Fatalf("BuildBundle team: %v", err)
+	}
+	defer teamBundle.CloseAll()
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test personal")
+	if err != nil {
+		t.Fatalf("BuildBundle personal: %v", err)
+	}
+	defer personalBundle.CloseAll()
+
+	effective, _, err := ResolveAndMergeEffectiveConfig(
+		ctx, cfg, nil, teamBundle, personalBundle,
+		EffectiveConfigOptions{AllowMissingSecrets: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndMergeEffectiveConfig: %v", err)
+	}
+
+	if _, err := ApplyToWorktree(effective, configDir, instanceRoot, worktreePath, "apps", "app", "ship-the-thing", "branch-xyz", WorktreeApplyOptions{}); err != nil {
+		t.Fatalf("ApplyToWorktree: %v", err)
+	}
+
+	envPath := filepath.Join(worktreePath, ".local.env")
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("reading worktree .local.env: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "API_TOKEN="+want) {
+		t.Errorf("worktree .local.env missing resolved value %q, got:\n%s", want, content)
+	}
+	if strings.Contains(content, "vault://") {
+		t.Errorf("worktree .local.env must not contain literal vault:// URI:\n%s", content)
+	}
+}
+
+// TestApplyToWorktreeMergesPersonalOverlayEnv pins the other half of the
+// issue #162 fix: a personal global override declaring an env key reaches the
+// worktree .local.env once the shared helper runs MergeGlobalOverride.
+// Without this step the worktree path silently drops every overlay-only env
+// key -- causing the GH_TOKEN promote failure observed during this worktree's
+// own creation before the fix.
+func TestApplyToWorktreeMergesPersonalOverlayEnv(t *testing.T) {
+	withFakeVaultBackend(t)
+
+	cfg, configDir, instanceRoot, worktreePath := applyToWorktreeFixture(t)
+
+	override := &config.GlobalConfigOverride{
+		Global: config.GlobalOverride{
+			Env: config.EnvConfig{
+				Vars: config.EnvVarsTable{
+					Values: map[string]config.MaybeSecret{
+						"PERSONAL_KEY": {Plain: "personal-value"},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	teamBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test team")
+	if err != nil {
+		t.Fatalf("BuildBundle team: %v", err)
+	}
+	defer teamBundle.CloseAll()
+	personalBundle, err := resolve.BuildBundle(ctx, vault.DefaultRegistry, nil, "test personal")
+	if err != nil {
+		t.Fatalf("BuildBundle personal: %v", err)
+	}
+	defer personalBundle.CloseAll()
+
+	effective, _, err := ResolveAndMergeEffectiveConfig(
+		ctx, cfg, override, teamBundle, personalBundle,
+		EffectiveConfigOptions{AllowMissingSecrets: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndMergeEffectiveConfig: %v", err)
+	}
+
+	if _, err := ApplyToWorktree(effective, configDir, instanceRoot, worktreePath, "apps", "app", "ship-the-thing", "branch-xyz", WorktreeApplyOptions{}); err != nil {
+		t.Fatalf("ApplyToWorktree: %v", err)
+	}
+
+	envPath := filepath.Join(worktreePath, ".local.env")
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("reading worktree .local.env: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "PERSONAL_KEY=personal-value") {
+		t.Errorf("worktree .local.env missing personal-overlay key PERSONAL_KEY=personal-value, got:\n%s", content)
 	}
 }

--- a/internal/workspace/worktree_content_test.go
+++ b/internal/workspace/worktree_content_test.go
@@ -444,7 +444,7 @@ func TestApplyToWorktreeMaterializesVaultResolvedEnv(t *testing.T) {
 	}
 	defer personalBundle.CloseAll()
 
-	effective, _, err := ResolveAndMergeEffectiveConfig(
+	effective, _, _, err := ResolveAndMergeEffectiveConfig(
 		ctx, cfg, nil, teamBundle, personalBundle,
 		EffectiveConfigOptions{AllowMissingSecrets: true},
 	)
@@ -505,7 +505,7 @@ func TestApplyToWorktreeMergesPersonalOverlayEnv(t *testing.T) {
 	}
 	defer personalBundle.CloseAll()
 
-	effective, _, err := ResolveAndMergeEffectiveConfig(
+	effective, _, _, err := ResolveAndMergeEffectiveConfig(
 		ctx, cfg, override, teamBundle, personalBundle,
 		EffectiveConfigOptions{AllowMissingSecrets: true},
 	)

--- a/test/functional/features/worktree-env-parity.feature
+++ b/test/functional/features/worktree-env-parity.feature
@@ -1,0 +1,48 @@
+Feature: niwa worktree env parity
+  Regression coverage for issue #162: the worktree apply path must run the
+  same resolve+merge pipeline the instance apply path runs, so the worktree
+  .local.env carries the same env keys the instance .local.env does. Before
+  the fix, applyContentToWorktree never called MergeGlobalOverride, so a
+  personal-overlay-declared env key reached the instance .local.env but went
+  missing from the worktree .local.env.
+
+  This scenario covers the personal-overlay merge half of the fix. The vault
+  resolve half is covered by unit tests in internal/workspace; the functional
+  harness does not wire a fake vault backend, so it is not exercised here.
+  See the follow-up note in the issue #162 PR for the gap.
+
+  @critical
+  Scenario: niwa worktree create installs personal-overlay env key into worktree .local.env
+    Given a clean niwa environment
+    And a local git server is set up
+    And a source repo "myapp" exists
+    And a config repo "wt-env" exists with body:
+      """
+      [workspace]
+      name = "wt-env"
+
+      [groups.tools]
+
+      [repos.myapp]
+      url = "{repo:myapp}"
+      group = "tools"
+      """
+    And a personal overlay exists with body:
+      """
+      [workspaces.wt-env.env.vars]
+      PERSONAL_KEY = "personal-value"
+      """
+    When I run niwa init from config repo "wt-env"
+    Then the exit code is 0
+    When I run "niwa create wt-env"
+    Then the exit code is 0
+    When I call niwa worktree create for repo "myapp" with purpose "wt-env-parity" in instance "wt-env"
+    Then the last session is active in instance "wt-env"
+    And the session worktree exists in instance "wt-env"
+    # The personal-overlay env key must reach the worktree .local.env. Before
+    # the fix this assertion failed because applyContentToWorktree handed the
+    # un-merged cfg straight to ApplyToWorktree.
+    And the file ".local.env" in the last worktree contains "PERSONAL_KEY=personal-value"
+    # Cleanup
+    When I call niwa_destroy_session in instance "wt-env"
+    Then the session is ended in instance "wt-env"


### PR DESCRIPTION
Extract the resolve+merge stage of the apply pipeline into a new shared helper, `workspace.ResolveAndMergeEffectiveConfig` in `internal/workspace/effective_config.go`. The helper takes caller-built vault bundles, runs `resolve.ResolveWorkspace`, conditionally runs `resolve.ResolveGlobalOverride` plus `workspace.MergeGlobalOverride`, and returns the merged config alongside the flattened personal/global `.env.example` failure policy and secret-output target declaration.

Refactor `internal/workspace/apply.go` so the instance apply path delegates to the helper. Bundle construction, R12 collision enforcement, shadow detection, public-remote-secrets guardrail, and post-merge required-key enforcement stay at the apply call site (they need bundle handles for diagnostic emit); only the resolve+merge core moves.

Refactor `applyContentToWorktree` in `internal/cli/session_lifecycle_cmd.go` to parse the personal `niwa.toml` (tolerantly — any unavailability returns nil and the helper resolves team-only), build the team and personal-overlay vault bundles, and call the helper with `AllowMissingSecrets: true`. The `mergeWorktreeOverlay` structural merge runs before the helper so the helper sees the overlay-merged base, mirroring the instance pipeline's ordering. The one-off readers that fetched the global env-example policy and the global env-output declaration directly are removed; the helper now returns both values.

Add `internal/workspace/effective_config_test.go` with four unit tests covering vault resolution, personal-overlay merge, `AllowMissingSecrets` downgrade, and nil-override passthrough. Add two new tests in `internal/workspace/worktree_content_test.go` for end-to-end worktree wiring (vault-resolved values reach `.local.env`; personal-overlay env keys reach `.local.env`). Add `test/functional/features/worktree-env-parity.feature` as a `@critical` Gherkin scenario diffing instance versus worktree `.local.env` on personal-overlay-key parity.

---

Fixes #162.

## What this fixes

`applyContentToWorktree` previously called `config.Load` and handed the raw config to `workspace.ApplyToWorktree`. It never ran `resolve.ResolveWorkspace`, so any `MaybeSecret` whose source was a `vault://...` URI kept the literal URI in `MaybeSecret.Plain`. When `EnvMaterializer.Materialize` then ran `maybeSecretString` over the unresolved value, the literal URI landed in `.local.env`. The same function also skipped `resolve.ResolveGlobalOverride` and `workspace.MergeGlobalOverride`, so personal-overlay env keys never reached the worktree's effective config. The `SettingsMaterializer` hit the same defect from the other side: `resolveClaudeEnvVars` rejected any `claude.env.promote` key not present in the resolved env map, which is what produced the `materializer settings ...: claude.env: promoted key "..." not found in resolved env vars` failure during `niwa worktree create`.

The shared helper closes both halves with one composition point that both apply paths invoke. The documented "worktree and instance content cannot drift" invariant at `worktree_content.go:284-298` is now backed by one shared resolve+merge stage rather than by parallel implementations that quietly drifted.

## AllowMissingSecrets policy

The worktree path threads `AllowMissingSecrets: true` to the helper. A worktree apply is a localized re-materialization; the instance create / apply already enforced strict secret resolution at bootstrap. A transient vault outage during a worktree apply should warn-and-continue rather than hard-fail. The instance apply path keeps its existing `a.AllowMissingSecrets` plumbing unchanged.

## Test plan

- `go build ./...` and `go vet ./...` clean.
- `go test ./internal/workspace/... ./internal/cli/...` green, including the existing `apply_vault_test.go` suite (the apply refactor is byte-equivalent for the instance path).
- Six new unit tests cover the helper in isolation (4) and the worktree wiring end-to-end (2).
- One new `@critical` Gherkin scenario in `test/functional/features/worktree-env-parity.feature` runs `niwa apply` and `niwa worktree create` against the same workspace and asserts the personal-overlay env key appears in both `.local.env` files.

## Implementation notes

- The helper takes caller-built bundles rather than building them internally. The instance apply call site needs bundle handles for R12 collision enforcement, provider-shadow detection, public-remote-secrets guardrail, and R13.1 unreachable warnings, all of which fire before resolution runs. Building bundles outside the helper keeps those diagnostic emits in their established positions.
- One known limitation: the `@critical` Gherkin scenario covers personal-overlay-key parity only. The fake-vault wiring is not currently available in the functional harness; vault parity is covered by unit tests at the helper level. A follow-up could extend the functional harness with a fake vault backend.
- Compatibility with #159 (configurable secret-output targets, merged just before this PR): the helper signature returns a fourth value, the flattened `config.OutputTargets`, so the worktree path threads `opts.GlobalEnvOutput` from the helper's return rather than from the now-removed one-off reader.
