### PR TITLE
fix(provisioning): pre-warm plugins at local scope to avoid settings.json drift

### DIFF
--- a/internal/cli/dispatch_plugins.go
+++ b/internal/cli/dispatch_plugins.go
@@ -75,10 +75,22 @@ func prewarmDeclaredPlugins(instanceRoot string, reporter *workspace.Reporter, s
 	}
 
 	// 2. Install the enabled plugins so the plugin cache is populated before the
-	// session enumerates skills. Scope is project (cwd = instance) so this matches
-	// the instance's settings.json and does not enable plugins in other projects.
+	// session enumerates skills -- the step that actually closes the race, since a
+	// `marketplace add` clones the marketplace but does NOT populate the per-plugin
+	// cache the first enumeration reads.
+	//
+	// Scope is local, not project. `--scope project` would re-serialize the instance's
+	// .claude/settings.json -- the file niwa materializes and fingerprints as a managed
+	// file -- so the next `niwa apply` reports it "modified outside niwa" (#179), even
+	// though niwa already wrote the same enablement. `--scope local` writes the
+	// enablement to .claude/settings.local.json instead, which niwa does not manage at
+	// the instance root, so the managed settings.json is left byte-identical. Like
+	// project scope, local scope is project-bound (cwd = instance), so it does not leak
+	// enablement into the user's other projects -- the reason #178 avoided `--scope
+	// user`. The plugin cache and the installed_plugins record (keyed on the instance
+	// projectPath) are populated identically to project scope, so the race fix holds.
 	for _, plugin := range sortedKeys(pluginNames(settings.EnabledPlugins)) {
-		if err := runClaudePluginCmd(context.Background(), instanceRoot, "install", plugin, "--scope", "project"); err != nil {
+		if err := runClaudePluginCmd(context.Background(), instanceRoot, "install", plugin, "--scope", "local"); err != nil {
 			warnPrewarm(reporter, "pre-warming plugin %q: %v; it will install on startup instead", plugin, err)
 		}
 	}
@@ -93,7 +105,7 @@ func warnPrewarm(reporter *workspace.Reporter, format string, a ...any) {
 }
 
 // runClaudePluginCmd runs `claude plugin <args...>` with the working directory set
-// to dir (so `--scope project` targets the instance). It is a package variable so
+// to dir (so `--scope local` targets the instance). It is a package variable so
 // tests can record the issued commands without a real claude install, mirroring the
 // lookClaude/dispatchAttach seam pattern in dispatch.go. Output is folded into the
 // returned error so a failure surfaces a useful message in the caller's warning.

--- a/internal/cli/dispatch_plugins_test.go
+++ b/internal/cli/dispatch_plugins_test.go
@@ -62,11 +62,38 @@ func TestPrewarm_GithubMarketplacesAndPlugins(t *testing.T) {
 
 	want := [][]string{
 		{instance, "marketplace", "add", "tsukumogami/shirabe"},
-		{instance, "install", "shirabe@shirabe", "--scope", "project"},
-		{instance, "install", "tsukumogami@tsukumogami", "--scope", "project"},
+		{instance, "install", "shirabe@shirabe", "--scope", "local"},
+		{instance, "install", "tsukumogami@tsukumogami", "--scope", "local"},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Errorf("calls =\n  %v\nwant\n  %v", *calls, want)
+	}
+}
+
+// TestPrewarm_InstallsAtLocalScopeNotProject guards the #179 fix: the install must
+// use `--scope local`, never `--scope project`. Project scope re-serializes the
+// instance's .claude/settings.json -- the file niwa fingerprints as managed -- so the
+// next `niwa apply` falsely reports it "modified outside niwa". Local scope writes the
+// enablement to the unmanaged settings.local.json instead while still populating the
+// plugin cache, so the race fix holds without dirtying the managed file.
+func TestPrewarm_InstallsAtLocalScopeNotProject(t *testing.T) {
+	instance := writeInstanceSettings(t, `{
+	  "enabledPlugins": {"shirabe@shirabe": true}
+	}`)
+	calls := recordPluginCalls(t, nil)
+
+	prewarmDeclaredPlugins(instance, nil, false)
+
+	for _, c := range *calls {
+		if len(c) >= 2 && c[1] == "install" {
+			scope := c[len(c)-1]
+			if scope == "project" {
+				t.Errorf("install must not use --scope project (dirties niwa-managed settings.json); call %v", c)
+			}
+			if scope != "local" {
+				t.Errorf("install must use --scope local, got %q in call %v", scope, c)
+			}
+		}
 	}
 }
 
@@ -78,7 +105,7 @@ func TestPrewarm_SkipsDisabledPlugins(t *testing.T) {
 
 	prewarmDeclaredPlugins(instance, nil, false)
 
-	want := [][]string{{instance, "install", "on@mkt", "--scope", "project"}}
+	want := [][]string{{instance, "install", "on@mkt", "--scope", "local"}}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Errorf("disabled plugin should be skipped; calls = %v, want %v", *calls, want)
 	}

--- a/test/functional/features/prewarm-settings-drift.feature
+++ b/test/functional/features/prewarm-settings-drift.feature
@@ -1,0 +1,44 @@
+Feature: Plugin pre-warm does not dirty niwa-managed settings.json
+  When an instance declares a github-sourced Claude marketplace and plugin, niwa
+  pre-warms them to disk during provisioning so the first Claude session finds the
+  skills already installed (the #178 race fix). That pre-warm must NOT mutate the
+  instance's .claude/settings.json -- the file niwa materializes and fingerprints as
+  a managed file -- or the next `niwa apply` falsely reports it "modified outside
+  niwa" (#179).
+
+  The pre-warm shells out to the real `claude plugin` CLI, which these scenarios
+  replace with a fake that mimics the real binary's scope-dependent settings write:
+  `--scope project` re-serializes settings.json (the regression), `--scope local`
+  writes settings.local.json and leaves settings.json untouched (the fix). The
+  scenarios run on the scenario-sandboxed $HOME and offline localGitServer.
+
+  Issue: #179 (follow-up to #178)
+
+  @critical
+  Scenario: pre-warming a declared github plugin leaves the managed settings.json clean
+    Given a clean niwa environment
+    And a local git server is set up
+    And a fake claude for plugin pre-warming
+    And a config repo "driftws" exists with body:
+      """
+      [workspace]
+      name = "driftws"
+
+      [claude]
+      plugins = ["example@example-marketplace"]
+
+      [[claude.marketplaces]]
+      source = "example-org/example-marketplace"
+      track = "main"
+      """
+    When I run niwa init from config repo "driftws"
+    Then the exit code is 0
+    When I run "niwa create driftws"
+    Then the exit code is 0
+    And the instance "driftws" exists
+    # The pre-warm ran and used local scope, not project scope: the install
+    # populates the plugin cache without rewriting the managed settings.json.
+    And the recorded pre-warm install scope is "local"
+    When I run "niwa apply driftws"
+    Then the exit code is 0
+    And the stderr does not contain "settings.json has been modified outside niwa"

--- a/test/functional/prewarm_drift_steps_test.go
+++ b/test/functional/prewarm_drift_steps_test.go
@@ -1,0 +1,100 @@
+package functional
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+// prewarmFakeClaudeScript builds a fake `claude` that stands in for the plugin
+// pre-warm shell-out during provisioning. It mimics the real binary's
+// scope-dependent settings write so the #179 regression is observable end to end:
+//
+//   - `plugin marketplace add <repo>` succeeds (the on-disk clone the race fix needs).
+//   - `plugin install <plugin> --scope project` REserializes the project
+//     settings.json -- the niwa-managed, fingerprinted file -- which is exactly what
+//     caused the false "modified outside niwa" drift. Here it appends a newline, which
+//     changes the file's content hash while leaving it valid JSON.
+//   - `plugin install <plugin> --scope local` writes settings.local.json instead and
+//     never touches settings.json, so the managed file's hash is preserved.
+//
+// Every install records the scope it was invoked with to $HOME/prewarm-install-scope
+// so a scenario can assert niwa issued `--scope local` (the fix) and not
+// `--scope project` (the regression). Any other invocation exits 0 so an unrelated
+// claude call during provisioning never fails the run.
+func prewarmFakeClaudeScript() string {
+	return `#!/bin/sh
+if [ "$1" = "plugin" ]; then
+  shift
+  case "$1" in
+    marketplace)
+      exit 0
+      ;;
+    install)
+      scope=""
+      while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--scope" ]; then
+          scope="$2"
+        fi
+        shift
+      done
+      printf '%s' "$scope" > "$HOME/prewarm-install-scope"
+      if [ "$scope" = "project" ]; then
+        # Mimic the real binary re-serializing the managed settings.json: change
+        # its bytes (and thus its content hash) while keeping valid JSON.
+        printf '\n' >> ".claude/settings.json"
+      elif [ "$scope" = "local" ]; then
+        printf '{"enabledPlugins":{}}\n' > ".claude/settings.local.json"
+      fi
+      exit 0
+      ;;
+  esac
+fi
+exit 0
+`
+}
+
+// aFakeClaudeForPrewarm installs the pre-warm fake claude on PATH for every niwa
+// subprocess in the scenario.
+func aFakeClaudeForPrewarm(ctx context.Context) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	binDir := filepath.Join(s.homeDir, "fake-claude-bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return ctx, fmt.Errorf("mkdir fake-claude-bin: %w", err)
+	}
+	scriptPath := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(scriptPath, []byte(prewarmFakeClaudeScript()), 0o755); err != nil {
+		return ctx, fmt.Errorf("writing fake claude script: %w", err)
+	}
+	s.pathPrefix = binDir
+	return ctx, nil
+}
+
+// theRecordedPrewarmInstallScopeIs asserts the scope niwa passed to the fake
+// claude's `plugin install`, proving the pre-warm ran and which scope it used.
+func theRecordedPrewarmInstallScopeIs(ctx context.Context, want string) (context.Context, error) {
+	s := getState(ctx)
+	if s == nil {
+		return ctx, fmt.Errorf("no test state")
+	}
+	data, err := os.ReadFile(filepath.Join(s.homeDir, "prewarm-install-scope"))
+	if err != nil {
+		return ctx, fmt.Errorf("reading recorded install scope (did pre-warm run?): %w", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != want {
+		return ctx, fmt.Errorf("pre-warm install scope = %q, want %q", got, want)
+	}
+	return ctx, nil
+}
+
+func registerPrewarmDriftSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^a fake claude for plugin pre-warming$`, aFakeClaudeForPrewarm)
+	ctx.Step(`^the recorded pre-warm install scope is "([^"]*)"$`, theRecordedPrewarmInstallScopeIs)
+}

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -328,6 +328,10 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 	// reclamation, driven offline against the localGitServer with a fake claude ---
 	registerDispatchSteps(ctx)
 
+	// --- plugin pre-warm settings drift (#179): the pre-warm must not dirty
+	// niwa's managed settings.json while still resolving plugins to disk ---
+	registerPrewarmDriftSteps(ctx)
+
 	// --- Init-bootstrap harness extensions (Issue 5) ---
 	// GitHub tarball fake — spun up lazily per scenario; backed by the
 	// existing tarballFakeServer used by unit tests. Wire it into the


### PR DESCRIPTION
The instance plugin pre-warm installed enabled plugins with `claude plugin install --scope project`. Project scope re-serializes the instance's `.claude/settings.json` -- the file niwa materializes and fingerprints as a managed file -- so the next `niwa apply` reported it "modified outside niwa" even though niwa had already written the same enablement. The warning was benign (niwa re-materializes the file) but recurring and misleading, since niwa's own provisioning caused the edit.

Switch the install to `--scope local`. Local scope writes the enablement to `.claude/settings.local.json`, which niwa does not manage at the instance root, so the managed `settings.json` is left byte-identical and no drift is reported. The plugin cache and the `installed_plugins` record (keyed on the instance project path) are populated identically to project scope, so the marketplace-clone race fix is preserved. Local scope is also project-bound, so it does not enable plugins in the user's other projects -- the property project scope was originally chosen for.

Update the unit tests to expect `--scope local`, add a regression guard asserting the install never falls back to `--scope project`, and add a `@critical` functional scenario that drives `create` then `apply` against a fake `claude` (which mimics the real binary's scope-dependent settings write) and asserts the managed `settings.json` is not reported as drifted.

---

## Root cause

`claude plugin install --scope project` does two things: it populates the shared plugin cache (`~/.claude/plugins/cache/...`) and it writes plugin enablement at project scope into `<instance>/.claude/settings.json`. niwa already materializes `enabledPlugins` into that same file and tracks it as a managed file by content hash, so the install's re-serialization (key reordering, whitespace) changes the file's bytes and trips niwa's drift check on the next apply.

## Why `--scope local` (and not `--scope user`)

The cache population is what closes the startup race, not the enablement write -- and the cache is global, independent of scope. `--scope local` keeps the cache-population and `installed_plugins` record intact while redirecting the enablement write to `settings.local.json`, which niwa does not manage at the instance root. `--scope user` would also avoid the managed file, but it enables the plugins globally across all of the user's projects; local scope stays project-bound and avoids that leak.

A `marketplace add` alone is not sufficient: it clones the marketplace to disk but does not populate the per-plugin cache the first session enumeration reads, so the install step is still needed -- just at a scope that does not touch the managed file.

## Verification

- Confirmed against the real `claude` CLI that `install --scope project` rewrites a niwa-style `settings.json` (content hash changes) while `install --scope local` leaves it byte-identical and instead writes `settings.local.json`, populating the same plugin cache and `installed_plugins` record.
- `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all pass.
- The new `@critical` functional scenario fails when the install is reverted to `--scope project` (drift reintroduced) and passes at `--scope local`.

## Preserved behavior

- The `auto_install_plugins` opt-out and best-effort, non-fatal pre-warm behavior.
- The per-command timeout and the `runClaudePluginCmd` exec seam.
- The existing `TestPrewarm_*` cases and the `configurePluginAutoInstall` wiring guard.

Fixes #179
