### PR TITLE
test: guard declared-matcher retention for both pre- and post-tool hooks

### DIFF
--- a/internal/workspace/hook_matcher_repro_test.go
+++ b/internal/workspace/hook_matcher_repro_test.go
@@ -1,0 +1,108 @@
+package workspace
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tsukumogami/niwa/internal/config"
+)
+
+// TestRunRepoMaterializers_BothEventsRetainMatcher mirrors the real production
+// scenario: a config declares BOTH pre_tool_use AND post_tool_use hooks, each
+// with matcher "Bash" AND each script present on disk under hooks/<event>/ (so
+// both are declared AND auto-discovered). After materialization BOTH events must
+// produce exactly ONE settings.local.json entry that keeps its declared matcher.
+//
+// The observed production defect was that pre_tool_use kept its matcher while
+// post_tool_use lost it (fired on every tool call). This test asserts symmetry
+// across events.
+func TestRunRepoMaterializers_BothEventsRetainMatcher(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+
+	// Both scripts live on disk under hooks/<event>/ so DiscoverHooks finds
+	// them, AND both are declared in config with matcher "Bash".
+	writeScript := func(event, name string) string {
+		dir := filepath.Join(configDir, "hooks", event)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rel := filepath.Join("hooks", event, name)
+		if err := os.WriteFile(filepath.Join(configDir, rel), []byte("#!/bin/sh\necho hook\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return rel
+	}
+	preScript := writeScript("pre_tool_use", "gate-online.sh")
+	postScript := writeScript("post_tool_use", "work-summary-capture.sh")
+
+	repoDir := filepath.Join(tmpDir, "instance", "public", "repo1")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.WorkspaceConfig{
+		Workspace: config.WorkspaceMeta{Name: "test-ws"},
+		Claude: config.ClaudeConfig{
+			Hooks: config.HooksConfig{
+				"pre_tool_use": {{
+					Matcher: "Bash",
+					Scripts: []string{preScript},
+				}},
+				"post_tool_use": {{
+					Matcher: "Bash",
+					Scripts: []string{postScript},
+				}},
+			},
+		},
+	}
+
+	discovered, err := DiscoverHooks(configDir)
+	if err != nil {
+		t.Fatalf("DiscoverHooks: %v", err)
+	}
+
+	materializers := defaultRepoMaterializers(io.Discard)
+	if _, _, err := runRepoMaterializers(materializers, repoMaterializeInputs{
+		Cfg:             cfg,
+		ConfigDir:       configDir,
+		RepoName:        "repo1",
+		RepoDir:         repoDir,
+		DiscoveredHooks: discovered,
+	}); err != nil {
+		t.Fatalf("runRepoMaterializers: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repoDir, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatalf("reading settings.local.json: %v", err)
+	}
+	var doc struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parsing settings.local.json: %v", err)
+	}
+
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		entries := doc.Hooks[event]
+		if len(entries) != 1 {
+			t.Fatalf("%s should have exactly 1 entry (dedup), got %d: %s", event, len(entries), string(data))
+		}
+		if entries[0].Matcher != "Bash" {
+			t.Errorf("%s entry matcher = %q, want %q (declared matcher must be retained): %s", event, entries[0].Matcher, "Bash", string(data))
+		}
+		if len(entries[0].Hooks) != 1 {
+			t.Fatalf("%s entry should register 1 command, got %d", event, len(entries[0].Hooks))
+		}
+	}
+}


### PR DESCRIPTION
Adds a focused regression test asserting that a hook declared with a `matcher` AND auto-discovered on disk materializes exactly one settings entry that retains its matcher — for BOTH `pre_tool_use` and `post_tool_use` simultaneously. No production code changes: the existing declared/discovered dedup in `runRepoMaterializers` already handles both events symmetrically, so this commit only locks that behavior in.

---

## What This Fixes

### Reported symptom
After `niwa apply` (niwa 0.18.0) with a config declaring two hooks identically (`matcher = "Bash"`), each also present on disk under `.niwa/hooks/<event>/`:

- `PreToolUse` (gate-online): `"matcher": "Bash"` — correct
- `PostToolUse` (work-summary-capture): no matcher field — wrong (fires on every tool call)

Exactly one registration per event; the surviving `PostToolUse` entry simply lost its matcher. This is the "declared+discovered hook loses its matcher" symptom the Issue-3 dedup fix (commit `7882dc1`) was meant to prevent — reportedly working for `pre_tool_use` but not `post_tool_use`.

### Investigation result: NOT reproducible in pure niwa
`TestRunRepoMaterializers_BothEventsRetainMatcher` mirrors the exact production shape — both events declared with `matcher: "Bash"` AND both scripts present under `hooks/<event>/` in the same config dir — and **passes** (50x, no map-iteration flakiness). Both events keep their matcher.

Root cause of the symmetry: the dedup/merge in `internal/workspace/worktree_content.go` (`runRepoMaterializers`) iterates events independently, always placing the declared entry (with its matcher) first and deduping discovered copies against it by resolved script path. Event-name handling (`hookEventMapping`, `snakeToPascal`) and per-event merge (`MergeOverrides`) treat `pre_tool_use` and `post_tool_use` identically. There is no code path in core niwa that drops the declared entry for one event but not the other.

### Reproduction gap → points to config layering / overlay
Because core niwa is symmetric, the observed asymmetry must originate outside the pure-niwa surface — most plausibly the overlay merge path (`MergeWorkspaceOverlay`, `internal/workspace/override.go`), where overlay-declared hook scripts are resolved to `overlayDir`-absolute paths while auto-discovered scripts resolve to `configDir`-relative paths. The dedup in `runRepoMaterializers` keys on the resolved path, so an overlay-sourced declared entry and a `configDir`-discovered copy would not match and would not dedup — a divergence this public repo's fixture surface cannot reproduce without the private overlay content.

### Recommendation
Move the investigation to the overlay/config-layering layer (the private overlay that supplies the `post_tool_use` declaration). This test stays as a durable symmetry guard: if a future change breaks per-event matcher retention in core, it fails immediately.