### PR TITLE
fix(cli): stop niwa apply from cloning repos into the workspace root

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,17 @@ On a TTY, `niwa create` and `niwa apply` show a single in-place status line for 
 Teams can share workspace configs via a GitHub repo:
 
 ```bash
-# Clone config from GitHub and set up the workspace
+# Clone config from GitHub; the workspace root is ready to use
 niwa init my-team --from my-org/workspace-config
-niwa apply
+# Create an instance to work in
+cd my-team && niwa create
 ```
+
+`niwa init` leaves you with a ready workspace root — it materializes the root
+configuration (CLAUDE.md, Claude Code settings and skills) but clones no repos.
+The repos live inside instances: `niwa create` makes one. You do not need to run
+`niwa apply` first; apply's job is to refresh an already-set-up workspace, not to
+set it up.
 
 The config repo is materialized as `.niwa/` — a snapshot of the source content at
 a specific commit, not a git checkout. Each `niwa apply` checks for upstream

--- a/docs/guides/ephemeral-session-instances.md
+++ b/docs/guides/ephemeral-session-instances.md
@@ -207,6 +207,15 @@ scope from it (or from `--instance`, or a registry name argument):
 3. If cwd is at the **workspace root**, materialize the root-managed config,
    then converge every instance and each instance's worktrees.
 
+The workspace root is **never** converged as an instance. `niwa init` persists
+an `.niwa/instance.json` at the root to carry init-time state that `niwa create`
+reads, so the root carries both `.niwa/workspace.toml` and `.niwa/instance.json`.
+The `workspace.toml` is authoritative: a directory that has it is the workspace
+root, classified as scope 3 above, not scope 2 — apply manages only its
+root-level config and clones no repos into the root. (Before this distinction
+was enforced, the root's `instance.json` made `apply` at the root treat the root
+as instance-0 and clone every configured repo directly under it.)
+
 Worktrees are refreshed as part of the instance apply, not by a separate niwa
 cascade: an instance-scope `apply` refreshes the instance's environment and the
 worktree path inherits that already-materialized environment (the upstream

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -67,7 +67,9 @@ Scope resolution (when no workspace-name argument is given):
      instance or sibling worktrees).
   3. If cwd is inside an instance, converge that instance and its worktrees.
   4. If cwd is at the workspace root, materialize the root-managed config, then
-     converge every instance and each instance's worktrees.
+     converge every instance and each instance's worktrees. The workspace root
+     itself is never converged as an instance: apply manages only its root-level
+     config and clones no repos into the root.
 
 Use --no-cascade at the workspace root to refresh only the root-managed config
 (hooks, permission posture, CLAUDE.md) without re-converging the instances

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1112,7 +1112,8 @@ func printSuccess(cmd *cobra.Command, mode initMode, name, resolvedName, absPath
 	case modeClone:
 		fmt.Fprintf(w, "Workspace %q initialized at %s from remote config.\n", displayName, absPath)
 		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, "Next steps:")
-		fmt.Fprintln(w, "  1. Run niwa apply to set up the workspace")
+		fmt.Fprintln(w, "The workspace root is ready. Create an instance to start working:")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "  niwa create <name>")
 	}
 }

--- a/internal/workspace/cwd_classify.go
+++ b/internal/workspace/cwd_classify.go
@@ -109,7 +109,15 @@ func ClassifyCwd(cwd string) (CwdClassification, error) {
 	}
 
 	// Inside an instance? Next most specific case.
-	if instanceDir, err := DiscoverInstance(abs); err == nil {
+	//
+	// A workspace root carries its own .niwa/instance.json (init persists
+	// init-time state there for `niwa create` to read), so DiscoverInstance
+	// resolves the root to itself. That must NOT classify as inside-instance:
+	// treating the root as instance-0 is exactly the bug that made `niwa apply`
+	// at the root clone repos directly under it. When the discovered directory
+	// is a workspace root (carries .niwa/workspace.toml), fall through to the
+	// workspace-root case below — the root is never an instance.
+	if instanceDir, err := DiscoverInstance(abs); err == nil && !isWorkspaceRoot(instanceDir) {
 		// We expect to also find the workspace root by walking further up
 		// (instances live under workspace roots). If config.Discover
 		// fails here, it's an unusual layout (orphan instance) — treat

--- a/internal/workspace/cwd_classify_root_instance_test.go
+++ b/internal/workspace/cwd_classify_root_instance_test.go
@@ -1,0 +1,119 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeRootInstanceJSON writes an .niwa/instance.json at the workspace root,
+// reproducing the state `niwa init` persists there (config-name override,
+// ephemeral-session flags) for `niwa create` to read. A root carrying this
+// file must still classify as a workspace root, never as instance-0.
+func writeRootInstanceJSON(t *testing.T, root string) {
+	t.Helper()
+	state := &InstanceState{
+		SchemaVersion: SchemaVersion,
+		InstanceName:  "test-ws",
+		Root:          root,
+		Created:       time.Now(),
+		LastApplied:   time.Now(),
+		Repos:         map[string]RepoState{},
+	}
+	if err := SaveState(root, state); err != nil {
+		t.Fatalf("writing root instance.json: %v", err)
+	}
+}
+
+// TestClassifyCwd_RootWithInstanceJSON is the regression guard for the bug where
+// a workspace root that also carries .niwa/instance.json (written by init) was
+// misclassified as inside-instance. That misclassification made `niwa apply` at
+// the root treat the root as instance-0 and clone repos directly under it.
+func TestClassifyCwd_RootWithInstanceJSON(t *testing.T) {
+	root := setupWorkspace(t, nil)
+	writeRootInstanceJSON(t, root)
+
+	got, err := ClassifyCwd(root)
+	if err != nil {
+		t.Fatalf("ClassifyCwd: %v", err)
+	}
+	if got.Class != CwdAtWorkspaceRoot {
+		t.Errorf("Class = %s, want %s (a root carrying instance.json is still the root, never instance-0)", got.Class, CwdAtWorkspaceRoot)
+	}
+	if got.WorkspaceRoot != root {
+		t.Errorf("WorkspaceRoot = %q, want %q", got.WorkspaceRoot, root)
+	}
+	if got.InstanceDir != "" {
+		t.Errorf("InstanceDir = %q, want empty (the root is not an instance)", got.InstanceDir)
+	}
+}
+
+// TestClassifyCwd_SubdirOfRootWithInstanceJSON verifies that a non-instance
+// subdirectory of such a root (e.g. a group dir like public/) still resolves to
+// the workspace root rather than the root-as-instance.
+func TestClassifyCwd_SubdirOfRootWithInstanceJSON(t *testing.T) {
+	root := setupWorkspace(t, nil)
+	writeRootInstanceJSON(t, root)
+
+	sub := filepath.Join(root, "public")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ClassifyCwd(sub)
+	if err != nil {
+		t.Fatalf("ClassifyCwd: %v", err)
+	}
+	if got.Class != CwdAtWorkspaceRoot {
+		t.Errorf("Class = %s, want %s", got.Class, CwdAtWorkspaceRoot)
+	}
+}
+
+// TestClassifyCwd_ChildInstanceStillClassifies confirms the fix does not break
+// real child instances: an instance directory under the root (instance.json,
+// no workspace.toml) still classifies as inside-instance.
+func TestClassifyCwd_ChildInstanceStillClassifies(t *testing.T) {
+	root := setupWorkspace(t, nil)
+	writeRootInstanceJSON(t, root)
+	instanceDir := destroySetupInstance(t, root, "alpha")
+
+	got, err := ClassifyCwd(instanceDir)
+	if err != nil {
+		t.Fatalf("ClassifyCwd: %v", err)
+	}
+	if got.Class != CwdInsideInstance {
+		t.Errorf("Class = %s, want %s", got.Class, CwdInsideInstance)
+	}
+	if got.InstanceDir != instanceDir {
+		t.Errorf("InstanceDir = %q, want %q", got.InstanceDir, instanceDir)
+	}
+}
+
+// TestResolveApplyScope_RootWithInstanceJSON is the end-to-end regression guard:
+// `niwa apply` at a root carrying instance.json must resolve to ApplyAll (root
+// config + cascade into child instances), NOT ApplySingle on the root (which
+// cloned repos under the root). The root must not appear in the cascade list.
+func TestResolveApplyScope_RootWithInstanceJSON(t *testing.T) {
+	root := setupWorkspace(t, []string{"alpha", "beta"})
+	writeRootInstanceJSON(t, root)
+
+	scope, err := ResolveApplyScope(root, "")
+	if err != nil {
+		t.Fatalf("ResolveApplyScope: %v", err)
+	}
+	if scope.Mode != ApplyAll {
+		t.Fatalf("Mode = %v, want ApplyAll (root scope, not ApplySingle on the root)", scope.Mode)
+	}
+	if scope.WorkspaceRoot != root {
+		t.Errorf("WorkspaceRoot = %q, want %q", scope.WorkspaceRoot, root)
+	}
+	for _, inst := range scope.Instances {
+		if inst == root {
+			t.Errorf("Instances contains the workspace root %q; the root must never be applied as an instance", root)
+		}
+	}
+	if len(scope.Instances) != 2 {
+		t.Errorf("len(Instances) = %d, want 2 (the two child instances)", len(scope.Instances))
+	}
+}

--- a/internal/workspace/state.go
+++ b/internal/workspace/state.go
@@ -337,6 +337,17 @@ func SaveState(dir string, state *InstanceState) error {
 	return nil
 }
 
+// isWorkspaceRoot reports whether dir is a workspace root, i.e. it carries
+// .niwa/workspace.toml. A workspace root is never an instance: instances live
+// *under* a root and carry .niwa/instance.json without a workspace.toml. The
+// root may legitimately hold its own instance.json (init writes one to persist
+// the config-name override and ephemeral-session flags), so the presence of
+// workspace.toml is the authoritative signal that distinguishes the two.
+func isWorkspaceRoot(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, StateDir, WorkspaceConfigFile))
+	return err == nil
+}
+
 // DiscoverInstance walks up from startPath to find the nearest directory
 // containing .niwa/instance.json. It returns the directory containing the
 // instance state, or an error if none is found.

--- a/test/functional/features/apply-root-not-instance.feature
+++ b/test/functional/features/apply-root-not-instance.feature
@@ -1,0 +1,34 @@
+Feature: niwa apply at the workspace root does not turn the root into an instance
+  Regression coverage for the init -> apply workflow. `niwa init` persists an
+  .niwa/instance.json at the workspace root (it carries init-time state that
+  `niwa create` reads). That file made `niwa apply` run from the root
+  misclassify the root as instance-0 and clone the configured repos directly
+  under the root. apply at the root must only manage the root-level
+  configuration and cascade to the instances within it -- never materialize
+  repos at the root.
+
+  Runs offline against the localGitServer bare-repo fake; no GitHub access.
+
+  @critical
+  Scenario: apply at the workspace root does not clone repos into the root
+    Given a clean niwa environment
+    And a local git server is set up
+    And a source repo "myapp" exists
+    And a config repo "cfg" exists with body:
+      """
+      [workspace]
+      name = "myws"
+
+      [groups.tools]
+
+      [repos.myapp]
+      url = "{repo:myapp}"
+      group = "tools"
+      """
+    When I run niwa init "team" from config repo "cfg"
+    Then the exit code is 0
+    And the workspace root "team" has a workspace.toml
+    When I run "niwa apply" from workspace "team"
+    Then the exit code is 0
+    And the file "tools" does not exist under workspace root "team"
+    And the file "tools/myapp" does not exist under workspace root "team"

--- a/test/functional/steps_init_workspace_dir_test.go
+++ b/test/functional/steps_init_workspace_dir_test.go
@@ -140,6 +140,21 @@ func theFileExistsUnderWorkspaceRoot(ctx context.Context, relPath, name string) 
 	return nil
 }
 
+// theFileDoesNotExistUnderWorkspaceRoot asserts that
+// `<workspaceRoot>/<name>/<relPath>` is absent. Used to prove `niwa apply` at
+// the root does not materialize repos directly under the workspace root.
+func theFileDoesNotExistUnderWorkspaceRoot(ctx context.Context, relPath, name string) error {
+	s := getState(ctx)
+	if s == nil {
+		return fmt.Errorf("no test state")
+	}
+	path := filepath.Join(s.workspaceRoot, name, filepath.FromSlash(relPath))
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("path %q exists under workspace root %q but should not (apply must not clone repos into the root)", relPath, name)
+	}
+	return nil
+}
+
 // theFileUnderWorkspaceRootContains asserts that
 // `<workspaceRoot>/<name>/<relPath>` exists and its content contains `want`.
 // Pairs with theFileExistsUnderWorkspaceRoot to confirm the materialized file
@@ -197,7 +212,6 @@ func theRegistryHasWorkspaceRootedAt(ctx context.Context, name, wantRoot string)
 	return nil
 }
 
-
 // iRunFromInstance runs `niwa <command>` with cwd set to the instance
 // directory `<workspaceRoot>/<workspace>/<instance>`, where the
 // `<workspace>` directory is the user-given name from `niwa init <name>`
@@ -212,7 +226,6 @@ func iRunFromInstance(ctx context.Context, command, instance, workspace string) 
 	cwd := filepath.Join(s.workspaceRoot, workspace, instance)
 	return ctx, runNiwa(s, cwd, command)
 }
-
 
 // niwaGoFromOutsideLandsIn runs `niwa go <name>` from a directory other
 // than the workspace, with a temp NIWA_RESPONSE_FILE set so the
@@ -266,4 +279,3 @@ func niwaGoFromOutsideLandsIn(ctx context.Context, name, expectedSubpath string)
 	}
 	return nil
 }
-

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -207,6 +207,7 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 	ctx.Step(`^the registry already has workspace "([^"]*)" rooted at "([^"]*)"$`, iRegisterWorkspaceAt)
 	ctx.Step(`^the workspace root "([^"]*)" has a workspace\.toml$`, theWorkspaceRootHasWorkspaceTOML)
 	ctx.Step(`^the file "([^"]*)" exists under workspace root "([^"]*)"$`, theFileExistsUnderWorkspaceRoot)
+	ctx.Step(`^the file "([^"]*)" does not exist under workspace root "([^"]*)"$`, theFileDoesNotExistUnderWorkspaceRoot)
 	ctx.Step(`^the file "([^"]*)" under workspace root "([^"]*)" contains "([^"]*)"$`, theFileUnderWorkspaceRootContains)
 	ctx.Step(`^the registry has workspace "([^"]*)" rooted at "([^"]*)"$`, theRegistryHasWorkspaceRootedAt)
 	ctx.Step(`^the registry entry "([^"]*)" still points at "([^"]*)"$`, theRegistryHasWorkspaceRootedAt)


### PR DESCRIPTION
Guard ClassifyCwd's instance branch with a new isWorkspaceRoot helper so a
directory carrying .niwa/workspace.toml is classified as the workspace root
rather than an instance, even when it also holds the .niwa/instance.json that
init persists for niwa create to read. niwa apply at the root now resolves to
root scope (materialize the root-managed config, then cascade into the child
instances) instead of converging the root as instance-0 and cloning every
configured repo directly under it. DiscoverInstance's contract is unchanged, so
the worktree and session-hook paths are untouched. Also correct the
niwa init --from success message to point at niwa create, since init
materializes the root config inline and leaves a ready, repo-free root.

---

## What This Fixes

`niwa init` is meant to leave a functional but empty workspace root, `niwa create`
makes instances, and `niwa apply` refreshes config and cascades into instances.
`init` persists an `.niwa/instance.json` at the root (legitimately -- `niwa create`
reads init-time state from it via `LoadState(workspaceRoot)`), so the root carries
both `.niwa/workspace.toml` and `.niwa/instance.json`.

`ClassifyCwd` checked for an enclosing instance (`DiscoverInstance`, keyed on
`instance.json`) before the workspace-root check (keyed on `workspace.toml`). At
the root, `DiscoverInstance` resolved the root to itself, so the root classified
as `CwdInsideInstance`. `niwa apply` at the root then resolved to `ApplySingle`
on the root and cloned every configured repo directly under it, turning the root
into instance-0.

The fix makes `workspace.toml` authoritative: a directory that has it is the
workspace root and is never an instance. The guard lives in `ClassifyCwd` (the
scope-resolution authority) rather than `DiscoverInstance`, keeping the fix
scoped to apply/classification and leaving the worktree/session-hook callers and
their tests unaffected. The root keeps its `instance.json` (still read by
`niwa create`).

## Changes

- `internal/workspace/state.go`: add `isWorkspaceRoot` helper (`.niwa/workspace.toml` probe).
- `internal/workspace/cwd_classify.go`: skip the inside-instance branch when the discovered directory is a workspace root.
- `internal/cli/init.go`: replace the `niwa init --from` "Run niwa apply" message with "create an instance to start working".
- `internal/cli/apply.go`: clarify in `--help` that the root is never converged as an instance.
- `internal/workspace/cwd_classify_root_instance_test.go`: unit regression tests (ClassifyCwd + ResolveApplyScope on a root carrying instance.json; child instances still classify correctly).
- `test/functional/features/apply-root-not-instance.feature` + step support: `@critical` end-to-end scenario via the offline `localGitServer`.
- `README.md`, `docs/guides/ephemeral-session-instances.md`: document the operational-after-init root and the root-is-never-an-instance rule.

## Example

Before this change:
```
niwa init foo --from tsukumogami/dot-niwa
cd foo && niwa apply
ls        # public/ private/ ... repos cloned into the workspace root
```

After this change:
```
niwa init foo --from tsukumogami/dot-niwa
cd foo && niwa apply
ls        # no repos under the root; apply only refreshed root config
```

## Test Plan

- [x] `go build`, `go vet`, `go test ./...` pass.
- [x] New unit tests and the `@critical` functional scenario fail on `main` (reproducing the bug) and pass with the fix.
- [x] Full `@critical` functional suite green except one pre-existing, unrelated failure (`provider-shadow notice`, an infisical vault-login env issue that fails identically on `main`).

## Migration Note

Existing workspace roots that already had repos cloned under them by the old
behavior are now inert: apply will neither add to nor remove them. They can be
deleted by hand (for example `rm -rf <root>/public <root>/private`); the real
instances under the root are unaffected.