### PR TITLE
feat(workspace): reconcile global marketplace auto-update on apply

### DIFF
--- a/docs/designs/current/DESIGN-niwa-plugin-record-lifecycle.md
+++ b/docs/designs/current/DESIGN-niwa-plugin-record-lifecycle.md
@@ -33,6 +33,10 @@ rationale: |
 
 Current
 
+Amended 2026-06-20 — see the "Amendment: global marketplace-registry
+reconciliation" section at the end, added after a post-implementation
+gap surfaced (R18).
+
 ## Context and Problem Statement
 
 Claude Code keeps a global plugin install registry at
@@ -453,3 +457,49 @@ the report with no write or backup); no user-facing command exposes it.
   repo directories before committing; out of scope for this design.
 - Reporting the underlying Claude Code GC gap upstream is tracked
   separately.
+
+## Amendment 2026-06-20: global marketplace-registry reconciliation
+
+**Gap.** The original design (Decision 3, Decision 6, R6/R7) had niwa
+write the per-marketplace `auto_update` policy into each repo's project
+`extraKnownMarketplaces`. In use this proved insufficient: Claude Code
+merges project `extraKnownMarketplaces` into its global
+`known_marketplaces.json` only when registering a marketplace it does
+not already know. For an already-registered marketplace it keeps the
+existing global entry, so a marketplace niwa had previously registered
+with `autoUpdate: true` kept that stale value even after the config
+flipped it to false — the churn the feature set out to stop continued
+for existing installs. (Fresh registrations were unaffected.)
+
+**Decision.** niwa reconciles the global marketplace registry directly,
+the same self-healing posture the dangling-record heal already applies
+to `installed_plugins.json`. This is consistent with the design's
+established stance that niwa may safely mutate Claude-owned files under
+`~/.claude/plugins/` using the remove/edit-only, atomic, backed-up,
+fail-safe discipline.
+
+**Mechanism.**
+
+- `pluginrecord.ReconcileAutoUpdate(desired map[string]bool, opts...)`
+  loads `~/.claude/plugins/known_marketplaces.json` (preserve-unknowns,
+  ordered), sets `autoUpdate` to the desired value for each named
+  marketplace that ALREADY exists, and writes via the existing atomic
+  temp-and-rename with a timestamped backup. It never adds a
+  marketplace (Claude owns registration), touches only the named
+  entries, no-ops on an absent file, and returns `ErrMalformed`
+  (leaving the file untouched) on a malformed one.
+- A `runPipeline` step (Step 9), invoked on every create and update like
+  the heal, builds the desired map from `cfg.Claude.Marketplaces`
+  (name via the shared `marketplaceRegistrationName`, value from
+  `MarketplaceConfig.AutoUpdate`) and calls the reconcile through an
+  `Applier` seam. It is fail-safe: a nil seam or any registry error is a
+  deferred warning, never failing create/update. It reports which
+  marketplaces it updated.
+- `marketplaceRegistrationName` is extracted from
+  `mapMarketplaceSourceWithIndex` so the project-settings name and the
+  global-registry name are computed by one function and cannot drift.
+
+**Scope.** Reconciliation adjusts only the `autoUpdate` flag (the churn
+knob). It deliberately does not rewrite the source object — the
+version-tracking ref limitation (Decision 6 spike) is unchanged.
+Satisfies R18.

--- a/docs/prds/PRD-niwa-plugin-record-lifecycle.md
+++ b/docs/prds/PRD-niwa-plugin-record-lifecycle.md
@@ -29,6 +29,13 @@ motivating_context: |
 
 Done
 
+Amended 2026-06-20 (post-implementation): added R18 after a gap surfaced
+in use — niwa's per-marketplace auto-update policy reached project
+settings but not Claude Code's already-registered global marketplace
+entries, so existing registrations kept the stale `autoUpdate: true`.
+R18 requires niwa to reconcile the global registry for the marketplaces
+it manages.
+
 ## Problem Statement
 
 Claude Code keeps a global plugin registry at
@@ -164,6 +171,18 @@ Functional (version tracking):
 - **R17.** The version-tracking selection SHALL live in the same
   per-marketplace configuration as the auto-update value (R7).
 
+Functional (registry reconciliation — amendment 2026-06-20):
+
+- **R18.** For a marketplace niwa manages that is ALREADY registered in
+  Claude Code's global marketplace registry, niwa SHALL reconcile that
+  registry's auto-update flag to the configured value on create and
+  update — because Claude Code does not refresh an already-registered
+  marketplace's global entry from project settings, so the configured
+  policy (R6) would otherwise never reach an existing registration. The
+  reconciliation SHALL only adjust marketplaces niwa manages, SHALL NOT
+  add new marketplaces, and SHALL be fail-safe (an absent or malformed
+  registry never fails create or update).
+
 ## Acceptance Criteria
 
 - [ ] Destroying an instance removes exactly the records whose project
@@ -206,6 +225,10 @@ Functional (version tracking):
       registers exactly that ref.
 - [ ] A github marketplace with no published stable release registers
       tracking the default branch and the fallback is reported.
+- [ ] For an already-registered managed marketplace, create/update sets
+      its auto-update flag in the global marketplace registry to the
+      configured value, leaves unmanaged entries untouched, adds no new
+      marketplace, and is a no-op on an absent registry (R18).
 - [ ] New behavior is covered by unit tests and at least one functional
       (end-to-end) scenario.
 

--- a/internal/pluginrecord/marketplaces.go
+++ b/internal/pluginrecord/marketplaces.go
@@ -1,0 +1,189 @@
+// This file extends the pluginrecord package to reconcile Claude Code's
+// global marketplace registry at ~/.claude/plugins/known_marketplaces.json.
+//
+// niwa writes the per-marketplace auto-update policy into each repo's project
+// settings (extraKnownMarketplaces), but Claude Code does not overwrite an
+// already-registered marketplace's entry in its global registry from those
+// project settings. So a marketplace niwa registered earlier with
+// autoUpdate=true keeps that stale value even after niwa's config flips it to
+// false. ReconcileAutoUpdate closes that gap by updating the global registry's
+// autoUpdate flag for the marketplaces niwa manages — the same self-healing
+// posture the dangling-record Prune already applies to installed_plugins.json.
+package pluginrecord
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const knownMarketplacesRelPath = ".claude/plugins/known_marketplaces.json"
+
+// marketplaceBackupRetain caps how many timestamped backups of the marketplace
+// registry are kept, matching the installed_plugins backup retention.
+const marketplaceBackupRetain = 5
+
+// LocateMarketplaces resolves the path to known_marketplaces.json from
+// os.UserHomeDir plus the fixed relative path; WithBaseDir substitutes a test
+// directory.
+func LocateMarketplaces(opts ...Option) (string, error) {
+	c := &config{}
+	for _, o := range opts {
+		o(c)
+	}
+	base := c.baseDir
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = home
+	}
+	return filepath.Join(base, knownMarketplacesRelPath), nil
+}
+
+// ReconcileReport describes the outcome of a ReconcileAutoUpdate call.
+type ReconcileReport struct {
+	// Updated lists the marketplace names whose autoUpdate value changed.
+	Updated []string
+	// BackupPath is the timestamped backup written before the change, or "".
+	BackupPath string
+}
+
+// ReconcileAutoUpdate sets autoUpdate to the desired value for each named
+// marketplace that ALREADY EXISTS in known_marketplaces.json. It never adds a
+// marketplace (Claude Code owns registration) and never touches marketplaces
+// absent from desired. An absent registry file is a no-op; a malformed file
+// returns an error wrapping ErrMalformed and leaves the file untouched. All
+// other fields and the file's key order are preserved; a backup is written
+// before the first change.
+func ReconcileAutoUpdate(desired map[string]bool, opts ...Option) (ReconcileReport, error) {
+	var rep ReconcileReport
+	if len(desired) == 0 {
+		return rep, nil
+	}
+	path, err := LocateMarketplaces(opts...)
+	if err != nil {
+		return rep, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return rep, nil
+	}
+	if err != nil {
+		return rep, err
+	}
+
+	top, err := decodeOrderedObject(data)
+	if err != nil {
+		return rep, fmt.Errorf("%w: %v", ErrMalformed, err)
+	}
+
+	var updated []string
+	for i := range top {
+		want, ok := desired[top[i].Key]
+		if !ok {
+			continue
+		}
+		newVal, changed, err := setEntryAutoUpdate(top[i].Value, want)
+		if err != nil {
+			// Entry is not an editable JSON object; leave it untouched
+			// rather than risk corrupting an unexpected shape.
+			continue
+		}
+		if changed {
+			top[i].Value = newVal
+			updated = append(updated, top[i].Key)
+		}
+	}
+	if len(updated) == 0 {
+		return rep, nil
+	}
+
+	pretty, err := indentOrderedObject(top)
+	if err != nil {
+		return rep, err
+	}
+
+	mode := defaultFileMode
+	if info, statErr := os.Stat(path); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+
+	backupPath, err := writeExclBackup(path, data, mode)
+	if err != nil {
+		return rep, err
+	}
+	if err := rotateBackups(path, marketplaceBackupRetain); err != nil {
+		return rep, err
+	}
+	if err := atomicWrite(path, pretty, mode); err != nil {
+		return rep, err
+	}
+
+	sort.Strings(updated)
+	rep.Updated = updated
+	rep.BackupPath = backupPath
+	return rep, nil
+}
+
+// setEntryAutoUpdate returns the entry with its autoUpdate field set to want,
+// preserving all other fields and their order. It reports whether a change was
+// made. An entry that is not a JSON object returns an error.
+func setEntryAutoUpdate(raw json.RawMessage, want bool) (json.RawMessage, bool, error) {
+	fields, err := decodeOrderedObject(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	wantRaw := json.RawMessage("false")
+	if want {
+		wantRaw = json.RawMessage("true")
+	}
+	for i := range fields {
+		if fields[i].Key == "autoUpdate" {
+			if strings.TrimSpace(string(fields[i].Value)) == string(wantRaw) {
+				return raw, false, nil
+			}
+			fields[i].Value = wantRaw
+			return marshalOrderedObject(fields), true, nil
+		}
+	}
+	fields = append(fields, rawField{Key: "autoUpdate", Value: wantRaw})
+	return marshalOrderedObject(fields), true, nil
+}
+
+// marshalOrderedObject renders ordered fields as a compact JSON object,
+// preserving field order and each field's raw value verbatim.
+func marshalOrderedObject(fields []rawField) json.RawMessage {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, f := range fields {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyJSON, _ := json.Marshal(f.Key)
+		buf.Write(keyJSON)
+		buf.WriteByte(':')
+		buf.Write(f.Value)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
+}
+
+// indentOrderedObject renders ordered fields as a 2-space indented JSON object
+// with a trailing newline, matching the style Claude Code writes.
+func indentOrderedObject(fields []rawField) ([]byte, error) {
+	compact := marshalOrderedObject(fields)
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, compact, "", "  "); err != nil {
+		return nil, err
+	}
+	pretty.WriteByte('\n')
+	return pretty.Bytes(), nil
+}

--- a/internal/pluginrecord/marketplaces_test.go
+++ b/internal/pluginrecord/marketplaces_test.go
@@ -1,0 +1,165 @@
+package pluginrecord
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeKnownMarketplaces(t *testing.T, base, body string) string {
+	t.Helper()
+	dir := filepath.Join(base, ".claude", "plugins")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "known_marketplaces.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readEntry(t *testing.T, path, name string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top map[string]map[string]any
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	return top[name]
+}
+
+func backupCount(t *testing.T, path string) int {
+	t.Helper()
+	matches, _ := filepath.Glob(path + ".niwa-bak.*")
+	return len(matches)
+}
+
+func TestReconcileAutoUpdate_FlipsExistingAndPreservesFields(t *testing.T) {
+	base := t.TempDir()
+	path := writeKnownMarketplaces(t, base, `{
+  "shirabe": {
+    "source": { "source": "github", "repo": "tsukumogami/shirabe" },
+    "installLocation": "/home/u/.claude/plugins/marketplaces/shirabe",
+    "lastUpdated": "2026-06-19T20:58:03.976Z",
+    "autoUpdate": true
+  },
+  "other": { "source": { "source": "github", "repo": "x/other" }, "autoUpdate": true }
+}`)
+
+	rep, err := ReconcileAutoUpdate(map[string]bool{"shirabe": false}, WithBaseDir(base))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rep.Updated) != 1 || rep.Updated[0] != "shirabe" {
+		t.Fatalf("Updated = %v, want [shirabe]", rep.Updated)
+	}
+
+	shirabe := readEntry(t, path, "shirabe")
+	if shirabe["autoUpdate"] != false {
+		t.Errorf("shirabe.autoUpdate = %v, want false", shirabe["autoUpdate"])
+	}
+	if shirabe["installLocation"] != "/home/u/.claude/plugins/marketplaces/shirabe" {
+		t.Errorf("installLocation not preserved: %v", shirabe["installLocation"])
+	}
+	if shirabe["lastUpdated"] != "2026-06-19T20:58:03.976Z" {
+		t.Errorf("lastUpdated not preserved: %v", shirabe["lastUpdated"])
+	}
+	if src, ok := shirabe["source"].(map[string]any); !ok || src["repo"] != "tsukumogami/shirabe" {
+		t.Errorf("source not preserved: %v", shirabe["source"])
+	}
+
+	// Untargeted entry left as-is.
+	if other := readEntry(t, path, "other"); other["autoUpdate"] != true {
+		t.Errorf("untargeted 'other' was modified: %v", other["autoUpdate"])
+	}
+	if backupCount(t, path) != 1 {
+		t.Errorf("expected exactly one backup, got %d", backupCount(t, path))
+	}
+}
+
+func TestReconcileAutoUpdate_AddsFieldWhenMissing(t *testing.T) {
+	base := t.TempDir()
+	path := writeKnownMarketplaces(t, base, `{"m": {"source": {"source": "github", "repo": "x/m"}}}`)
+	rep, err := ReconcileAutoUpdate(map[string]bool{"m": false}, WithBaseDir(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Updated) != 1 {
+		t.Fatalf("Updated = %v, want one entry", rep.Updated)
+	}
+	if v := readEntry(t, path, "m")["autoUpdate"]; v != false {
+		t.Errorf("autoUpdate = %v, want false", v)
+	}
+}
+
+func TestReconcileAutoUpdate_NoChangeWhenAlreadyDesired(t *testing.T) {
+	base := t.TempDir()
+	body := `{"m": {"autoUpdate": false}}`
+	path := writeKnownMarketplaces(t, base, body)
+	before, _ := os.ReadFile(path)
+
+	rep, err := ReconcileAutoUpdate(map[string]bool{"m": false}, WithBaseDir(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Updated) != 0 {
+		t.Errorf("Updated = %v, want empty", rep.Updated)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("file changed on a no-op reconcile")
+	}
+	if backupCount(t, path) != 0 {
+		t.Errorf("backup written on a no-op reconcile")
+	}
+}
+
+func TestReconcileAutoUpdate_DoesNotAddAbsentMarketplace(t *testing.T) {
+	base := t.TempDir()
+	path := writeKnownMarketplaces(t, base, `{"present": {"autoUpdate": true}}`)
+	rep, err := ReconcileAutoUpdate(map[string]bool{"ghost": false}, WithBaseDir(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Updated) != 0 {
+		t.Errorf("Updated = %v, want empty", rep.Updated)
+	}
+	data, _ := os.ReadFile(path)
+	var top map[string]any
+	_ = json.Unmarshal(data, &top)
+	if _, exists := top["ghost"]; exists {
+		t.Errorf("absent marketplace 'ghost' was added")
+	}
+}
+
+func TestReconcileAutoUpdate_AbsentFileIsNoOp(t *testing.T) {
+	base := t.TempDir()
+	rep, err := ReconcileAutoUpdate(map[string]bool{"m": false}, WithBaseDir(base))
+	if err != nil {
+		t.Fatalf("absent file should be a no-op, got %v", err)
+	}
+	if len(rep.Updated) != 0 {
+		t.Errorf("Updated = %v, want empty", rep.Updated)
+	}
+}
+
+func TestReconcileAutoUpdate_MalformedIsFailSafe(t *testing.T) {
+	base := t.TempDir()
+	path := writeKnownMarketplaces(t, base, `{ this is not json`)
+	before, _ := os.ReadFile(path)
+
+	_, err := ReconcileAutoUpdate(map[string]bool{"m": false}, WithBaseDir(base))
+	if !errors.Is(err, ErrMalformed) {
+		t.Fatalf("error = %v, want ErrMalformed", err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("malformed file was modified")
+	}
+}

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -98,6 +98,15 @@ type Applier struct {
 	// unit tests that don't exercise the registry at all.
 	prunePluginRecords func() (pluginrecord.PruneReport, error)
 
+	// reconcileMarketplaceAutoUpdate sets the autoUpdate flag in Claude Code's
+	// global known_marketplaces.json for the marketplaces niwa manages, so an
+	// already-registered marketplace adopts the configured policy instead of
+	// keeping a stale value Claude Code does not refresh from project settings.
+	// Production wires it (via NewApplier) to pluginrecord.ReconcileAutoUpdate
+	// against the real ~/.claude; tests override it to a temp HOME or a fake.
+	// When nil, the reconcile is a silent no-op.
+	reconcileMarketplaceAutoUpdate func(desired map[string]bool) (pluginrecord.ReconcileReport, error)
+
 	// vaultRegistry overrides vault.DefaultRegistry for vault bundle building.
 	// Nil means use the process-wide DefaultRegistry (production behaviour).
 	// Tests set this to a fresh *vault.Registry with the fake backend registered
@@ -136,6 +145,11 @@ func NewApplier(gh github.Client) *Applier {
 	// dangling-only keeps this broadly-run step from removing live records.
 	a.prunePluginRecords = func() (pluginrecord.PruneReport, error) {
 		return pluginrecord.Prune(pluginrecord.Dangling)
+	}
+	// Reconcile the global marketplace registry's autoUpdate flag to the
+	// configured per-marketplace policy. Defaults to the real ~/.claude.
+	a.reconcileMarketplaceAutoUpdate = func(desired map[string]bool) (pluginrecord.ReconcileReport, error) {
+		return pluginrecord.ReconcileAutoUpdate(desired)
 	}
 	a.cloneOrSync = func(ctx context.Context, url, dir string) (bool, int, error) {
 		fetcher, _ := a.GitHubClient.(FetchClient)
@@ -1385,6 +1399,13 @@ func (a *Applier) runPipeline(ctx context.Context, cfg *config.WorkspaceConfig, 
 	// removed so the heal is never silent (R4).
 	a.healDanglingPluginRecords()
 
+	// Step 9: Reconcile the global marketplace registry's autoUpdate flag to
+	// the configured per-marketplace policy. niwa writes the policy into
+	// project settings, but Claude Code does not refresh an already-registered
+	// marketplace's global entry from those, so this closes the gap on every
+	// create and update (R18). Fail-safe like the heal above.
+	a.reconcileMarketplaceRegistry(effectiveCfg, repoIndex)
+
 	return &pipelineResult{
 		classified:       classified,
 		repoStates:       repoStates,
@@ -1427,6 +1448,42 @@ func (a *Applier) healDanglingPluginRecords() {
 		a.Reporter.Log("healed %d dangling plugin record(s): %s", report.Removed, strings.Join(affected, ", "))
 	} else {
 		a.Reporter.Log("healed %d dangling plugin record(s)", report.Removed)
+	}
+}
+
+// reconcileMarketplaceRegistry sets the autoUpdate flag in Claude Code's global
+// known_marketplaces.json to the configured per-marketplace policy for the
+// marketplaces niwa manages, so an already-registered marketplace adopts the
+// new policy instead of keeping a stale value Claude Code never refreshes from
+// project settings. It runs from runPipeline on every create and update.
+//
+// Like the dangling-record heal, it is fail-safe: a nil seam or any registry
+// error is reported via a deferred warning and never propagated, so a missing
+// or malformed registry can never fail a create or update.
+func (a *Applier) reconcileMarketplaceRegistry(cfg *config.WorkspaceConfig, repoIndex map[string]string) {
+	if a.reconcileMarketplaceAutoUpdate == nil || cfg == nil {
+		return
+	}
+
+	desired := make(map[string]bool, len(cfg.Claude.Marketplaces))
+	for _, mc := range cfg.Claude.Marketplaces {
+		name, err := marketplaceRegistrationName(mc.Source, repoIndex)
+		if err != nil || name == "" {
+			continue
+		}
+		desired[name] = mc.AutoUpdate
+	}
+	if len(desired) == 0 {
+		return
+	}
+
+	report, err := a.reconcileMarketplaceAutoUpdate(desired)
+	if err != nil {
+		a.Reporter.DeferWarn("could not reconcile marketplace auto-update policy: %v", err)
+		return
+	}
+	if len(report.Updated) > 0 {
+		a.Reporter.Log("updated auto-update policy for %d marketplace(s): %s", len(report.Updated), strings.Join(report.Updated, ", "))
 	}
 }
 

--- a/internal/workspace/marketplace_reconcile_test.go
+++ b/internal/workspace/marketplace_reconcile_test.go
@@ -1,0 +1,125 @@
+package workspace
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/niwa/internal/config"
+	"github.com/tsukumogami/niwa/internal/pluginrecord"
+)
+
+func writeToolsManifest(t *testing.T, repoDir, name string) {
+	t.Helper()
+	dir := filepath.Join(repoDir, ".claude-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"name":"` + name + `","plugins":[]}`
+	if err := os.WriteFile(filepath.Join(dir, "marketplace.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMarketplaceRegistrationName(t *testing.T) {
+	base := t.TempDir()
+	toolsDir := filepath.Join(base, "tools")
+	writeToolsManifest(t, toolsDir, "tsukumogami")
+	// bare has a manifest present (so the source resolves) but with no
+	// declared name, exercising the ref-name fallback.
+	bareDir := filepath.Join(base, "bare")
+	bareManifestDir := filepath.Join(bareDir, ".claude-plugin")
+	if err := os.MkdirAll(bareManifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bareManifestDir, "marketplace.json"), []byte(`{"plugins":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repoIndex := map[string]string{"tools": toolsDir, "bare": bareDir}
+
+	cases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"github uses repo name", "tsukumogami/shirabe", "shirabe"},
+		{"local uses manifest name", "repo:tools/.claude-plugin/marketplace.json", "tsukumogami"},
+		{"local falls back to ref name", "repo:bare/.claude-plugin/marketplace.json", "bare"},
+		{"unrecognized source", "not-a-valid-ref", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := marketplaceRegistrationName(tc.source, repoIndex)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("marketplaceRegistrationName(%q) = %q, want %q", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMarketplaceRegistry_BuildsDesiredAndReports(t *testing.T) {
+	base := t.TempDir()
+	toolsDir := filepath.Join(base, "tools")
+	writeToolsManifest(t, toolsDir, "tsukumogami")
+	repoIndex := map[string]string{"tools": toolsDir}
+
+	var captured map[string]bool
+	var buf bytes.Buffer
+	a := &Applier{
+		Reporter: NewReporter(&buf),
+		reconcileMarketplaceAutoUpdate: func(desired map[string]bool) (pluginrecord.ReconcileReport, error) {
+			captured = desired
+			return pluginrecord.ReconcileReport{Updated: []string{"shirabe"}}, nil
+		},
+	}
+	cfg := &config.WorkspaceConfig{
+		Claude: config.ClaudeConfig{
+			Marketplaces: config.MarketplaceConfigs{
+				{Source: "tsukumogami/shirabe", AutoUpdate: false},
+				{Source: "repo:tools/.claude-plugin/marketplace.json", AutoUpdate: true},
+			},
+		},
+	}
+
+	a.reconcileMarketplaceRegistry(cfg, repoIndex)
+
+	if len(captured) != 2 {
+		t.Fatalf("desired = %v, want 2 entries", captured)
+	}
+	if v, ok := captured["shirabe"]; !ok || v != false {
+		t.Errorf("desired[shirabe] = %v (ok=%v), want false", v, ok)
+	}
+	if v, ok := captured["tsukumogami"]; !ok || v != true {
+		t.Errorf("desired[tsukumogami] = %v (ok=%v), want true", v, ok)
+	}
+	if !strings.Contains(buf.String(), "auto-update policy") {
+		t.Errorf("expected a report log mentioning the policy update, got %q", buf.String())
+	}
+}
+
+func TestReconcileMarketplaceRegistry_FailSafe(t *testing.T) {
+	cfg := &config.WorkspaceConfig{
+		Claude: config.ClaudeConfig{
+			Marketplaces: config.MarketplaceConfigs{{Source: "tsukumogami/shirabe"}},
+		},
+	}
+
+	// Seam returns an error: must not panic or propagate.
+	var buf bytes.Buffer
+	a := &Applier{
+		Reporter: NewReporter(&buf),
+		reconcileMarketplaceAutoUpdate: func(map[string]bool) (pluginrecord.ReconcileReport, error) {
+			return pluginrecord.ReconcileReport{}, os.ErrPermission
+		},
+	}
+	a.reconcileMarketplaceRegistry(cfg, nil)
+
+	// Nil seam: silent no-op, no panic.
+	b := &Applier{Reporter: NewReporter(&bytes.Buffer{})}
+	b.reconcileMarketplaceRegistry(cfg, nil)
+}

--- a/internal/workspace/workspace_context.go
+++ b/internal/workspace/workspace_context.go
@@ -450,6 +450,11 @@ func readMarketplaceManifestName(dir string) (string, bool) {
 //   - "main": register against the default branch, no ref (R15).
 //   - any other value: treated as an explicit ref and emitted verbatim (R17).
 func mapMarketplaceSourceWithIndex(source string, repoIndex map[string]string, autoUpdate bool, track string) (string, map[string]any, string, error) {
+	name, err := marketplaceRegistrationName(source, repoIndex)
+	if err != nil {
+		return "", nil, "", err
+	}
+
 	if strings.HasPrefix(source, repoRefPrefix) {
 		// repo:tools/.claude-plugin/marketplace.json -> directory source.
 		// Local sources ignore track (no remote version to resolve).
@@ -461,14 +466,6 @@ func mapMarketplaceSourceWithIndex(source string, repoIndex map[string]string, a
 		// .claude-plugin/marketplace.json. Strip the filename and the
 		// .claude-plugin directory to get the root.
 		dir := filepath.Dir(filepath.Dir(resolved))
-		// Prefer the marketplace's declared name; fall back to the repo name
-		// when the manifest cannot be read.
-		ref := strings.TrimPrefix(source, repoRefPrefix)
-		slashIdx := strings.IndexByte(ref, '/')
-		name := ref[:slashIdx]
-		if declared, ok := readMarketplaceManifestName(dir); ok {
-			name = declared
-		}
 		return name, map[string]any{
 			"source": map[string]any{
 				"source": "directory",
@@ -481,7 +478,6 @@ func mapMarketplaceSourceWithIndex(source string, repoIndex map[string]string, a
 	// GitHub ref: "org/repo" -> {source: {source: "github", repo: "org/repo"}}
 	parts := strings.SplitN(source, "/", 3)
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
-		name := parts[1] // use repo name as marketplace name
 		src := map[string]any{
 			"source": "github",
 			"repo":   source,
@@ -494,6 +490,35 @@ func mapMarketplaceSourceWithIndex(source string, repoIndex map[string]string, a
 	}
 
 	return "", nil, "", nil
+}
+
+// marketplaceRegistrationName computes the registry key niwa uses for a
+// marketplace source: the manifest-declared name for a local repo:/directory
+// source (falling back to the repo-ref-derived name), or the repo name for a
+// github source. It is the single source of truth for the name shared by
+// mapMarketplaceSourceWithIndex (project-settings materialization) and the
+// global known_marketplaces reconciliation. Returns "" for an unrecognized
+// source.
+func marketplaceRegistrationName(source string, repoIndex map[string]string) (string, error) {
+	if strings.HasPrefix(source, repoRefPrefix) {
+		resolved, err := ResolveMarketplaceSource(source, repoIndex)
+		if err != nil {
+			return "", err
+		}
+		dir := filepath.Dir(filepath.Dir(resolved))
+		ref := strings.TrimPrefix(source, repoRefPrefix)
+		name := ref[:strings.IndexByte(ref, '/')]
+		if declared, ok := readMarketplaceManifestName(dir); ok {
+			name = declared
+		}
+		return name, nil
+	}
+
+	parts := strings.SplitN(source, "/", 3)
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[1], nil
+	}
+	return "", nil
 }
 
 // applyGithubTrack mutates a github source map to register against the


### PR DESCRIPTION
Add `pluginrecord.ReconcileAutoUpdate`, which sets the `autoUpdate` flag in Claude Code's global `known_marketplaces.json` for named marketplaces that are already registered, preserving all other fields and key order, writing atomically with a timestamped backup, and failing safe on an absent or malformed registry. Wire a reconcile step into the shared `runPipeline` (Step 9, after the dangling-record heal) through an `Applier` seam: it builds the desired name→autoUpdate map from `cfg.Claude.Marketplaces` and applies it on every create and update. Extract `marketplaceRegistrationName` from `mapMarketplaceSourceWithIndex` so the project-settings name and the global-registry name are computed by one function. Amend the PRD (R18 + acceptance criterion) and the DESIGN (reconciliation amendment section).

---

## What This Fixes

niwa writes each marketplace's `auto_update` policy into the per-repo project `extraKnownMarketplaces`, but Claude Code only merges that into its global `known_marketplaces.json` when registering a marketplace it does not already know. For an already-registered marketplace it keeps the existing global entry, so a marketplace niwa had previously registered with `autoUpdate: true` kept that stale value even after the policy flipped to false — the auto-update churn the plugin-record-lifecycle feature set out to stop continued for existing installs. Fresh registrations were already correct.

niwa now reconciles the global registry directly on create/update, the same self-healing posture the dangling-record heal already applies to `installed_plugins.json`. The reconciliation only touches marketplaces niwa manages, never adds a marketplace, and is fail-safe (an absent or malformed registry never fails create or update). It deliberately adjusts only the `autoUpdate` flag — the version-tracking ref limitation (Claude ignoring a github-source ref) is unchanged.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` green
- [x] `pluginrecord` unit tests: flip existing entry + preserve other fields/backup; add field when missing; no-op when already desired; absent marketplace not added; absent file no-op; malformed fail-safe
- [x] `workspace` unit tests: `marketplaceRegistrationName` (github / manifest-name / ref-name fallback / unrecognized); `reconcileMarketplaceRegistry` builds the desired map and reports; fail-safe on seam error and nil seam
