### PR TITLE
fix(workspace): hoist workspace plugins into root settings

### DIFF
--- a/docs/guides/ephemeral-session-instances.md
+++ b/docs/guides/ephemeral-session-instances.md
@@ -279,6 +279,35 @@ launched at the root, not only dispatched workers. This is wider than
 per-instance bypass; the opt-in ephemeral mode bounds it to workspaces that
 chose the feature.
 
+### Workspace plugins and skills at the root
+
+The root `.claude/settings.json` also carries the workspace's **plugins** and
+**marketplaces** (`enabledPlugins` / `extraKnownMarketplaces`), so a session
+launched at the workspace root — including a dispatched worker before its
+ephemeral instance is provisioned — loads the workspace's plugins and the skills
+they carry. This is the same `enabledPlugins` / `extraKnownMarketplaces` block an
+instance gets, with one exception below.
+
+Forwarding these into the root scaffold (rather than relying on the SessionStart
+hook to deliver them) is deliberate: Claude Code resolves plugins, marketplaces,
+hooks, and env from the launch directory's `settings.json` **at startup**, before
+the SessionStart hook runs. The hook injects only `additionalContext` and an
+instruction to `cd` into the instance; a mid-session `cd` cannot re-resolve plugin
+or settings configuration (the same reason it does not reload `CLAUDE.md`). So the
+only place a plugin can become available to a root-launched session is the root's
+own `settings.json`.
+
+The one exception is marketplaces with no root-resolvable path. A github-sourced
+marketplace (`org/repo`) hoists to the root unchanged. A `repo:`-sourced
+marketplace resolves to a directory inside an instance checkout (for example a
+private `tools` repo) that does not exist at the workspace root, so it has no
+root-stable path. Such a marketplace — and any plugin bound to it — is excluded
+from the root settings and a notice is printed at `niwa init` / `niwa apply` time
+(no silent drop). Those plugins still load normally inside a provisioned instance,
+where the `repo:` source resolves. In short: a root-launched session has the
+workspace's github-sourced plugins/skills; instance-local (`repo:`) plugins are
+available only once the session is inside its instance.
+
 ## Opting out
 
 The feature installs by default at `niwa init`. To skip it:
@@ -312,4 +341,11 @@ root, and the root config installs again.
   instance has no such marker and is never a target.
 - The root materializer (`internal/workspace/root_materializer.go`) reuses the
   shared `buildSettingsDoc`, so the root settings ride the same path the
-  instance settings do.
+  instance settings do for permissions, hooks, env, plugins, and marketplaces.
+  One field is deliberately filtered, not forwarded verbatim: the root receives
+  only the **root-hoistable** subset of marketplaces (see `rootHoistableConfig`).
+  github-sourced marketplaces hoist as-is; `repo:`-sourced ones point into an
+  instance checkout that does not exist at the root, so they and the plugins
+  bound to them are excluded and reported. Do not assume the root settings are a
+  byte-for-byte copy of an instance's — they match for everything except those
+  instance-local marketplaces.

--- a/internal/workspace/root_materializer.go
+++ b/internal/workspace/root_materializer.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tsukumogami/niwa/internal/config"
 )
@@ -15,7 +16,10 @@ import (
 // (internal/workspace/rootskills). Each rootskills/<name>/SKILL.md is
 // materialized as a project skill under <workspaceRoot>/.claude/skills/<name>/
 // so a Claude Code session launched at the workspace root loads it from the cwd
-// regardless of plugin enablement (plugins are not enabled at the root today).
+// regardless of plugin enablement. These are niwa-owned skills (e.g. dispatch)
+// that must exist even when no plugin marketplace does; the workspace's own
+// plugins are forwarded separately into the root settings by writeRootSettings
+// (see rootHoistableConfig).
 //
 //go:embed rootskills
 var rootSkillsFS embed.FS
@@ -182,18 +186,33 @@ func writeRootSkills(workspaceRoot string) ([]string, error) {
 // effective [claude.settings] block (MergeInstanceOverrides) -- the same input
 // the instance-root materializer feeds to buildSettingsDoc -- so the
 // permissions.defaultMode value matches what an instance would get. The
+// effective plugins and marketplaces are forwarded too, filtered to the subset
+// that resolves at the workspace root (see rootHoistableConfig), so a
+// root-launched session loads the workspace's plugins/skills. The
 // SessionStart/SessionEnd hook entries and the ephemeral-mode flag are layered
 // on top via the SessionHooks injection.
 func writeRootSettings(cfg *config.WorkspaceConfig, workspaceRoot, niwaPath string, ephemeral bool) (string, error) {
 	effective := MergeInstanceOverrides(cfg)
 
+	// Forward only the plugins/marketplaces that have a root-resolvable form.
+	// repo:-sourced marketplaces point into an instance checkout that does not
+	// exist at the workspace root, so they (and the plugins bound to them) are
+	// excluded and reported -- never silently dropped.
+	rootPlugins, rootMarketplaces, hoistReports := rootHoistableConfig(effective.Plugins, effective.Claude.Marketplaces)
+
 	includeGit := false
-	var reports []string
+	reports := append([]string(nil), hoistReports...)
 	doc, err := buildSettingsDoc(BuildSettingsConfig{
 		// Permission posture: sourced exactly as the instance root sources it,
 		// from the effective [claude.settings] map. buildSettingsDoc maps the
 		// "permissions" key to permissions.defaultMode.
-		Settings:               effective.Claude.Settings,
+		Settings: effective.Claude.Settings,
+		// Plugins/marketplaces: the root-hoistable subset, so the workspace's
+		// plugins (and the skills they carry) load for a session launched at the
+		// workspace root, matching what an instance would get for the github-
+		// sourced entries.
+		Plugins:                rootPlugins,
+		Marketplaces:           rootMarketplaces,
 		BaseDir:                workspaceRoot,
 		IncludeGitInstructions: &includeGit,
 		UseAbsolutePaths:       true,
@@ -227,6 +246,78 @@ func writeRootSettings(cfg *config.WorkspaceConfig, workspaceRoot, niwaPath stri
 		return "", fmt.Errorf("writing workspace-root settings: %w", err)
 	}
 	return settingsPath, nil
+}
+
+// rootHoistableConfig partitions the effective workspace plugins and
+// marketplaces into the subset that loads at the workspace root and the subset
+// that does not. A root-launched session resolves its Claude config from the
+// workspace root, where no instance has been provisioned and no repos are
+// cloned, so an instance-relative source has no path to point at.
+//
+//   - github-sourced marketplaces ("org/repo") are root-stable: the source is a
+//     remote reference that resolves identically anywhere, so they hoist as-is.
+//   - repo:-sourced marketplaces ("repo:<name>/...") resolve to a directory
+//     inside an instance checkout (e.g. a private `tools` repo) that exists only
+//     once an instance is created. They have no root-resolvable path and are
+//     excluded.
+//
+// A plugin is kept only when its marketplace hoisted (or it carries no
+// "@marketplace" qualifier): Claude Code cannot enable a plugin from a
+// marketplace it does not know at the root. Excluded marketplaces and plugins
+// are returned as human-readable reports so the omission is visible rather than
+// silent; the caller surfaces them via emitReports.
+func rootHoistableConfig(plugins []string, marketplaces []config.MarketplaceConfig) (keptPlugins []string, keptMarketplaces []config.MarketplaceConfig, reports []string) {
+	// Registration names of the marketplaces that survived to the root. This is
+	// the set the plugin filter consults. github names derive without a
+	// repoIndex (the repo name), which is all the kept entries need.
+	rootMarketplaceNames := make(map[string]bool)
+	var excludedMarketplaces []string
+	for _, mc := range marketplaces {
+		if strings.HasPrefix(mc.Source, repoRefPrefix) {
+			excludedMarketplaces = append(excludedMarketplaces, mc.Source)
+			continue
+		}
+		keptMarketplaces = append(keptMarketplaces, mc)
+		if name, err := marketplaceRegistrationName(mc.Source, nil); err == nil && name != "" {
+			rootMarketplaceNames[name] = true
+		}
+	}
+
+	var excludedPlugins []string
+	for _, p := range plugins {
+		mkt := pluginMarketplace(p)
+		if mkt == "" || rootMarketplaceNames[mkt] {
+			keptPlugins = append(keptPlugins, p)
+			continue
+		}
+		excludedPlugins = append(excludedPlugins, p)
+	}
+
+	if len(excludedMarketplaces) > 0 {
+		reports = append(reports, fmt.Sprintf(
+			"workspace root: omitting %d instance-local marketplace(s) with no root-resolvable path (%s); their plugins load only inside a provisioned instance",
+			len(excludedMarketplaces), strings.Join(excludedMarketplaces, ", "),
+		))
+	}
+	if len(excludedPlugins) > 0 {
+		reports = append(reports, fmt.Sprintf(
+			"workspace root: omitting %d plugin(s) bound to an instance-local marketplace (%s); they load only inside a provisioned instance",
+			len(excludedPlugins), strings.Join(excludedPlugins, ", "),
+		))
+	}
+	return keptPlugins, keptMarketplaces, reports
+}
+
+// pluginMarketplace returns the marketplace registration name a plugin entry
+// binds to: the substring after the last "@" in a "plugin@marketplace" string.
+// Returns "" when the entry carries no "@" qualifier (or a trailing "@" with no
+// name), in which case the plugin is not tied to a specific marketplace.
+func pluginMarketplace(plugin string) string {
+	at := strings.LastIndexByte(plugin, '@')
+	if at < 0 || at == len(plugin)-1 {
+		return ""
+	}
+	return plugin[at+1:]
 }
 
 // writeRootClaudeMD writes <workspaceRoot>/CLAUDE.md with workspace-context

--- a/internal/workspace/root_materializer_test.go
+++ b/internal/workspace/root_materializer_test.go
@@ -195,3 +195,146 @@ func TestMaterializeWorkspaceRoot_NoPermissionsConfigured(t *testing.T) {
 		t.Errorf("hooks block missing")
 	}
 }
+
+func TestMaterializeWorkspaceRoot_HoistsWorkspacePlugins(t *testing.T) {
+	// A github-sourced marketplace and its plugin hoist to the root settings so
+	// a root-launched session loads the workspace's plugins/skills. Track is
+	// "main" so the build does no network release resolution.
+	plugins := []string{"shirabe@shirabe"}
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "ws"},
+		Claude: config.ClaudeConfig{
+			Plugins: &plugins,
+			Marketplaces: config.MarketplaceConfigs{
+				{Source: "tsukumogami/shirabe", Track: "main"},
+			},
+		},
+	}
+
+	doc, _ := materializeRoot(t, cfg, RootMaterializeOptions{EphemeralSessionMode: true})
+
+	enabled, ok := doc["enabledPlugins"].(map[string]any)
+	if !ok {
+		t.Fatalf("enabledPlugins block missing or wrong type: %#v", doc["enabledPlugins"])
+	}
+	if enabled["shirabe@shirabe"] != true {
+		t.Errorf("enabledPlugins[shirabe@shirabe] = %v, want true", enabled["shirabe@shirabe"])
+	}
+
+	mkts, ok := doc["extraKnownMarketplaces"].(map[string]any)
+	if !ok {
+		t.Fatalf("extraKnownMarketplaces block missing or wrong type: %#v", doc["extraKnownMarketplaces"])
+	}
+	if _, ok := mkts["shirabe"]; !ok {
+		t.Errorf("extraKnownMarketplaces missing github marketplace 'shirabe': %#v", mkts)
+	}
+}
+
+func TestMaterializeWorkspaceRoot_ExcludesInstanceLocalMarketplace(t *testing.T) {
+	// A repo:-sourced marketplace points into an instance checkout that does not
+	// exist at the workspace root, so it (and the plugin bound to it) is omitted
+	// from the root settings while a github-sourced sibling still hoists.
+	plugins := []string{"shirabe@shirabe", "tsukumogami@tsukumogami"}
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "ws"},
+		Claude: config.ClaudeConfig{
+			Plugins: &plugins,
+			Marketplaces: config.MarketplaceConfigs{
+				{Source: "tsukumogami/shirabe", Track: "main"},
+				{Source: "repo:tools/.claude-plugin/marketplace.json"},
+			},
+		},
+	}
+
+	doc, _ := materializeRoot(t, cfg, RootMaterializeOptions{EphemeralSessionMode: true})
+
+	enabled, ok := doc["enabledPlugins"].(map[string]any)
+	if !ok {
+		t.Fatalf("enabledPlugins block missing: %#v", doc["enabledPlugins"])
+	}
+	if enabled["shirabe@shirabe"] != true {
+		t.Errorf("github-sourced plugin should hoist; enabledPlugins = %#v", enabled)
+	}
+	if _, present := enabled["tsukumogami@tsukumogami"]; present {
+		t.Errorf("instance-local plugin must be excluded from root, got enabledPlugins = %#v", enabled)
+	}
+
+	mkts, ok := doc["extraKnownMarketplaces"].(map[string]any)
+	if !ok {
+		t.Fatalf("extraKnownMarketplaces block missing: %#v", doc["extraKnownMarketplaces"])
+	}
+	if _, ok := mkts["shirabe"]; !ok {
+		t.Errorf("github marketplace should hoist; got %#v", mkts)
+	}
+	if _, ok := mkts["tsukumogami"]; ok {
+		t.Errorf("instance-local marketplace must be excluded from root; got %#v", mkts)
+	}
+}
+
+func TestRootHoistableConfig(t *testing.T) {
+	plugins := []string{"shirabe@shirabe", "tsukumogami@tsukumogami", "bare"}
+	marketplaces := config.MarketplaceConfigs{
+		{Source: "tsukumogami/shirabe"},
+		{Source: "repo:tools/.claude-plugin/marketplace.json"},
+	}
+
+	keptPlugins, keptMarketplaces, reports := rootHoistableConfig(plugins, marketplaces)
+
+	// github marketplace survives; repo: source is dropped.
+	if len(keptMarketplaces) != 1 || keptMarketplaces[0].Source != "tsukumogami/shirabe" {
+		t.Errorf("keptMarketplaces = %#v, want only tsukumogami/shirabe", keptMarketplaces)
+	}
+
+	// shirabe@shirabe (github marketplace) and the unqualified "bare" plugin
+	// survive; tsukumogami@tsukumogami (repo: marketplace) is dropped.
+	wantPlugins := map[string]bool{"shirabe@shirabe": true, "bare": true}
+	if len(keptPlugins) != len(wantPlugins) {
+		t.Fatalf("keptPlugins = %#v, want %v", keptPlugins, wantPlugins)
+	}
+	for _, p := range keptPlugins {
+		if !wantPlugins[p] {
+			t.Errorf("unexpected kept plugin %q", p)
+		}
+	}
+
+	// Both exclusions are reported, no silent truncation.
+	if len(reports) != 2 {
+		t.Fatalf("want 2 exclusion reports (marketplace + plugin), got %d: %#v", len(reports), reports)
+	}
+	joined := strings.Join(reports, "\n")
+	if !strings.Contains(joined, "repo:tools/.claude-plugin/marketplace.json") {
+		t.Errorf("marketplace exclusion report missing the source; got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "tsukumogami@tsukumogami") {
+		t.Errorf("plugin exclusion report missing the plugin; got:\n%s", joined)
+	}
+}
+
+func TestRootHoistableConfig_NoExclusions(t *testing.T) {
+	// All github sources: nothing is excluded, so no reports are produced.
+	plugins := []string{"shirabe@shirabe"}
+	marketplaces := config.MarketplaceConfigs{{Source: "tsukumogami/shirabe"}}
+
+	keptPlugins, keptMarketplaces, reports := rootHoistableConfig(plugins, marketplaces)
+	if len(keptPlugins) != 1 || len(keptMarketplaces) != 1 {
+		t.Errorf("expected all entries kept; plugins=%#v marketplaces=%#v", keptPlugins, keptMarketplaces)
+	}
+	if len(reports) != 0 {
+		t.Errorf("expected no exclusion reports, got %#v", reports)
+	}
+}
+
+func TestPluginMarketplace(t *testing.T) {
+	cases := map[string]string{
+		"shirabe@shirabe":         "shirabe",
+		"tsukumogami@tsukumogami": "tsukumogami",
+		"bare":                    "",
+		"trailing@":               "",
+		"a@b@c":                   "c",
+	}
+	for in, want := range cases {
+		if got := pluginMarketplace(in); got != want {
+			t.Errorf("pluginMarketplace(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Forward the effective workspace plugins and marketplaces into the workspace-root `.claude/settings.json`. `writeRootSettings` previously computed the effective config but passed only `Settings` to `buildSettingsDoc`, so the root settings emitted no `enabledPlugins` or `extraKnownMarketplaces` and a session launched at the workspace root loaded none of the workspace's plugins or skills (the instance materialization path forwards both).

`writeRootSettings` now forwards the root-hoistable subset of `effective.Plugins` and `effective.Claude.Marketplaces`. A new `rootHoistableConfig` helper partitions them: github-sourced marketplaces hoist unchanged, while `repo:`-sourced marketplaces -- which resolve to a directory inside an instance checkout that does not exist at the workspace root -- and any plugin bound to them are excluded and reported via `emitReports`. Add `pluginMarketplace` to map a plugin entry to its marketplace registration name. Update the stale `rootSkillsFS` comment that claimed plugins are never enabled at the root.

Correct `docs/guides/ephemeral-session-instances.md`: the "root settings ride the same path" contributor note now names the one filtered field, and a new section states which plugins a root-launched session receives and why config is forwarded into the root scaffold rather than relayed through the SessionStart hook.

---

## What This Fixes

In ephemeral-session mode, a Claude Code session launched at the workspace root never loaded the workspace's plugins/skills (e.g. `shirabe@shirabe`). The root `.claude/settings.json` carried no `enabledPlugins` or `extraKnownMarketplaces`, so a dispatched coordinator/worker started at the root without them. Root cause: `writeRootSettings` fed only `Settings` to `buildSettingsDoc`, even though `MergeInstanceOverrides` already carries `Plugins` and `Marketplaces` -- the instance path forwards both, the root path did not.

## Why Forward Into The Scaffold, Not The Hook

The issue proposed two directions; I chose to hoist into the root settings (Option A) rather than relaunch the worker rooted in the instance (Option B), because Option B is structurally infeasible from the SessionStart hook. Claude Code resolves plugins, marketplaces, hooks, and env from the launch directory's `settings.json` at startup, before the SessionStart hook runs. The hook can only inject `additionalContext` plus a `cd` instruction, and a mid-session `cd` cannot re-resolve plugin/settings config (the same reason it does not reload `CLAUDE.md`). Re-rooting would require Claude Code support or pre-launch provisioning -- which is exactly what the separate `niwa dispatch` path (#173) already does. The lazily-provisioned ephemeral mechanism (#169) has no re-root window, so the root's own `settings.json` is the only place a plugin can reach a root-launched session.

## The Marketplace Caveat

Not every marketplace can hoist. github-sourced (`org/repo`) marketplaces are root-stable and hoist as-is. `repo:`-sourced marketplaces point into an instance checkout that does not exist at the workspace root, so the marketplace and any plugin bound to it are excluded and a notice is printed at `niwa init` / `niwa apply` time -- never silently dropped. Those plugins still load once the session is inside its provisioned instance. The discriminator is the `repo:` source prefix, the only instance-relative form `mapMarketplaceSourceWithIndex` produces.

## Changes

- `internal/workspace/root_materializer.go`: forward the root-hoistable plugins/marketplaces; add `rootHoistableConfig` and `pluginMarketplace`; report exclusions; refresh the `rootSkillsFS` comment.
- `internal/workspace/root_materializer_test.go`: cover hoisting, instance-local exclusion, the partition helper, and plugin-marketplace parsing.
- `docs/guides/ephemeral-session-instances.md`: fix the misleading contributor note and add the root-plugins section.

## Verification

Confirmed against the live workspace root: before, `enabledPlugins: null` and empty `extraKnownMarketplaces`; the fix produces `{shirabe@shirabe: true}` plus the `shirabe` github marketplace, excluding the `tsukumogami` (`repo:tools`) marketplace with a logged notice. `go build ./...`, `go vet ./...`, `go test ./...` pass; `gofmt` clean.

Fixes #172