### PR TITLE
fix(reap): make dispatch backstop liveness-aware to prevent data loss

### DIFF
--- a/internal/cli/dispatch_capture.go
+++ b/internal/cli/dispatch_capture.go
@@ -119,6 +119,46 @@ func matchSessionByCwd(jobsDir, targetDir string) (id, short string, ambiguous b
 	return found, foundShort, false, nil
 }
 
+// liveJobInInstance reports whether a live Claude Code background job is running
+// with its working directory inside instanceDir, reusing the SAME jobs-dir cwd
+// correlation the dispatch capture path uses (matchSessionByCwd). This is the
+// single shared implementation of that correlation: dispatch capture calls it
+// (through captureSessionID) to recover a launched worker's session id, and the
+// reaper backstop calls it to avoid destroying an unmapped instance a live
+// worker is still running in.
+//
+// It returns:
+//   - (sessionID, true) when exactly one job claims instanceDir and its recorded
+//     sessionId is a valid UUID -- the caller can adopt the orphan by writing the
+//     missing mapping from sessionID.
+//   - ("", true) when a live job claims instanceDir but its id cannot be singled
+//     out (more than one job claims it, or the sole match has not yet recorded a
+//     valid id). The instance must be SPARED but cannot be adopted.
+//   - ("", false) when no job's cwd matches instanceDir (no live worker there).
+//
+// A jobs-dir read error fails safe as ("", true): without being able to rule out
+// a live worker, the caller must not destroy the instance. An empty jobsDir (HOME
+// unresolved) yields ("", false): there is no jobs tree to observe.
+func liveJobInInstance(jobsDir, instanceDir string) (sessionID string, live bool) {
+	if jobsDir == "" {
+		return "", false
+	}
+	targetDir := normalizePath(instanceDir)
+	id, _, ambiguous, err := matchSessionByCwd(jobsDir, targetDir)
+	if err != nil {
+		// Could not read the jobs dir to rule out a surviving worker. Fail safe
+		// so the data-loss path never destroys an instance we merely failed to
+		// observe.
+		return "", true
+	}
+	if ambiguous {
+		// More than one job claims this unique dir: a live worker is present even
+		// though we cannot single out which id to adopt.
+		return "", true
+	}
+	return id, id != ""
+}
+
 // normalizePath resolves symlinks then cleans path so two spellings of the
 // same directory compare equal. EvalSymlinks fails on a path that does not
 // exist (e.g. a stale job's cwd); in that case fall back to Clean alone so a

--- a/internal/cli/instance_from_hook.go
+++ b/internal/cli/instance_from_hook.go
@@ -154,6 +154,17 @@ func runInstanceHookStart(cmd *cobra.Command, payload instanceHookPayload, jobsD
 		return nil
 	}
 
+	// Defense in depth for the reaper backstop: a dispatched bg worker booting
+	// inside an ephemeral dispatch instance that still carries the pending marker
+	// but has no mapping self-heals by writing the mapping itself, so the worker
+	// is never left as an unmapped orphan the backstop could reap even if its
+	// dispatch parent died before mapping it. This is a terminal case (the worker
+	// is already inside its instance), so on success it returns without
+	// provisioning a new one.
+	if maybeAdoptSelf(workspaceRoot, payload, jobsDir) {
+		return nil
+	}
+
 	if !sessionStartGuardPasses(workspaceRoot, payload.Cwd, payload.SessionID, jobsDir) {
 		return nil
 	}
@@ -272,6 +283,83 @@ func isBackgroundWorker(jobsDir, sessionID string) bool {
 		return false
 	}
 	return js.Template == bgJobTemplate
+}
+
+// maybeAdoptSelf handles the adopt-self case of the SessionStart guard: a
+// dispatched background worker booting INSIDE an ephemeral dispatch instance that
+// still carries the pending marker but has no mapping writes the mapping itself.
+// It returns true when it took ownership of this hook invocation (the worker is
+// already inside its instance, so the caller must NOT provision a new one),
+// whether or not the mapping write ultimately succeeded; it returns false when
+// this is not the adopt-self shape, so the caller falls through to the ordinary
+// three-part guard.
+//
+// This is the defense-in-depth complement to the reaper backstop's own liveness
+// check: it makes the worker's own boot a mapping source, so the data-loss path
+// (a dispatch parent that dies before writing the mapping, leaving a live but
+// unmapped instance) is closed even without the parent surviving. It deliberately
+// mirrors the ordinary guard's gates -- ephemeral mode on, a confirmed bg worker
+// -- so an ordinary session is never touched, and it relaxes only guard #3
+// (re-entrancy) for exactly this case: the instance must be a dispatch instance
+// with an unresolved pending marker and no mapping, not any nested/dev instance.
+func maybeAdoptSelf(workspaceRoot string, payload instanceHookPayload, jobsDir string) bool {
+	// Honor the master switch: outside ephemeral-session mode the hook is inert.
+	if !workspace.EphemeralSessionMode(workspaceRoot) {
+		return false
+	}
+
+	// Only a dispatched background worker self-heals.
+	if !isBackgroundWorker(jobsDir, payload.SessionID) {
+		return false
+	}
+
+	// The worker must be booting inside a genuine instance (the condition that
+	// makes guard #3 no-op for a dispatched worker). A workspace-root or
+	// non-instance cwd is not an adopt-self case.
+	instanceDir, err := workspace.DiscoverInstance(payload.Cwd)
+	if err != nil {
+		return false
+	}
+	if workspace.ValidateInstanceDir(instanceDir) != nil {
+		return false
+	}
+
+	// The instance must be a dispatch instance carrying an unresolved pending
+	// marker: dispatch drops the marker at create and removes it only after the
+	// mapping is durably written, so marker-present + unmapped is precisely the
+	// "parent died before mapping" shape. A non-dispatch instance, or a dispatch
+	// instance whose marker was already cleaned up, is not healed here.
+	if !isDispatchInstanceName(filepath.Base(instanceDir)) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(instanceDir, dispatchPendingMarker)); err != nil {
+		return false
+	}
+
+	// If a mapping already exists for this session (the parent mapped it, or a
+	// prior hook run did), there is nothing to heal -- fall through to the guard,
+	// which no-ops on re-entrancy.
+	if _, err := workspace.ReadSessionMapping(workspaceRoot, payload.SessionID); err == nil {
+		return false
+	}
+
+	// Write the missing mapping. This is the terminal action for this worker's
+	// SessionStart: it is already inside its instance, so we never provision a
+	// nested one regardless of the write outcome.
+	mapping := workspace.SessionMapping{
+		SessionID:      payload.SessionID,
+		InstanceName:   filepath.Base(instanceDir),
+		InstancePath:   instanceDir,
+		TranscriptPath: payload.TranscriptPath,
+		Ephemeral:      true,
+		Origin:         backstopAdoptedOrigin,
+	}
+	if err := workspace.WriteSessionMapping(workspaceRoot, mapping); err != nil {
+		// Best effort: a failed self-heal must not break the session. The reaper
+		// backstop's own liveness check remains the primary protection.
+		fmt.Fprintf(os.Stderr, "niwa: warning: self-healing session mapping for %s: %v\n", payload.SessionID, err)
+	}
+	return true
 }
 
 // sessionStartInjection is the SessionStart hook output shape Claude Code

--- a/internal/cli/instance_from_hook_test.go
+++ b/internal/cli/instance_from_hook_test.go
@@ -297,6 +297,160 @@ func TestSessionStart_PassingWorker_Provisions(t *testing.T) {
 	}
 }
 
+// makeDispatchInstance creates a genuine instance directory named name under
+// root (with .niwa/instance.json so DiscoverInstance/ValidateInstanceDir accept
+// it as an instance, no workspace.toml so it is not a root) and, when marker is
+// true, drops the dispatch pending marker inside it. It returns the instance dir.
+func makeDispatchInstance(t *testing.T, root, name string, marker bool) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	st := &workspace.InstanceState{
+		SchemaVersion: workspace.SchemaVersion,
+		InstanceName:  name,
+		Root:          dir,
+		Repos:         map[string]workspace.RepoState{},
+	}
+	if err := workspace.SaveState(dir, st); err != nil {
+		t.Fatal(err)
+	}
+	if marker {
+		m := filepath.Join(dir, dispatchPendingMarker)
+		if err := os.MkdirAll(filepath.Dir(m), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(m, []byte("2026-01-01T00:00:00Z\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// TestSessionStart_DispatchOrphanSelfHeals: a bg worker booting inside a
+// dispatch-named instance that carries the pending marker but has no mapping
+// (its dispatch parent died before mapping it) self-heals -- the hook writes the
+// mapping itself, marked ephemeral and adopted-origin, and does NOT provision a
+// nested instance. This closes the data-loss window without the reaper's own
+// liveness check having to fire.
+func TestSessionStart_DispatchOrphanSelfHeals(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	writeJobState(t, jobsDir, testSessionID, testSessionID, "bg")
+	rec := stubProvision(t, "guidance")
+
+	instanceDir := makeDispatchInstance(t, root, "test-ws+-0000abcd", true /* marker */)
+
+	out, _, err := runStart(t, instanceHookPayload{
+		HookEventName:  hookEventSessionStart,
+		SessionID:      testSessionID,
+		Cwd:            instanceDir,
+		TranscriptPath: "/tmp/t.jsonl",
+	}, jobsDir)
+	if err != nil {
+		t.Fatalf("runInstanceHookStart: %v", err)
+	}
+	if rec.called {
+		t.Error("provisioner was called; want self-heal only (no nested provision)")
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty (self-heal emits no injection)", out)
+	}
+
+	m, err := workspace.ReadSessionMapping(root, testSessionID)
+	if err != nil {
+		t.Fatalf("self-healed mapping not written: %v", err)
+	}
+	if m.InstancePath != instanceDir {
+		t.Errorf("mapping InstancePath = %q, want %q", m.InstancePath, instanceDir)
+	}
+	if !m.Ephemeral {
+		t.Error("mapping Ephemeral = false, want true")
+	}
+	if m.Origin != backstopAdoptedOrigin {
+		t.Errorf("mapping Origin = %q, want %q", m.Origin, backstopAdoptedOrigin)
+	}
+	if m.TranscriptPath != "/tmp/t.jsonl" {
+		t.Errorf("mapping TranscriptPath = %q, want the hook transcript", m.TranscriptPath)
+	}
+}
+
+// TestSessionStart_DispatchOrphanAlreadyMapped_NoOp: when a dispatch instance
+// already has a mapping (the parent wrote it, or a prior hook run did), the
+// worker's SessionStart does not rewrite it and does not provision -- guard #3
+// re-entrancy simply no-ops. The existing mapping is left untouched.
+func TestSessionStart_DispatchOrphanAlreadyMapped_NoOp(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	writeJobState(t, jobsDir, testSessionID, testSessionID, "bg")
+	rec := stubProvision(t, "guidance")
+
+	instanceDir := makeDispatchInstance(t, root, "test-ws+-0000abcd", true)
+	// A pre-existing mapping written by the parent (Origin "dispatch").
+	if err := workspace.WriteSessionMapping(root, workspace.SessionMapping{
+		SessionID:    testSessionID,
+		InstanceName: "test-ws+-0000abcd",
+		InstancePath: instanceDir,
+		Ephemeral:    true,
+		Origin:       "dispatch",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runStart(t, instanceHookPayload{
+		HookEventName: hookEventSessionStart,
+		SessionID:     testSessionID,
+		Cwd:           instanceDir,
+	}, jobsDir)
+	if err != nil {
+		t.Fatalf("runInstanceHookStart: %v", err)
+	}
+	if rec.called {
+		t.Error("provisioner was called; want re-entrancy no-op")
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	// The existing mapping must be untouched (not rewritten to adopted-origin).
+	m, err := workspace.ReadSessionMapping(root, testSessionID)
+	if err != nil {
+		t.Fatalf("ReadSessionMapping: %v", err)
+	}
+	if m.Origin != "dispatch" {
+		t.Errorf("mapping Origin = %q, want %q (self-heal must not overwrite an existing mapping)", m.Origin, "dispatch")
+	}
+}
+
+// TestSessionStart_DispatchInstanceNoMarker_NoHeal: a dispatch-named instance
+// with NO pending marker (a completed dispatch whose marker was already cleaned
+// up) is NOT self-healed -- marker-present is the signal that a mapping is
+// genuinely missing. The worker's SessionStart no-ops on re-entrancy and writes
+// no mapping.
+func TestSessionStart_DispatchInstanceNoMarker_NoHeal(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	writeJobState(t, jobsDir, testSessionID, testSessionID, "bg")
+	rec := stubProvision(t, "guidance")
+
+	instanceDir := makeDispatchInstance(t, root, "test-ws+-0000abcd", false /* no marker */)
+
+	out, _, err := runStart(t, instanceHookPayload{
+		HookEventName: hookEventSessionStart,
+		SessionID:     testSessionID,
+		Cwd:           instanceDir,
+	}, jobsDir)
+	if err != nil {
+		t.Fatalf("runInstanceHookStart: %v", err)
+	}
+	if rec.called {
+		t.Error("provisioner was called; want re-entrancy no-op")
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	if _, err := workspace.ReadSessionMapping(root, testSessionID); err == nil {
+		t.Error("a mapping was written for an unmarked instance; want none (no self-heal)")
+	}
+}
+
 // TestBuildSessionStartInjection_NoClaudeMD: a missing instance CLAUDE.md is
 // tolerated; the path + cd instruction still inject.
 func TestBuildSessionStartInjection_NoClaudeMD(t *testing.T) {

--- a/internal/cli/reap.go
+++ b/internal/cli/reap.go
@@ -25,6 +25,14 @@ import (
 // not job-state.
 const dispatchBackstopTTL = 30 * time.Minute
 
+// backstopAdoptedOrigin is the SessionMapping.Origin the backstop stamps on a
+// mapping it writes to adopt a live-but-unmapped dispatch orphan (a worker whose
+// dispatch parent died before writing the mapping). It marks the mapping as
+// recovered by the reaper rather than authored by the dispatch command
+// ("dispatch") or the SessionStart hook (absent), so the provenance of a healed
+// mapping is traceable.
+const backstopAdoptedOrigin = "adopted"
+
 func init() {
 	rootCmd.AddCommand(reapCmd)
 }
@@ -196,7 +204,7 @@ func reapWorkspace(workspaceRoot, jobsDir string, now time.Time) (int, error) {
 	// under its own gates (dispatch instance name, no mapping, age past the TTL).
 	// It runs after the primary reclamation so the existing sweep keeps ownership
 	// of every mapped instance (DESIGN Decision 4).
-	n, err := reapBackstop(workspaceRoot, now)
+	n, err := reapBackstop(workspaceRoot, jobsDir, now)
 	if err != nil {
 		return reaped, err
 	}
@@ -205,16 +213,33 @@ func reapWorkspace(workspaceRoot, jobsDir string, now time.Time) (int, error) {
 	return reaped, nil
 }
 
-// backstopTarget is an instance the marker+TTL backstop has selected. Unlike a
-// reapTarget it carries no session id: a backstop target is by definition
-// unmapped, so there is no mapping entry to delete after the destroy.
+// backstopTarget is an instance the marker+TTL backstop has selected for
+// DESTRUCTION. Unlike a reapTarget it carries no session id: a backstop target
+// is by definition unmapped AND has no surviving worker, so there is no mapping
+// entry to delete after the destroy.
 type backstopTarget struct {
 	InstancePath string
 }
 
+// backstopAdoption is a dispatch-named, unmapped, past-TTL instance the backstop
+// spared BECAUSE a live worker is still running in it (its dispatch parent died
+// before writing the mapping). Rather than destroy it -- the data-loss incident
+// this guards -- the backstop adopts it: it writes the missing SessionMapping
+// from the discovered session id so the liveness-checking primary sweep owns it
+// from then on. It carries the session id and instance identity the mapping
+// needs.
+type backstopAdoption struct {
+	InstancePath string
+	InstanceName string
+	SessionID    string
+}
+
 // selectBackstopTargets enumerates the on-disk instances under workspaceRoot and
-// returns those eligible for the name+TTL backstop. An instance is eligible only
-// when ALL of the following hold:
+// classifies the dispatch-named, unmapped, past-TTL ones into two sets: instances
+// to DESTROY (genuine SIGKILL orphans with no surviving worker) and instances to
+// ADOPT (a live worker is still running in them, so a mapping is written instead
+// of destroying them). An instance is considered by the backstop only when ALL of
+// the following hold:
 //
 //   - its base directory name is a dispatch instance name (isDispatchInstanceName
 //     -- the purely structural "<config>+-<8hex>" or "<config>+<slug>-<8hex>", regex
@@ -234,21 +259,34 @@ type backstopTarget struct {
 //     must show age > TTL; a present-but-malformed marker does NOT spare the
 //     instance forever -- it falls back to mtime.
 //
+// The past-TTL gate alone is NOT sufficient to destroy: the TTL was chosen for
+// the worst-case dispatch *capture* wall-clock, not a session's *lifetime*. A
+// dispatch parent that dies (SIGKILL/crash) after launching the detached worker
+// but before writing the mapping leaves the worker running -- for hours, far past
+// this TTL -- while the instance stays unmapped. Reaping on name+TTL alone
+// destroyed that live worker's workspace (the data-loss incident). So before an
+// unmapped past-TTL instance is destroyed, liveJobInInstance reuses the dispatch
+// capture path's jobs-dir cwd correlation to check for a surviving worker: if one
+// is found the instance is spared and, when the worker's session id is
+// recoverable, adopted (a mapping is written so the primary sweep owns it). Only
+// an instance with NO live cwd-matched worker is destroyed -- the backstop's real
+// purpose (SIGKILL orphans that left nothing running).
+//
 // A developer instance ("<config>", "<config>-2"), a hook-created instance
 // ("<config>-<sessionhex>", no "+" marker), and a create instance
 // ("<config>+<slug>", no trailing "-<8hex>") never match the name predicate,
 // so they are never touched regardless of age or mapping. This function performs
-// no destruction, so it is unit-testable against fixture instances and an
-// injectable now.
-func selectBackstopTargets(workspaceRoot string, now time.Time) ([]backstopTarget, error) {
+// no destruction and writes no mapping, so it is unit-testable against fixture
+// instances, a fixture jobs tree, and an injectable now.
+func selectBackstopTargets(workspaceRoot, jobsDir string, now time.Time) ([]backstopTarget, []backstopAdoption, error) {
 	records, err := workspace.EnumerateInstanceRecords(workspaceRoot)
 	if err != nil {
-		return nil, fmt.Errorf("enumerating instances: %w", err)
+		return nil, nil, fmt.Errorf("enumerating instances: %w", err)
 	}
 
 	mappings, err := workspace.ListSessionMappings(workspaceRoot)
 	if err != nil {
-		return nil, fmt.Errorf("listing session mappings: %w", err)
+		return nil, nil, fmt.Errorf("listing session mappings: %w", err)
 	}
 	mappedPaths := make(map[string]bool, len(mappings))
 	for _, m := range mappings {
@@ -258,6 +296,7 @@ func selectBackstopTargets(workspaceRoot string, now time.Time) ([]backstopTarge
 	}
 
 	var targets []backstopTarget
+	var adoptions []backstopAdoption
 	for _, rec := range records {
 		// The dispatch instance NAME is the eligibility signal. A non-dispatch
 		// name (developer or hook-created instance) is never a backstop target.
@@ -283,10 +322,29 @@ func selectBackstopTargets(workspaceRoot string, now time.Time) ([]backstopTarge
 			continue
 		}
 
+		// Past the TTL. Before destroying, confirm no live worker is still
+		// running in the instance: a dispatch parent that died after launching
+		// the detached worker but before writing the mapping leaves a live,
+		// unmapped, past-TTL instance whose destruction is data loss.
+		sessionID, live := liveJobInInstance(jobsDir, rec.Path)
+		if live {
+			if sessionID != "" {
+				// Adopt: write the missing mapping so the primary sweep owns it.
+				adoptions = append(adoptions, backstopAdoption{
+					InstancePath: rec.Path,
+					InstanceName: filepath.Base(rec.Path),
+					SessionID:    sessionID,
+				})
+			}
+			// Live but unidentifiable (ambiguous or id not yet recorded): spare
+			// without adopting rather than risk destroying a live worker.
+			continue
+		}
+
 		targets = append(targets, backstopTarget{InstancePath: rec.Path})
 	}
 
-	return targets, nil
+	return targets, adoptions, nil
 }
 
 // dispatchInstanceAge returns the creation time the backstop ages a dispatch
@@ -329,15 +387,34 @@ func readDispatchMarkerTime(instancePath string) (time.Time, bool) {
 }
 
 // reapBackstop selects and reclaims dispatch-named, unmapped, past-TTL orphan
-// instances under workspaceRoot, returning the count actually destroyed. Each target is
-// force-destroyed via destroyInstanceFunc, the same path the primary sweep
-// uses. A destroy failure on one target is surfaced on
-// stderr and does not abort the rest. There is no mapping to delete (a backstop
-// target is unmapped by definition).
-func reapBackstop(workspaceRoot string, now time.Time) (int, error) {
-	targets, err := selectBackstopTargets(workspaceRoot, now)
+// instances under workspaceRoot, returning the count actually destroyed. It first
+// ADOPTS every live-but-unmapped orphan by writing the missing session mapping
+// (so the liveness-checking primary sweep owns it from then on, closing the
+// data-loss window a dead dispatch parent opens); adopted instances are NOT
+// counted as reaped. It then force-destroys each genuine orphan (no surviving
+// worker) via destroyInstanceFunc, the same path the primary sweep uses. A
+// destroy or adopt failure on one instance is surfaced on stderr and does not
+// abort the rest. There is no mapping to delete for a destroyed target (it is
+// unmapped by definition).
+func reapBackstop(workspaceRoot, jobsDir string, now time.Time) (int, error) {
+	targets, adoptions, err := selectBackstopTargets(workspaceRoot, jobsDir, now)
 	if err != nil {
 		return 0, err
+	}
+
+	// Adopt live orphans first: write the mapping the dead dispatch parent never
+	// wrote, so a subsequent sweep spares the worker on the entry-present rule.
+	for _, a := range adoptions {
+		m := workspace.SessionMapping{
+			SessionID:    a.SessionID,
+			InstanceName: a.InstanceName,
+			InstancePath: a.InstancePath,
+			Ephemeral:    true,
+			Origin:       backstopAdoptedOrigin,
+		}
+		if err := workspace.WriteSessionMapping(workspaceRoot, m); err != nil {
+			fmt.Fprintf(os.Stderr, "niwa: warning: adopting live dispatch orphan %s: %v\n", a.InstancePath, err)
+		}
 	}
 
 	reaped := 0

--- a/internal/cli/reap_backstop_test.go
+++ b/internal/cli/reap_backstop_test.go
@@ -75,7 +75,7 @@ func TestBackstop_MarkedUnmappedOld_Reclaimed(t *testing.T) {
 
 	destroyed := stubDestroyAll(t)
 
-	n, err := reapBackstop(root, now)
+	n, err := reapBackstop(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("reapBackstop error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestBackstop_DispNamedUnmappedOldNoMarker_ReclaimedViaMtime(t *testing.T) {
 
 	destroyed := stubDestroyAll(t)
 
-	n, err := reapBackstop(root, now)
+	n, err := reapBackstop(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("reapBackstop error: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestBackstop_MarkedUnmappedYoung_Spared(t *testing.T) {
 
 	destroyed := stubDestroyAll(t)
 
-	n, err := reapBackstop(root, now)
+	n, err := reapBackstop(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("reapBackstop error: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestBackstop_MappedInstance_NotTouched(t *testing.T) {
 
 	destroyed := stubDestroyAll(t)
 
-	n, err := reapBackstop(root, now)
+	n, err := reapBackstop(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("reapBackstop error: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestBackstop_NonDispatchName_NeverTouched(t *testing.T) {
 
 	destroyed := stubDestroyAll(t)
 
-	n, err := reapBackstop(root, now)
+	n, err := reapBackstop(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("reapBackstop error: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestBackstop_MalformedMarker_FallsBackToMtime(t *testing.T) {
 
 	destroyed := stubDestroyAll(t)
 
-	n, err := reapBackstop(root, now)
+	n, err := reapBackstop(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("reapBackstop error: %v", err)
 	}
@@ -278,6 +278,204 @@ func TestBackstop_RunsViaReapWorkspace(t *testing.T) {
 	}
 }
 
+// TestBackstop_LiveUnmappedOld_SparedAndAdopted is the primary data-loss
+// regression: a dispatch-named, unmapped instance whose marker is past the TTL --
+// the exact shape the old backstop force-destroyed -- is SPARED when a live
+// background job's cwd points at it (the dispatch parent died before mapping, but
+// the detached worker is still running). The backstop must not destroy it and
+// must ADOPT it by writing the missing session mapping so the liveness-checking
+// primary sweep owns it from then on.
+func TestBackstop_LiveUnmappedOld_SparedAndAdopted(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	now := time.Now()
+
+	inst := makeReapInstance(t, root, "test-ws+-0000a1b2")
+	// Unmapped, marker aged well past the TTL (a worker that has run for hours).
+	writeDispatchMarkerAt(t, inst, now.Add(-4*dispatchBackstopTTL))
+	// A live worker is still running in the instance: its job's cwd is the
+	// instance dir.
+	writeJobEntryWithCwd(t, jobsDir, reapLiveSessionID, inst)
+
+	destroyed := stubDestroyAll(t)
+
+	n, err := reapBackstop(root, jobsDir, now)
+	if err != nil {
+		t.Fatalf("reapBackstop error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("reaped count = %d, want 0 (a live worker's instance must never be destroyed)", n)
+	}
+	if len(*destroyed) != 0 {
+		t.Fatalf("destroyed = %v, want [] (live-worker instance must not be destroyed)", *destroyed)
+	}
+
+	// The instance must be adopted: a mapping is written from the live worker's
+	// session id, marked ephemeral and adopted-origin, pointing at the instance.
+	m, err := workspace.ReadSessionMapping(root, reapLiveSessionID)
+	if err != nil {
+		t.Fatalf("adopted mapping not written: %v", err)
+	}
+	if m.InstancePath != inst {
+		t.Errorf("adopted mapping InstancePath = %q, want %q", m.InstancePath, inst)
+	}
+	if !m.Ephemeral {
+		t.Error("adopted mapping Ephemeral = false, want true")
+	}
+	if m.Origin != backstopAdoptedOrigin {
+		t.Errorf("adopted mapping Origin = %q, want %q", m.Origin, backstopAdoptedOrigin)
+	}
+	if m.InstanceName != filepath.Base(inst) {
+		t.Errorf("adopted mapping InstanceName = %q, want %q", m.InstanceName, filepath.Base(inst))
+	}
+}
+
+// TestBackstop_OrphanNoLiveMatch_StillReaped confirms the liveness check does NOT
+// regress the backstop's real purpose: a dispatch-named, unmapped, past-TTL
+// instance with NO job whose cwd matches it is still a genuine SIGKILL orphan and
+// is reaped -- even when the jobs tree is non-empty (other, unrelated workers are
+// running).
+func TestBackstop_OrphanNoLiveMatch_StillReaped(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	now := time.Now()
+
+	inst := makeReapInstance(t, root, "test-ws+-0000c3d4")
+	writeDispatchMarkerAt(t, inst, now.Add(-2*dispatchBackstopTTL))
+	// A live job exists but its cwd points somewhere else entirely (an unrelated
+	// worker), so it must not spare this orphan.
+	writeJobEntryWithCwd(t, jobsDir, reapLiveSessionID, filepath.Join(root, "some-other-place"))
+
+	destroyed := stubDestroyAll(t)
+
+	n, err := reapBackstop(root, jobsDir, now)
+	if err != nil {
+		t.Fatalf("reapBackstop error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("reaped count = %d, want 1 (an orphan with no cwd-matched worker must still be reaped)", n)
+	}
+	if len(*destroyed) != 1 || (*destroyed)[0] != inst {
+		t.Fatalf("destroyed = %v, want [%s]", *destroyed, inst)
+	}
+	// No mapping should have been written for a genuine orphan.
+	if _, err := workspace.ReadSessionMapping(root, reapLiveSessionID); err == nil {
+		t.Error("a mapping was written for a non-matching worker; want none")
+	}
+}
+
+// TestBackstop_LiveAmbiguous_SparedNotAdopted: when more than one job claims the
+// same unmapped past-TTL instance, the backstop cannot single out an id to adopt,
+// but a live worker IS present, so the instance is SPARED (not destroyed) and no
+// mapping is written.
+func TestBackstop_LiveAmbiguous_SparedNotAdopted(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	now := time.Now()
+
+	inst := makeReapInstance(t, root, "test-ws+-0000e5f6")
+	writeDispatchMarkerAt(t, inst, now.Add(-2*dispatchBackstopTTL))
+	// Two distinct jobs both claim this instance's cwd -> ambiguous.
+	writeJobEntryWithCwd(t, jobsDir, reapLiveSessionID, inst)
+	writeJobEntryWithCwd(t, jobsDir, reapDeadSessionID, inst)
+
+	destroyed := stubDestroyAll(t)
+
+	n, err := reapBackstop(root, jobsDir, now)
+	if err != nil {
+		t.Fatalf("reapBackstop error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("reaped count = %d, want 0 (an ambiguous live match must spare the instance)", n)
+	}
+	if len(*destroyed) != 0 {
+		t.Fatalf("destroyed = %v, want [] (spared on ambiguous live match)", *destroyed)
+	}
+	// Ambiguity means no single id to adopt: no mapping is written for either id.
+	if _, err := workspace.ReadSessionMapping(root, reapLiveSessionID); err == nil {
+		t.Error("a mapping was written despite ambiguity; want none")
+	}
+	if _, err := workspace.ReadSessionMapping(root, reapDeadSessionID); err == nil {
+		t.Error("a mapping was written despite ambiguity; want none")
+	}
+}
+
+// TestReapWorkspace_LiveDispatchOrphan_AdoptedNotDestroyed exercises the full
+// reapWorkspace path end to end: a dead mapped instance is reaped by the primary
+// sweep while a live-but-unmapped dispatch orphan is adopted (not destroyed) by
+// the backstop in the same call.
+func TestReapWorkspace_LiveDispatchOrphan_AdoptedNotDestroyed(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	now := time.Now()
+
+	dead := makeReapInstance(t, root, "test-ws-dead")
+	mapEphemeral(t, root, reapDeadSessionID, dead, true) // no job -> dead -> reaped
+
+	orphan := makeReapInstance(t, root, "test-ws+-00007788")
+	writeDispatchMarkerAt(t, orphan, now.Add(-3*dispatchBackstopTTL))
+	writeJobEntryWithCwd(t, jobsDir, reapLiveSessionID, orphan) // live -> adopted
+
+	destroyed := stubDestroyAll(t)
+
+	n, err := reapWorkspace(root, jobsDir, now)
+	if err != nil {
+		t.Fatalf("reapWorkspace error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("reaped count = %d, want 1 (only the dead mapped instance; the live orphan is adopted)", n)
+	}
+	if len(*destroyed) != 1 || (*destroyed)[0] != dead {
+		t.Fatalf("destroyed = %v, want [%s] (the live orphan must not be destroyed)", *destroyed, dead)
+	}
+
+	// The live orphan is now mapped (adopted); the dead mapping was deleted.
+	m, err := workspace.ReadSessionMapping(root, reapLiveSessionID)
+	if err != nil {
+		t.Fatalf("live orphan was not adopted: %v", err)
+	}
+	if m.InstancePath != orphan || m.Origin != backstopAdoptedOrigin {
+		t.Errorf("adopted mapping = %+v, want InstancePath=%s Origin=%s", m, orphan, backstopAdoptedOrigin)
+	}
+	if _, err := workspace.ReadSessionMapping(root, reapDeadSessionID); err == nil {
+		t.Error("dead mapping retained after reapWorkspace; want deleted")
+	}
+}
+
+// TestSelectBackstopTargets_LiveOrphan_ClassifiedAsAdoption checks the pure
+// selection: a live-but-unmapped past-TTL orphan is returned as an adoption (with
+// the discovered session id), not as a destroy target.
+func TestSelectBackstopTargets_LiveOrphan_ClassifiedAsAdoption(t *testing.T) {
+	root := setupHookWorkspace(t, true)
+	jobsDir := t.TempDir()
+	now := time.Now()
+
+	live := makeReapInstance(t, root, "test-ws+-0000aa11")
+	writeDispatchMarkerAt(t, live, now.Add(-2*dispatchBackstopTTL))
+	writeJobEntryWithCwd(t, jobsDir, reapLiveSessionID, live)
+
+	orphan := makeReapInstance(t, root, "test-ws+-0000bb22")
+	writeDispatchMarkerAt(t, orphan, now.Add(-2*dispatchBackstopTTL))
+
+	targets, adoptions, err := selectBackstopTargets(root, jobsDir, now)
+	if err != nil {
+		t.Fatalf("selectBackstopTargets error: %v", err)
+	}
+
+	if len(targets) != 1 || targets[0].InstancePath != orphan {
+		t.Fatalf("destroy targets = %v, want [%s]", targets, orphan)
+	}
+	if len(adoptions) != 1 {
+		t.Fatalf("adoptions = %v, want exactly 1", adoptions)
+	}
+	if adoptions[0].InstancePath != live {
+		t.Errorf("adoption InstancePath = %q, want %q", adoptions[0].InstancePath, live)
+	}
+	if adoptions[0].SessionID != reapLiveSessionID {
+		t.Errorf("adoption SessionID = %q, want %q", adoptions[0].SessionID, reapLiveSessionID)
+	}
+}
+
 // TestSelectBackstopTargets_Matrix exercises the pure selection logic across the
 // full spare/reap matrix in one workspace and asserts the exact target set,
 // independent of the destroy path.
@@ -303,7 +501,7 @@ func TestSelectBackstopTargets_Matrix(t *testing.T) {
 	touchInstanceMtime(t, dev, now.Add(-2*dispatchBackstopTTL))
 	writeDispatchMarkerAt(t, hook, now.Add(-2*dispatchBackstopTTL))
 
-	targets, err := selectBackstopTargets(root, now)
+	targets, _, err := selectBackstopTargets(root, t.TempDir(), now)
 	if err != nil {
 		t.Fatalf("selectBackstopTargets error: %v", err)
 	}

--- a/internal/cli/reap_test.go
+++ b/internal/cli/reap_test.go
@@ -70,6 +70,22 @@ func writeJobEntry(t *testing.T, jobsDir, sessionID string) {
 	}
 }
 
+// writeJobEntryWithCwd writes a present job-state entry for sessionID under
+// jobsDir whose recorded cwd is cwd, so the backstop's liveness correlation
+// (liveJobInInstance -> matchSessionByCwd) matches it to the instance at cwd.
+// This models a detached dispatch worker still running in an unmapped instance.
+func writeJobEntryWithCwd(t *testing.T, jobsDir, sessionID, cwd string) {
+	t.Helper()
+	dir := filepath.Join(jobsDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{"sessionId":"` + sessionID + `","template":"` + bgJobTemplate + `","cwd":"` + cwd + `"}`)
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // stubDestroyAll installs a fake destroyInstanceFunc that records every path it
 // was asked to destroy, without touching the filesystem. It restores the
 // original on cleanup and returns a pointer to the recorded slice.


### PR DESCRIPTION
## Problem

The `niwa reap` name+TTL backstop could destroy the workspace of a **live, actively-running** dispatched background worker — branch, worktree, and all uncommitted work — with no warning. Two defects composed to cause it:

**Defect A — a dispatched worker can outlive its mapping.** `niwa dispatch` provisions the instance, launches the detached worker, then in the same short-lived parent process polls the jobs dir to correlate the worker to its instance and only then writes the session→instance mapping. If the parent dies abnormally (SIGKILL/crash) after launching the worker but before writing the mapping, the worker keeps running (it is a detached background session with its own job entry) while the instance is left **unmapped**. The worker never self-maps, because the SessionStart hook no-ops for a cwd already inside an instance.

**Defect B — the backstop reaped unmapped dispatch instances with no liveness check.** `selectBackstopTargets` reclaimed an instance when its name matched the dispatch pattern, it had no mapping, and it was older than `dispatchBackstopTTL` (30m). It never checked whether a live worker was running in it. The TTL was chosen for the worst-case dispatch *capture* wall-clock (seconds), but a healthy worker's *lifetime* is hours. Once Defect A left such a worker unmapped, the backstop destroyed its workspace at the 30-minute mark.

## Fix

### Liveness-aware backstop (primary)

Before destroying an unmapped, past-TTL dispatch instance, the backstop now checks for a surviving worker by scanning `~/.claude/jobs/*/state.json` for a job whose normalized `cwd` matches the candidate instance. This reuses the dispatch capture path's cwd correlation: the shared `matchSessionByCwd` is now wrapped by a single `liveJobInInstance` helper that both dispatch capture and the reaper call — the logic is not duplicated.

- A **live cwd-matched worker** spares the instance. When the worker's session id is recoverable, the backstop **adopts** the orphan: it writes the missing `SessionMapping` (`Ephemeral: true`, `Origin: "adopted"`) so the liveness-checking primary sweep owns it from then on. If the match is ambiguous, the instance is spared without adopting.
- A **genuine orphan** with no cwd-matched worker is still reaped, preserving the backstop's SIGKILL-orphan-cleanup purpose.

The `dispatchBackstopTTL` value is unchanged — the fix is a liveness check, not a longer timeout.

### Self-healing mapping (defense-in-depth)

The SessionStart hook now self-heals: when a `bg` worker boots inside an ephemeral dispatch instance that still carries the `.niwa/dispatch-pending` marker but has no mapping, the hook writes the mapping itself (it knows the session id and cwd). This removes dispatch-parent survival as a single point of failure. The re-entrancy guard is relaxed for exactly this adopt-self case and still no-ops for an ordinary nested/dev instance.

## Tests

Table-driven regression tests against a fixture jobs tree and fixture instances, using the existing `destroyInstanceFunc` / jobsDir seams:

- live-but-unmapped past-TTL orphan is spared and adopted (the data-loss case)
- genuine orphan with no cwd-matched worker is still reaped (no regression)
- ambiguous live match spares without adopting
- end-to-end `reapWorkspace` adopts the live orphan while the primary sweep reaps a dead mapped instance
- self-heal writes the mapping for a marked-but-unmapped worker

`go test ./...` passes (one pre-existing unrelated failure in `TestDispatch_PassthroughFlags_DiscreteArgv`, present on `main`); `go vet` is clean.
