### PR TITLE
fix(provisioning): pre-warm declared Claude plugins on instance provision

### DIFF
--- a/docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md
+++ b/docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md
@@ -1,0 +1,259 @@
+---
+status: Complete
+question: |
+  Why do niwa-dispatched background workers produce pull requests that ignore the
+  org's pr-creation two-part template, even when the brief tells them to run the
+  shirabe /scope and /execute workflows (which author a template-conformant PR), and
+  what is the narrowest durable fix that makes the next dispatched worker conformant
+  by construction?
+timebox: "1 session (diagnosis only; no fix implemented)"
+---
+
+# SPIKE: dispatched workers ignore the pr-creation two-part PR template
+
+## Status
+
+Complete
+
+The cause is identified and reproduced from inside a live dispatched instance. This
+spike diagnoses and recommends only. No fix is implemented here; landing the fix is
+deferred for human direction (see Recommendation).
+
+## Question
+
+A coordinator dispatched a background worker into a fresh ephemeral niwa instance
+with a brief that said "run shirabe:scope, then shirabe:execute." The worker did the
+work but authored PR tsukumogami/niwa#177 with a freeform body: no `---` separator,
+no two-part (Part 1 commit message / Part 2 reviewer context) structure, and it
+leaked internal-workflow phrasing into a public-repo PR. It only fixed this afterward
+by running `/fix-pr`.
+
+Why does the template step get skipped for a dispatched worker, and what's the
+narrowest durable fix?
+
+A gate question had to be settled first, because an existing brief
+(`.niwa/dispatch-briefs/fix-root-plugin-provisioning.md`) asserts the opposite of
+what the worker reported. That brief claims ephemeral **instances** load the full
+shirabe plugin set and only the workspace **root** is missing them. The worker
+reported shirabe was not invocable inside its instance. The whole diagnosis branches
+on which is true, so it was established empirically before anything else.
+
+## Context
+
+The shirabe `/execute` workflow has an explicit step that authors a
+template-conformant PR. If a dispatched worker can run `/execute` the normal way,
+the PR is conformant by construction and no agent memory is required. The symptom PR
+shows that didn't happen. Three things needed to be distinguished:
+
+- whether the shirabe skills were even loadable in the dispatched instance (a
+  provisioning question, owned by niwa);
+- whether the concrete PR-template spec is reachable when the workflow is hand-run
+  from its `SKILL.md` instead of driven by the koto runtime (a content question,
+  owned by shirabe);
+- whether anything downstream enforces conformance (a CI question).
+
+The candidate hypotheses going in:
+
+- **H1 — plugin-load gap.** Dispatched instances don't load the shirabe plugin, so
+  the worker can't invoke `/scope` / `/execute` and hand-runs them.
+- **H2 — template step unreachable when hand-run.** The concrete spec lives only in
+  the koto template, which a human or agent reading `SKILL.md` never opens.
+- **H3 — enforcement gap.** Nothing checks PR-body conformance, so a malformed PR
+  merges silently.
+- **H4 — dispatch front door.** The `/dispatch` brief convention should hard-wire the
+  template requirement, since a dispatched worker predictably hand-runs workflows.
+
+## Approach
+
+The investigation ran inside a live dispatched ephemeral instance (the one created
+for this spike), so the gate question could be answered with direct evidence rather
+than inference.
+
+1. Enumerated the skills actually invocable in this session and compared them against
+   the plugins declared enabled.
+2. Inspected this instance's `.claude/settings.json`, `.niwa/instance.json`, and the
+   shared `~/.claude/plugins/` store (`known_marketplaces.json`,
+   `installed_plugins.json`, and the on-disk plugin cache).
+3. Compared install timestamps against instance-creation time to test for a
+   startup race.
+4. Traced niwa's dispatch and provisioning code
+   (`internal/cli/dispatch.go`, `internal/cli/dispatch_launcher.go`,
+   `internal/cli/instance_from_hook.go`, `internal/workspace/materialize.go`,
+   `internal/workspace/apply.go`, `internal/plugin/`) to find whether plugins are
+   installed before the worker launches.
+5. Read the shirabe `/execute` skill surface
+   (`skills/execute/SKILL.md` vs `skills/execute/koto-templates/execute.md`) and the
+   `tsukumogami:pr-creation` skill to locate where the two-part spec actually lives
+   and whether its references resolve.
+
+## Findings
+
+### Gate: shirabe-namespace skills are NOT invocable in a dispatched instance
+
+Confirmed, with evidence from this instance. The shirabe skills (`scope`, `execute`,
+`design`, `plan`, `brief`, `prd`, ...) are not in this session's invocable skill set.
+Only the `tsukumogami:*` skills, plus the stock plugins (superpowers, vercel,
+telegram, skill-creator) and `dispatch`, are present. An independent tell: the
+`tsukumogami:legacy-design` skill advertises "[DEPRECATED: use /shirabe:design]" —
+pointing at a skill that isn't loaded.
+
+This is not a misconfiguration. The plugin is enabled and fully present on disk:
+
+- `.claude/settings.json` declares
+  `enabledPlugins: { "shirabe@shirabe": true, "tsukumogami@tsukumogami": true }`.
+- `installed_plugins.json` registers `shirabe@shirabe` for this exact project path,
+  installPath `~/.claude/plugins/cache/shirabe/shirabe/0.13.1-dev`.
+- That cache directory contains the full `skills/` tree (scope, execute, design,
+  plan, brief, prd, ...) and a `plugin.json` declaring `"skills": "./skills/"`.
+
+So the plugin is on disk and enabled, yet its skills were never loaded into the
+running session.
+
+### Mechanism: a startup race between marketplace install and skill enumeration
+
+The two declared marketplaces resolve very differently:
+
+- `tsukumogami` is **directory**-sourced (local `private/tools`). It's already on
+  disk, so its skills load immediately. These are the skills that did appear.
+- `shirabe` is **github**-sourced (`tsukumogami/shirabe`). It requires a network
+  clone/update at Claude Code startup. These are the skills that didn't appear.
+
+Timestamps from this instance show the race directly:
+
+- instance created (`.niwa/instance.json`): `2026-06-28T03:08:33Z`
+- shirabe plugin cache install finished (`installed_plugins.json` `installedAt`):
+  `2026-06-28T03:08:52Z` (+19s)
+- shirabe marketplace `lastUpdated` (`known_marketplaces.json`):
+  `2026-06-28T03:08:54Z` (+21s)
+
+niwa launches the worker without waiting for any of this. In
+`internal/cli/dispatch.go`, `runDispatch` provisions the instance and then calls
+`dispatchLaunch` immediately; `internal/cli/dispatch_launcher.go` runs
+`claude --bg ...` with no readiness gate. Provisioning
+(`internal/workspace/materialize.go`, the `buildSettingsDoc` path that emits
+`enabledPlugins` / `extraKnownMarketplaces`) only **writes settings** — there is no
+`claude plugin install` / `marketplace add` shell-out and no poll that blocks until
+the github marketplace is resolved. Claude Code therefore enumerates its skills at
+startup before the github clone finishes, and the shirabe skills are absent for the
+entire session.
+
+Worth noting: niwa already knows how to materialize a plugin to disk before launch —
+`internal/plugin/` embeds niwa's own plugin and installs it under
+`~/.claude/plugins/marketplaces/niwa/` from the binary, with no network. That
+machinery just isn't applied to the workspace-declared marketplaces.
+
+An aggravating factor: a version/config mismatch widens the race window. This
+instance's settings pin shirabe to `ref: v0.13.0`, but the shared
+`known_marketplaces.json` has shirabe with `autoUpdate: true` and no pin, and the
+installed version is `0.13.1-dev`. The autoUpdate-plus-pin mismatch invites a fresh
+fetch at startup every time, where a stable, already-resolved local marketplace would
+never race.
+
+**This refutes the premise of `fix-root-plugin-provisioning.md`.** That brief assumes
+instances load shirabe and only the root is short. In fact an instance gets shirabe
+*written into settings and eventually installed to disk*, but *not loaded into the
+running session*. The earlier observation of "instances are fine" most likely came
+from inspecting settings/disk state (where shirabe looks enabled) rather than the
+session's actual invocable-skill list. The root-provisioning work in that brief may
+still be valid on its own terms, but it does not address — and is partly contradicted
+by — what breaks dispatched workers.
+
+### Why the template is then skipped: H2 is real and compounds H1
+
+Because `/execute` wasn't invocable, the worker hand-ran it by reading
+`skills/execute/SKILL.md`. The concrete two-part PR spec is not there. `SKILL.md`
+mentions it only in passing: "`pr_finalization` — assemble the template-conformant PR
+(title + two-part body)" (around line 187). The actual spec — conventional-commit
+title, Part 1 becomes the squash commit body, everything from `---` down is deleted
+at merge, the exact `gh pr edit --title ... --body-file ...` form — lives only in
+`skills/execute/koto-templates/execute.md`, in the `pr_finalization` state
+(lines 386-417). That koto template is consumed by the koto runtime, not by a human
+or agent reading `SKILL.md`. Hand-running drops the spec.
+
+Two details make the hand-run path worse:
+
+- **Dangling cross-plugin pointer.** `execute.md:390` says the canonical spec is
+  `skills/pr-creation/SKILL.md` and to "apply that spec inline." But shirabe has no
+  `pr-creation` skill; that path doesn't resolve inside the shirabe repo. The real
+  skill is `tsukumogami:pr-creation`, which lives in a different plugin (sourced from
+  the `tools` repo). An agent that did reach `execute.md` still couldn't follow the
+  pointer without already knowing where the skill lives.
+- **An instruction that backfires when hand-run.** `execute.md:390` also says "do
+  NOT invoke the cross-plugin `/fix-pr` or `pr-creation` skill at runtime." That's
+  correct when koto drives, because koto inlines the spec. When the workflow is
+  hand-run, it actively tells the agent not to use the one skill that was loaded the
+  whole time and would have produced a conformant PR — `tsukumogami:pr-creation`.
+
+So the symptom is a chain: **H1 (the load race) forces the hand-run, and H2 (spec
+only in the koto template, plus an unresolvable pointer) is what actually drops the
+template.** A third factor sits behind both: "create a PR" is itself a task with a
+dedicated, loaded skill (`tsukumogami:pr-creation`), and the worker treated it as
+freeform writing.
+
+H3 (no PR-body conformance check) and H4 (dispatch brief doesn't hard-wire it) are
+genuine gaps but secondary — defense-in-depth, not the root cause.
+
+### Note on single-repo /scope
+
+`skills/scope/SKILL.md` confirms a single-repo `/scope` opens no regular PR (only a
+coordination PR when coordination intent is present; line 121). So for a single-repo
+scope, the "open a PR" step is supplied by the brief or operator and has no template
+anchor of its own — another reason the worker was authoring a PR body without a spec
+in front of it.
+
+## Recommendation
+
+Go on a two-part fix, in priority order. Prefer making the right thing happen by
+construction (the niwa fix) over relying on the agent to remember (brief/CI nudges).
+
+### Primary — close the plugin-load race in niwa (owner: niwa)
+
+Make instance provisioning install/resolve the declared github-sourced marketplaces
+and plugins to disk **before** launching the worker, so the skills are present when
+Claude Code enumerates them at startup. niwa already has the shape for this in
+`internal/plugin/` (it materializes its own plugin pre-launch); extend the dispatch
+path (`internal/cli/dispatch.go` -> `dispatch_launcher.go`) to either shell out to
+`claude plugin marketplace add` / `claude plugin install` for the declared set, or
+block on a readiness check until the marketplace cache is resolved, before
+`dispatchLaunch`. Also reconcile the `autoUpdate: true` vs pinned-`ref` mismatch so
+the marketplace resolves deterministically instead of re-fetching at every startup.
+
+This is the durable root fix: it makes `/scope`, `/execute`, and every other shirabe
+skill invocable for dispatched workers. Once `/execute` is koto-driven, the
+`pr_finalization` state inlines the correct spec and authors a conformant PR with no
+agent memory required — which dissolves H2 in the normal path.
+
+Trade-off: it adds latency to dispatch (a network clone before launch) and couples
+niwa to Claude Code's plugin CLI surface. Both are acceptable for correctness; the
+latency is one-time per instance and the CLI surface is already a dependency.
+
+### Companion — harden the hand-run fallback in shirabe (owner: shirabe)
+
+Even with the niwa fix, the hand-run path persists during any residual race window or
+if a pre-install fails, so make it safe:
+
+- Fix the dangling reference at `skills/execute/koto-templates/execute.md:390`.
+  Either make it resolvable ("if running outside koto, invoke the `pr-creation`
+  skill") or stop telling a hand-running agent not to invoke `pr-creation`. The
+  "do not invoke at runtime" instruction should be scoped to koto-driven runs.
+- Surface the two-part requirement in `skills/execute/SKILL.md` itself — at minimum a
+  pointer that resolves without the koto runtime — so a worker reading only `SKILL.md`
+  sees it.
+
+This is low-cost and high-value; it's the difference between a hand-run that degrades
+gracefully and one that silently drops the template.
+
+### Optional — backstops (owners: dot-niwa-overlay / CI)
+
+- Have the `/dispatch` brief convention state that PRs must follow the pr-creation
+  two-part template and that `tsukumogami:pr-creation` should be invoked. Cheap, but
+  relies on agent memory — weaker than the niwa fix.
+- Consider a CI PR-body conformance check (analogous to the existing per-file
+  validate-docs workflow). Likely overkill for now; flagged for completeness.
+
+### Scope discipline for the follow-up
+
+The niwa fix and the shirabe fix are separate PRs in separate repos. Don't fold the
+shirabe content fix into the niwa change. Don't re-litigate the #177 idle-reap fix —
+only its PR format is in scope here. The `fix-root-plugin-provisioning.md` task should
+be re-scoped in light of this spike's gate finding before it proceeds.

--- a/docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md
+++ b/docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md
@@ -6,7 +6,7 @@ question: |
   shirabe /scope and /execute workflows (which author a template-conformant PR), and
   what is the narrowest durable fix that makes the next dispatched worker conformant
   by construction?
-timebox: "1 session (diagnosis only; no fix implemented)"
+timebox: "1 session (diagnosis + the niwa-side fix)"
 ---
 
 # SPIKE: dispatched workers ignore the pr-creation two-part PR template
@@ -15,9 +15,14 @@ timebox: "1 session (diagnosis only; no fix implemented)"
 
 Complete
 
-The cause is identified and reproduced from inside a live dispatched instance. This
-spike diagnoses and recommends only. No fix is implemented here; landing the fix is
-deferred for human direction (see Recommendation).
+The cause is identified and reproduced from inside a live dispatched instance. The
+**primary fix — niwa-side plugin pre-warming during instance provisioning — is
+implemented in this PR** (see the "Implemented in this PR" note under Recommendation).
+Two items the diagnosis surfaced remain deliberately out of scope and are tracked as
+follow-ups: the shirabe-side hardening of the hand-run fallback (H2, a different repo)
+and the `autoUpdate`-vs-pinned-`ref` marketplace mismatch (a config/overlay concern).
+So this PR closes the root cause (the plugin-load race, H1); it does not by itself
+close every path the originating question describes.
 
 ## Question
 
@@ -220,23 +225,37 @@ construction (the niwa fix) over relying on the agent to remember (brief/CI nudg
 ### Primary — close the plugin-load race in niwa (owner: niwa)
 
 Make instance provisioning install/resolve the declared github-sourced marketplaces
-and plugins to disk **before** launching the worker, so the skills are present when
-Claude Code enumerates them at startup. niwa already has the shape for this in
-`internal/plugin/` (it materializes its own plugin pre-launch); extend the dispatch
-path (`internal/cli/dispatch.go` -> `dispatch_launcher.go`) to either shell out to
-`claude plugin marketplace add` / `claude plugin install` for the declared set, or
-block on a readiness check until the marketplace cache is resolved, before
-`dispatchLaunch`. Also reconcile the `autoUpdate: true` vs pinned-`ref` mismatch so
-the marketplace resolves deterministically instead of re-fetching at every startup.
+and plugins to disk as part of provisioning, so the skills are present when the first
+Claude session in the instance enumerates them at startup. The right home is the
+provisioning pipeline, not the dispatch launch step: the race fires at first-session
+skill enumeration regardless of who starts the session, so `niwa create` followed by
+a manual `claude` launch hits it just as `niwa dispatch` does. niwa already has the
+shape for this — `internal/plugin/` materializes its own plugin during apply, and the
+`Applier` already manages Claude's global marketplace registry
+(`reconcileMarketplaceAutoUpdate`, `prunePluginRecords`). Add a sibling step that
+shells out to `claude plugin marketplace add` / `claude plugin install` for the
+declared github set, gated by the existing `auto_install_plugins` opt-out.
+
+Separately, reconcile the `autoUpdate: true` vs pinned-`ref` mismatch so the
+marketplace resolves deterministically instead of re-fetching at every startup (a
+config/overlay concern, tracked as its own follow-up).
 
 This is the durable root fix: it makes `/scope`, `/execute`, and every other shirabe
-skill invocable for dispatched workers. Once `/execute` is koto-driven, the
-`pr_finalization` state inlines the correct spec and authors a conformant PR with no
-agent memory required — which dissolves H2 in the normal path.
+skill invocable for any worker in a provisioned instance. Once `/execute` is
+koto-driven, the `pr_finalization` state inlines the correct spec and authors a
+conformant PR with no agent memory required — which dissolves H2 in the normal path.
 
-Trade-off: it adds latency to dispatch (a network clone before launch) and couples
-niwa to Claude Code's plugin CLI surface. Both are acceptable for correctness; the
-latency is one-time per instance and the CLI surface is already a dependency.
+Trade-off: it adds latency to provisioning (a network clone) and couples niwa to
+Claude Code's plugin CLI surface. Both are acceptable for correctness; the latency is
+one-time per instance and the CLI surface is already a dependency.
+
+**Implemented in this PR** as `Applier.PrewarmDeclaredPlugins` — a best-effort,
+non-fatal seam wired via `configurePluginAutoInstall` and called from both `Create`
+and `Apply` after settings are materialized, so dispatch, plain `create`, and `apply`
+all benefit. It reads the instance's `settings.json`, runs `marketplace add` for
+github sources (skipping directory sources, which are already local) and
+`install --scope project` for enabled plugins, honors the opt-out, and bounds each
+call with a timeout.
 
 ### Companion — harden the hand-run fallback in shirabe (owner: shirabe)
 

--- a/docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md
+++ b/docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md
@@ -142,6 +142,17 @@ Worth noting: niwa already knows how to materialize a plugin to disk before laun
 `~/.claude/plugins/marketplaces/niwa/` from the binary, with no network. That
 machinery just isn't applied to the workspace-declared marketplaces.
 
+**Confirming experiment.** Running `/reload-plugins` mid-session made every shirabe
+skill (`scope`, `execute`, `design`, `plan`, `brief`, `prd`, ...) invocable
+immediately — no install, no clone, no network. The on-disk state was identical
+before and after; only the enumeration was re-run. This is the signature of a startup
+enumeration race, not a missing or broken install: if provisioning had genuinely
+failed to put the plugin on disk (the premise of `fix-root-plugin-provisioning.md`), a
+reload would have nothing to enumerate and would not fix it. The single variable is
+*when enumeration runs relative to install completion*. The durable automated
+equivalent of that manual reload is for niwa to resolve the declared marketplaces to
+disk before launching the worker, so the first enumeration already sees them.
+
 An aggravating factor: a version/config mismatch widens the race window. This
 instance's settings pin shirabe to `ref: v0.13.0`, but the shared
 `known_marketplaces.json` has shirabe with `autoUpdate: true` and no pin, and the

--- a/internal/cli/dispatch_plugins.go
+++ b/internal/cli/dispatch_plugins.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tsukumogami/niwa/internal/workspace"
+)
+
+// prewarmCmdTimeout bounds a single `claude plugin` invocation during dispatch
+// pre-warming. A marketplace add performs a network clone; without a bound a stuck
+// fetch would hang the whole dispatch. On timeout the command is killed and the
+// best-effort caller proceeds to launch -- the worker still installs from settings
+// on startup. It is generous (clones are normally seconds) so a slow-but-working
+// network is not cut off.
+const prewarmCmdTimeout = 120 * time.Second
+
+// prewarmDeclaredPlugins resolves an instance's workspace-declared Claude
+// marketplaces and plugins to disk so the FIRST Claude session started in the
+// instance finds them already installed when it enumerates skills. It is the
+// cli-side implementation wired onto workspace.Applier.PrewarmDeclaredPlugins (see
+// configurePluginAutoInstall), called from the provisioning pipeline after settings
+// are materialized -- so every entry path benefits: `niwa dispatch`, `niwa create`
+// + a manual `claude` launch, and `niwa apply`.
+//
+// It closes the race where a github-sourced marketplace (e.g. shirabe) is cloned
+// asynchronously during a session's own Claude startup and finishes AFTER skill
+// enumeration, leaving that marketplace's skills uninvocable for the whole session.
+// Pre-warming runs that clone synchronously here so the session finds it on disk.
+//
+// The instance's just-written .claude/settings.json is the source of truth: it is
+// the materialized, post-overlay-merge set of marketplaces/plugins, so reading it
+// back keeps this self-contained and needs no extra config plumbing from the caller.
+//
+// It is best-effort. skipInstall (the same opt-out that gates InstallNiwaPlugin,
+// already OR'd with the global auto_install_plugins setting by the caller) short-
+// circuits it. Every other failure (claude absent, CLI error, unreadable settings)
+// is a warning, never fatal: Claude still installs from settings.json at startup, so
+// pre-warming only removes the race -- a provision must never be less robust than
+// before when the plugin CLI is unavailable. reporter may be nil.
+func prewarmDeclaredPlugins(instanceRoot string, reporter *workspace.Reporter, skipInstall bool) {
+	if skipInstall {
+		return
+	}
+
+	settings, err := readInstanceSettings(instanceRoot)
+	if err != nil {
+		// No settings file or unparseable: nothing to pre-warm. The session's own
+		// startup install remains the fallback.
+		return
+	}
+
+	// 1. Clone the github-sourced marketplaces -- the ones that require a network
+	// fetch and therefore race. Directory/local sources are already on disk and
+	// never race, so they are skipped.
+	for _, name := range sortedKeys(marketplaceNames(settings.ExtraKnownMarketplaces)) {
+		mkt := settings.ExtraKnownMarketplaces[name]
+		if mkt.Source.Source != "github" || mkt.Source.Repo == "" {
+			continue
+		}
+		// Only the repo is needed: pre-warming clones the marketplace to disk to
+		// remove the network step from the session's startup. The exact ref/version
+		// pin stays governed by the instance settings.json read at startup --
+		// `claude plugin marketplace add` has no ref option anyway.
+		if err := runClaudePluginCmd(context.Background(), instanceRoot, "marketplace", "add", mkt.Source.Repo); err != nil {
+			warnPrewarm(reporter, "pre-warming marketplace %q (%s): %v; it will install on startup instead", name, mkt.Source.Repo, err)
+		}
+	}
+
+	// 2. Install the enabled plugins so the plugin cache is populated before the
+	// session enumerates skills. Scope is project (cwd = instance) so this matches
+	// the instance's settings.json and does not enable plugins in other projects.
+	for _, plugin := range sortedKeys(pluginNames(settings.EnabledPlugins)) {
+		if err := runClaudePluginCmd(context.Background(), instanceRoot, "install", plugin, "--scope", "project"); err != nil {
+			warnPrewarm(reporter, "pre-warming plugin %q: %v; it will install on startup instead", plugin, err)
+		}
+	}
+}
+
+// warnPrewarm emits a best-effort warning, tolerating a nil reporter (the seam
+// contract allows a nil reporter, mirroring InstallNiwaPlugin).
+func warnPrewarm(reporter *workspace.Reporter, format string, a ...any) {
+	if reporter != nil {
+		reporter.Warn(format, a...)
+	}
+}
+
+// runClaudePluginCmd runs `claude plugin <args...>` with the working directory set
+// to dir (so `--scope project` targets the instance). It is a package variable so
+// tests can record the issued commands without a real claude install, mirroring the
+// lookClaude/dispatchAttach seam pattern in dispatch.go. Output is folded into the
+// returned error so a failure surfaces a useful message in the caller's warning.
+var runClaudePluginCmd = func(ctx context.Context, dir string, args ...string) error {
+	bin, err := lookClaude()
+	if err != nil {
+		return err
+	}
+	// Bound each invocation so a hung network clone (marketplace add) cannot stall
+	// dispatch indefinitely; on timeout the command is killed and the best-effort
+	// caller falls back to the worker's own startup install.
+	ctx, cancel := context.WithTimeout(ctx, prewarmCmdTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, append([]string{"plugin"}, args...)...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return err
+	}
+	return nil
+}
+
+// instanceSettings is the narrow projection of .claude/settings.json this package
+// reads back: just the plugin/marketplace declarations niwa materialized. Unknown
+// fields are ignored.
+type instanceSettings struct {
+	EnabledPlugins         map[string]bool             `json:"enabledPlugins"`
+	ExtraKnownMarketplaces map[string]marketplaceEntry `json:"extraKnownMarketplaces"`
+}
+
+type marketplaceEntry struct {
+	Source marketplaceSource `json:"source"`
+}
+
+// marketplaceSource is the subset of the Claude Code marketplace source shape (emitted
+// by mapMarketplaceSourceWithIndex in internal/workspace) that pre-warming needs:
+// Source is the kind ("github", "directory", ...) and Repo is set for github sources.
+// The ref/path fields the emitter also writes are intentionally omitted -- pre-warming
+// only clones github marketplaces to disk; everything else is governed by the
+// settings.json the worker reads at startup.
+type marketplaceSource struct {
+	Source string `json:"source"`
+	Repo   string `json:"repo"`
+}
+
+// readInstanceSettings reads the dispatched instance's Claude settings from
+// <instancePath>/.claude/settings.json. The instance root receives settings.json
+// (per InstallWorkspaceRootSettings; see internal/workspace/permissions.go) -- the
+// settings.local.json variant is for per-repo dirs, never the root, so it is not
+// consulted here. Returns an error when the file is absent or not valid JSON;
+// callers treat any error as "nothing to pre-warm."
+func readInstanceSettings(instancePath string) (*instanceSettings, error) {
+	data, err := os.ReadFile(filepath.Join(instancePath, ".claude", "settings.json"))
+	if err != nil {
+		return nil, err
+	}
+	var s instanceSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parsing settings.json: %w", err)
+	}
+	return &s, nil
+}
+
+func marketplaceNames(m map[string]marketplaceEntry) []string {
+	names := make([]string, 0, len(m))
+	for k := range m {
+		names = append(names, k)
+	}
+	return names
+}
+
+func pluginNames(m map[string]bool) []string {
+	names := make([]string, 0, len(m))
+	for k, enabled := range m {
+		if enabled {
+			names = append(names, k)
+		}
+	}
+	return names
+}
+
+// sortedKeys returns the input sorted, so the issued commands are deterministic
+// (stable warnings and testable ordering).
+func sortedKeys(names []string) []string {
+	sort.Strings(names)
+	return names
+}

--- a/internal/cli/dispatch_plugins_test.go
+++ b/internal/cli/dispatch_plugins_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/niwa/internal/workspace"
+)
+
+// writeInstanceSettings writes a .claude/settings.json under a fresh temp instance
+// dir and returns the instance path.
+func writeInstanceSettings(t *testing.T, body string) string {
+	t.Helper()
+	instance := t.TempDir()
+	claudeDir := filepath.Join(instance, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	return instance
+}
+
+// recordPluginCalls swaps runClaudePluginCmd for a recorder and restores it on
+// cleanup. err is returned from every invocation (nil for success).
+func recordPluginCalls(t *testing.T, err error) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := runClaudePluginCmd
+	runClaudePluginCmd = func(_ context.Context, dir string, args ...string) error {
+		calls = append(calls, append([]string{dir}, args...))
+		return err
+	}
+	t.Cleanup(func() { runClaudePluginCmd = prev })
+	return &calls
+}
+
+// The settings fixtures below mirror the shape niwa emits in
+// mapMarketplaceSourceWithIndex (internal/workspace): github sources carry
+// source+repo (+ref, which pre-warming ignores), directory sources carry
+// source+path. If that emitted shape changes, these fixtures (and the reader in
+// dispatch_plugins.go) must change together.
+
+func TestPrewarm_GithubMarketplacesAndPlugins(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "enabledPlugins": {"shirabe@shirabe": true, "tsukumogami@tsukumogami": true},
+	  "extraKnownMarketplaces": {
+	    "shirabe": {"source": {"source": "github", "repo": "tsukumogami/shirabe", "ref": "v0.13.0"}},
+	    "tsukumogami": {"source": {"source": "directory", "path": "/local/tools"}}
+	  }
+	}`)
+	calls := recordPluginCalls(t, nil)
+
+	prewarmDeclaredPlugins(instance, nil, false)
+
+	want := [][]string{
+		{instance, "marketplace", "add", "tsukumogami/shirabe"},
+		{instance, "install", "shirabe@shirabe", "--scope", "project"},
+		{instance, "install", "tsukumogami@tsukumogami", "--scope", "project"},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Errorf("calls =\n  %v\nwant\n  %v", *calls, want)
+	}
+}
+
+func TestPrewarm_SkipsDisabledPlugins(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "enabledPlugins": {"on@mkt": true, "off@mkt": false}
+	}`)
+	calls := recordPluginCalls(t, nil)
+
+	prewarmDeclaredPlugins(instance, nil, false)
+
+	want := [][]string{{instance, "install", "on@mkt", "--scope", "project"}}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Errorf("disabled plugin should be skipped; calls = %v, want %v", *calls, want)
+	}
+}
+
+func TestPrewarm_SkipsDirectoryMarketplaces(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "extraKnownMarketplaces": {
+	    "tsukumogami": {"source": {"source": "directory", "path": "/local/tools"}}
+	  }
+	}`)
+	calls := recordPluginCalls(t, nil)
+
+	prewarmDeclaredPlugins(instance, nil, false)
+
+	for _, c := range *calls {
+		if len(c) >= 2 && c[1] == "marketplace" {
+			t.Errorf("directory marketplace should not be added, got call %v", c)
+		}
+	}
+}
+
+func TestPrewarm_OptOutShortCircuits(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "enabledPlugins": {"shirabe@shirabe": true},
+	  "extraKnownMarketplaces": {"shirabe": {"source": {"source": "github", "repo": "tsukumogami/shirabe"}}}
+	}`)
+	calls := recordPluginCalls(t, nil)
+
+	// skipInstall=true (the opt-out the caller computes from --no-install-plugins +
+	// auto_install_plugins) must issue no plugin commands.
+	prewarmDeclaredPlugins(instance, nil, true)
+
+	if len(*calls) != 0 {
+		t.Errorf("opt-out should issue no plugin commands, got %v", *calls)
+	}
+}
+
+func TestPrewarm_MissingSettingsIsNoOp(t *testing.T) {
+	calls := recordPluginCalls(t, nil)
+
+	// A temp dir with no .claude/settings.json.
+	prewarmDeclaredPlugins(t.TempDir(), nil, false)
+
+	if len(*calls) != 0 {
+		t.Errorf("missing settings should issue no commands, got %v", *calls)
+	}
+}
+
+func TestPrewarm_ExecFailureIsNonFatalAndWarns(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "enabledPlugins": {"shirabe@shirabe": true},
+	  "extraKnownMarketplaces": {"shirabe": {"source": {"source": "github", "repo": "tsukumogami/shirabe"}}}
+	}`)
+	calls := recordPluginCalls(t, errors.New("boom"))
+	var buf bytes.Buffer
+	reporter := workspace.NewReporter(&buf)
+
+	// Must not panic and must attempt both the marketplace add and the install
+	// even though the first call fails.
+	prewarmDeclaredPlugins(instance, reporter, false)
+
+	if len(*calls) != 2 {
+		t.Errorf("expected 2 attempts despite failures, got %d: %v", len(*calls), *calls)
+	}
+	if !strings.Contains(buf.String(), "pre-warming") {
+		t.Errorf("expected a warning mentioning pre-warming, got %q", buf.String())
+	}
+}
+
+func TestPrewarm_NilReporterDoesNotPanic(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "extraKnownMarketplaces": {"shirabe": {"source": {"source": "github", "repo": "tsukumogami/shirabe"}}}
+	}`)
+	recordPluginCalls(t, errors.New("boom"))
+
+	// A nil reporter (allowed by the seam contract) must not panic on warning.
+	prewarmDeclaredPlugins(instance, nil, false)
+}
+
+// TestConfigurePluginAutoInstall_WiresPrewarm guards the load-bearing wiring: if the
+// PrewarmDeclaredPlugins seam is left nil, the provisioning pipeline silently skips
+// pre-warming and the whole fix becomes a no-op. It must be wired alongside
+// InstallNiwaPlugin for every Applier the cli constructs.
+func TestConfigurePluginAutoInstall_WiresPrewarm(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate from the host's global config
+	var applier workspace.Applier
+	configurePluginAutoInstall(&applier, false)
+
+	if applier.PrewarmDeclaredPlugins == nil {
+		t.Error("configurePluginAutoInstall must wire PrewarmDeclaredPlugins (nil would no-op the fix)")
+	}
+	if applier.InstallNiwaPlugin == nil {
+		t.Error("configurePluginAutoInstall must still wire InstallNiwaPlugin")
+	}
+	if applier.SkipPluginInstall {
+		t.Error("SkipPluginInstall should be false with flagOptOut=false and no global opt-out")
+	}
+}

--- a/internal/cli/plugin_adapter.go
+++ b/internal/cli/plugin_adapter.go
@@ -31,4 +31,5 @@ func configurePluginAutoInstall(applier *workspace.Applier, flagOptOut bool) {
 	}
 	applier.SkipPluginInstall = flagOptOut || skipFromGlobal
 	applier.InstallNiwaPlugin = installNiwaPluginAdapter
+	applier.PrewarmDeclaredPlugins = prewarmDeclaredPlugins
 }

--- a/internal/workspace/apply.go
+++ b/internal/workspace/apply.go
@@ -76,6 +76,18 @@ type Applier struct {
 	// exercise rank-2 + plugin-install at the same time.
 	InstallNiwaPlugin func(state *InstanceState, reporter *Reporter, skipInstall bool)
 
+	// PrewarmDeclaredPlugins resolves the instance's workspace-declared Claude
+	// marketplaces/plugins (the github-sourced ones) to disk after the pipeline
+	// materializes .claude/settings.json, so the FIRST Claude session started in
+	// the instance finds them already installed when it enumerates skills. This
+	// closes the race where a github marketplace is cloned asynchronously during
+	// that session's own startup and finishes AFTER enumeration, leaving its
+	// skills uninvocable. It runs for every provisioned instance, not just the
+	// dispatch path: `niwa create` followed by a manual `claude` launch hits the
+	// same race. Wired from cli (where the claude exec lives) via NewApplier's
+	// callers; nil means no-op (tests, or a surface that didn't wire it).
+	PrewarmDeclaredPlugins func(instanceRoot string, reporter *Reporter, skipInstall bool)
+
 	// cloneOrSync materializes or refreshes the overlay snapshot at dir.
 	// Returns wasFreshClone=true when no marker/.git was present (fresh
 	// materialization), so callers can distinguish "overlay doesn't
@@ -360,6 +372,14 @@ func (a *Applier) Create(ctx context.Context, cfg *config.WorkspaceConfig, confi
 		}
 	}
 
+	// Resolve the workspace-declared marketplaces/plugins to disk now, while the
+	// just-materialized settings.json is fresh, so the first Claude session in this
+	// instance enumerates them without losing the async-clone race. Runs for every
+	// instance create (dispatch and plain `niwa create` alike); best-effort.
+	if a.PrewarmDeclaredPlugins != nil {
+		a.PrewarmDeclaredPlugins(instanceRoot, a.Reporter, a.SkipPluginInstall)
+	}
+
 	// Use the effective configName (resolved earlier above) for the
 	// instance-number derivation so `niwa init my-name --from upstream`
 	// correctly resolves the first instance to InstanceNumber=1 (not 0).
@@ -498,6 +518,13 @@ func (a *Applier) Apply(ctx context.Context, cfg *config.WorkspaceConfig, config
 		if a.InstallNiwaPlugin != nil {
 			a.InstallNiwaPlugin(nil, a.Reporter, a.SkipPluginInstall)
 		}
+	}
+
+	// Pre-warm the workspace-declared marketplaces/plugins to disk on every apply
+	// too, so a re-applied instance picks up newly declared plugins before its next
+	// Claude session enumerates skills. Best-effort; see Create for the rationale.
+	if a.PrewarmDeclaredPlugins != nil {
+		a.PrewarmDeclaredPlugins(instanceRoot, a.Reporter, a.SkipPluginInstall)
 	}
 
 	// Emit `rotated <path>` to stderr for every managed file whose


### PR DESCRIPTION
Resolve the workspace-declared Claude marketplaces and plugins to disk during instance provisioning, so the first Claude session started in an instance finds them already installed when it enumerates skills. Add the spike that diagnoses why this was needed.

The pre-warm is an `Applier` seam (`PrewarmDeclaredPlugins`) wired via `configurePluginAutoInstall` and called from both `Create` and `Apply` after the pipeline materializes settings — so every entry path benefits, not just dispatch. It reads the instance's `.claude/settings.json` (the materialized, post-overlay declaration), runs `claude plugin marketplace add <repo>` for each github-sourced marketplace and `claude plugin install <plugin> --scope project` for each enabled plugin. Directory-sourced marketplaces are already on disk and skipped. The step honors the existing `auto_install_plugins` opt-out, bounds each CLI call with a timeout, and is best-effort: any failure is a warning, never fatal, because Claude still installs from settings on startup. The claude invocation sits behind a package-var exec seam (`runClaudePluginCmd`).

---

## What This Fixes

A freshly provisioned niwa instance has `enabledPlugins` + `extraKnownMarketplaces` written into its settings, but no plugin install step runs before a Claude session starts in it. A github-sourced marketplace (e.g. shirabe) is cloned asynchronously during that session's own Claude startup and can finish *after* skill enumeration, leaving its skills uninvocable for the entire session. A worker then hand-runs workflows it could not invoke and, among other things, produces PRs that bypass the team's two-part PR template.

This race fires at first-session skill enumeration regardless of who starts the session, so it affects `niwa create` followed by a manual `claude` launch just as much as `niwa dispatch` — which is why the fix lives in the provisioning pipeline rather than the dispatch launch step.

The diagnosis was confirmed empirically from inside a live dispatched instance: the shirabe plugin was enabled and fully present on disk, yet its skills were absent from the session; a mid-session `/reload-plugins` (re-enumerating the unchanged on-disk state, no network) made them all invocable — the signature of a startup enumeration race, not a provisioning failure.

## Changes

- `internal/workspace/apply.go`: new `Applier.PrewarmDeclaredPlugins` seam, called from `Create` and `Apply` after settings are materialized (outside the rank-2 niwa-plugin conditional).
- `internal/cli/plugin_adapter.go`: wire the seam in `configurePluginAutoInstall`, alongside `InstallNiwaPlugin`.
- `internal/cli/dispatch_plugins.go` (new): the pre-warm implementation, settings reader, and `runClaudePluginCmd` exec seam.
- `internal/cli/dispatch_plugins_test.go` (new): 8 tests — github add + project-scope install ordering, directory-marketplace skip, disabled-plugin skip, opt-out short-circuit, missing-settings no-op, exec-failure non-fatal + warning, nil-reporter safety, and a guard that `configurePluginAutoInstall` actually wires the seam (a nil seam would silently no-op the fix).
- `docs/spikes/SPIKE-dispatched-worker-pr-template-gap.md` (new): the root-cause analysis and recommendation.

## Test Plan

- `go build ./...`, `go vet ./...`, gofmt, and `go test ./...` all pass.
- The pre-warm path is exercised via the exec seam; the `claude plugin marketplace add` / `install --scope project` CLI contract was confirmed against `claude plugin ... --help`. The full provisioning end-to-end (real instance + session launch) was intentionally not run to avoid side effects.

## Scope and Follow-ups

This is the primary, by-construction fix the spike recommends. Two items remain deliberately out of scope: the shirabe-side hardening of the hand-run fallback (a separate repo / PR) and the `autoUpdate`-vs-pinned-`ref` marketplace mismatch (a config/overlay concern).
